### PR TITLE
feat(cli): запись свойств объекта, сортировка структуры и настраиваемые каталоги исходников

### DIFF
--- a/src/main/java/io/github/yellowhammer/designerxml/cf/ExternalArtifactLister.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/ExternalArtifactLister.java
@@ -26,19 +26,20 @@ public final class ExternalArtifactLister {
   }
 
   public static List<ExternalArtifactEntry> listErf(Path projectRoot) throws IOException {
-    return listSubdir(projectRoot, "src", "erf");
+    return listArtifacts(projectRoot, projectRoot.resolve("src").resolve("erf"));
   }
 
   public static List<ExternalArtifactEntry> listEpf(Path projectRoot) throws IOException {
-    return listSubdir(projectRoot, "src", "epf");
+    return listArtifacts(projectRoot, projectRoot.resolve("src").resolve("epf"));
   }
 
-  private static List<ExternalArtifactEntry> listSubdir(Path projectRoot, String first, String second)
+  /** Артефакты в произвольном каталоге; relativePath — от корня проекта (вне корня — абсолютный). */
+  public static List<ExternalArtifactEntry> listArtifacts(Path projectRoot, Path dir)
     throws IOException {
-    Path dir = projectRoot.resolve(first).resolve(second);
     if (!Files.isDirectory(dir)) {
       return List.of();
     }
+    Path rootNorm = projectRoot.toAbsolutePath().normalize();
     List<ExternalArtifactEntry> out = new ArrayList<>();
     try (DirectoryStream<Path> ds = Files.newDirectoryStream(dir, Files::isDirectory)) {
       for (Path sub : ds) {
@@ -50,8 +51,11 @@ public final class ExternalArtifactLister {
         if (xml == null || !Files.isRegularFile(xml)) {
           continue;
         }
-        Path rel = projectRoot.relativize(xml);
-        out.add(new ExternalArtifactEntry(name, rel.toString().replace('\\', '/')));
+        Path xmlNorm = xml.toAbsolutePath().normalize();
+        String rel = xmlNorm.startsWith(rootNorm)
+          ? rootNorm.relativize(xmlNorm).toString().replace('\\', '/')
+          : xmlNorm.toString().replace('\\', '/');
+        out.add(new ExternalArtifactEntry(name, rel));
       }
     }
     out.sort(Comparator.comparing(ExternalArtifactEntry::name, String.CASE_INSENSITIVE_ORDER));

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdCatalogPropertiesGranularSerial.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdCatalogPropertiesGranularSerial.java
@@ -25,7 +25,7 @@ public final class MdCatalogPropertiesGranularSerial {
     List<MdObjectPropertiesLeafDiff.GranularPatchChange> out) {
     if (!Objects.equals(b.objectBelonging, i.objectBelonging)) {
       out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
-        "ObjectBelonging", textElement("ObjectBelonging", nz(i.objectBelonging))));
+        "ObjectBelonging", enumTextElement("ObjectBelonging", nz(i.objectBelonging))));
     }
     if (!Objects.equals(b.extendedConfigurationObject, i.extendedConfigurationObject)) {
       out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
@@ -38,7 +38,7 @@ public final class MdCatalogPropertiesGranularSerial {
     }
     if (!Objects.equals(b.hierarchyType, i.hierarchyType)) {
       out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
-        "HierarchyType", textElement("HierarchyType", nz(i.hierarchyType))));
+        "HierarchyType", enumTextElement("HierarchyType", nz(i.hierarchyType))));
     }
     if (b.limitLevelCount != i.limitLevelCount) {
       out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
@@ -62,7 +62,7 @@ public final class MdCatalogPropertiesGranularSerial {
     }
     if (!Objects.equals(b.subordinationUse, i.subordinationUse)) {
       out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
-        "SubordinationUse", textElement("SubordinationUse", nz(i.subordinationUse))));
+        "SubordinationUse", enumTextElement("SubordinationUse", nz(i.subordinationUse))));
     }
     if (!Objects.equals(b.codeLength, i.codeLength)) {
       out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
@@ -74,15 +74,15 @@ public final class MdCatalogPropertiesGranularSerial {
     }
     if (!Objects.equals(b.codeType, i.codeType)) {
       out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
-        "CodeType", textElement("CodeType", nz(i.codeType))));
+        "CodeType", enumTextElement("CodeType", nz(i.codeType))));
     }
     if (!Objects.equals(b.codeAllowedLength, i.codeAllowedLength)) {
       out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
-        "CodeAllowedLength", textElement("CodeAllowedLength", nz(i.codeAllowedLength))));
+        "CodeAllowedLength", enumTextElement("CodeAllowedLength", nz(i.codeAllowedLength))));
     }
     if (!Objects.equals(b.codeSeries, i.codeSeries)) {
       out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
-        "CodeSeries", textElement("CodeSeries", nz(i.codeSeries))));
+        "CodeSeries", enumTextElement("CodeSeries", nz(i.codeSeries))));
     }
     if (b.checkUnique != i.checkUnique) {
       out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
@@ -94,7 +94,7 @@ public final class MdCatalogPropertiesGranularSerial {
     }
     if (!Objects.equals(b.defaultPresentation, i.defaultPresentation)) {
       out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
-        "DefaultPresentation", textElement("DefaultPresentation", nz(i.defaultPresentation))));
+        "DefaultPresentation", enumTextElement("DefaultPresentation", nz(i.defaultPresentation))));
     }
     if (!MdObjectPropertiesDiff.looseXmlBlobEquals(b.standardAttributesXml, i.standardAttributesXml)) {
       out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
@@ -110,11 +110,11 @@ public final class MdCatalogPropertiesGranularSerial {
     }
     if (!Objects.equals(b.predefinedDataUpdate, i.predefinedDataUpdate)) {
       out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
-        "PredefinedDataUpdate", textElement("PredefinedDataUpdate", nz(i.predefinedDataUpdate))));
+        "PredefinedDataUpdate", enumTextElement("PredefinedDataUpdate", nz(i.predefinedDataUpdate))));
     }
     if (!Objects.equals(b.editType, i.editType)) {
       out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
-        "EditType", textElement("EditType", nz(i.editType))));
+        "EditType", enumTextElement("EditType", nz(i.editType))));
     }
     if (b.quickChoice != i.quickChoice) {
       out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
@@ -122,7 +122,7 @@ public final class MdCatalogPropertiesGranularSerial {
     }
     if (!Objects.equals(b.choiceMode, i.choiceMode)) {
       out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
-        "ChoiceMode", textElement("ChoiceMode", nz(i.choiceMode))));
+        "ChoiceMode", enumTextElement("ChoiceMode", nz(i.choiceMode))));
     }
     if (!MdObjectPropertiesDiff.listStringEquals(b.inputByString, i.inputByString)) {
       out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
@@ -131,17 +131,17 @@ public final class MdCatalogPropertiesGranularSerial {
     if (!Objects.equals(b.searchStringModeOnInputByString, i.searchStringModeOnInputByString)) {
       out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
         "SearchStringModeOnInputByString",
-        textElement("SearchStringModeOnInputByString", nz(i.searchStringModeOnInputByString))));
+        enumTextElement("SearchStringModeOnInputByString", nz(i.searchStringModeOnInputByString))));
     }
     if (!Objects.equals(b.fullTextSearchOnInputByString, i.fullTextSearchOnInputByString)) {
       out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
         "FullTextSearchOnInputByString",
-        textElement("FullTextSearchOnInputByString", nz(i.fullTextSearchOnInputByString))));
+        enumTextElement("FullTextSearchOnInputByString", nz(i.fullTextSearchOnInputByString))));
     }
     if (!Objects.equals(b.choiceDataGetModeOnInputByString, i.choiceDataGetModeOnInputByString)) {
       out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
         "ChoiceDataGetModeOnInputByString",
-        textElement("ChoiceDataGetModeOnInputByString", nz(i.choiceDataGetModeOnInputByString))));
+        enumTextElement("ChoiceDataGetModeOnInputByString", nz(i.choiceDataGetModeOnInputByString))));
     }
     if (!Objects.equals(b.defaultObjectForm, i.defaultObjectForm)) {
       out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
@@ -209,11 +209,11 @@ public final class MdCatalogPropertiesGranularSerial {
     }
     if (!Objects.equals(b.dataLockControlMode, i.dataLockControlMode)) {
       out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
-        "DataLockControlMode", textElement("DataLockControlMode", nz(i.dataLockControlMode))));
+        "DataLockControlMode", enumTextElement("DataLockControlMode", nz(i.dataLockControlMode))));
     }
     if (!Objects.equals(b.fullTextSearch, i.fullTextSearch)) {
       out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
-        "FullTextSearch", textElement("FullTextSearch", nz(i.fullTextSearch))));
+        "FullTextSearch", enumTextElement("FullTextSearch", nz(i.fullTextSearch))));
     }
     if (!Objects.equals(b.objectPresentationRu, i.objectPresentationRu)) {
       out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
@@ -239,15 +239,15 @@ public final class MdCatalogPropertiesGranularSerial {
     }
     if (!Objects.equals(b.createOnInput, i.createOnInput)) {
       out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
-        "CreateOnInput", textElement("CreateOnInput", nz(i.createOnInput))));
+        "CreateOnInput", enumTextElement("CreateOnInput", nz(i.createOnInput))));
     }
     if (!Objects.equals(b.choiceHistoryOnInput, i.choiceHistoryOnInput)) {
       out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
-        "ChoiceHistoryOnInput", textElement("ChoiceHistoryOnInput", nz(i.choiceHistoryOnInput))));
+        "ChoiceHistoryOnInput", enumTextElement("ChoiceHistoryOnInput", nz(i.choiceHistoryOnInput))));
     }
     if (!Objects.equals(b.dataHistory, i.dataHistory)) {
       out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
-        "DataHistory", textElement("DataHistory", nz(i.dataHistory))));
+        "DataHistory", enumTextElement("DataHistory", nz(i.dataHistory))));
     }
     if (b.updateDataHistoryImmediatelyAfterWrite != i.updateDataHistoryImmediatelyAfterWrite) {
       out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
@@ -271,7 +271,35 @@ public final class MdCatalogPropertiesGranularSerial {
   }
 
   static String textElement(String localName, String text) {
+    if (text == null || text.isEmpty()) {
+      return "<" + localName + "/>";
+    }
     return "<" + localName + ">" + escapeXml(text) + "</" + localName + ">";
+  }
+
+  /**
+   * Элемент enum-свойства: DTO несёт имя Java-константы ({@code BOTH_WAYS}), XML ждёт значение схемы
+   * ({@code BothWays}). Ошибочная конвертация не опасна: гранулярный патч верифицируется обратным чтением.
+   */
+  static String enumTextElement(String localName, String constantName) {
+    return textElement(localName, enumConstantToXmlText(constantName));
+  }
+
+  private static String enumConstantToXmlText(String constantName) {
+    if (constantName == null || constantName.isEmpty() || !constantName.equals(constantName.toUpperCase())) {
+      return constantName == null ? "" : constantName;
+    }
+    StringBuilder out = new StringBuilder(constantName.length());
+    for (String part : constantName.split("_")) {
+      if (part.isEmpty()) {
+        continue;
+      }
+      out.append(Character.toUpperCase(part.charAt(0)));
+      if (part.length() > 1) {
+        out.append(part.substring(1).toLowerCase());
+      }
+    }
+    return out.toString();
   }
 
   static String boolElement(String localName, boolean v) {
@@ -353,7 +381,7 @@ public final class MdCatalogPropertiesGranularSerial {
         if (f == null || f.isBlank()) {
           continue;
         }
-        sb.append("<Field>").append(escapeXml(f.trim())).append("</Field>");
+        sb.append("<xr:Field>").append(escapeXml(f.trim())).append("</xr:Field>");
       }
     }
     sb.append("</InputByString>");
@@ -367,7 +395,7 @@ public final class MdCatalogPropertiesGranularSerial {
         if (f == null || f.isBlank()) {
           continue;
         }
-        sb.append("<Field>").append(escapeXml(f.trim())).append("</Field>");
+        sb.append("<xr:Field>").append(escapeXml(f.trim())).append("</xr:Field>");
       }
     }
     sb.append("</DataLockFields>");

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectChildMutations.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectChildMutations.java
@@ -135,7 +135,7 @@ public final class MdObjectChildMutations {
       return insertIntoRootChildObjects(
         xml,
         containerLocal,
-        buildTabularSectionSnippet(newName, newName, "")
+        buildTabularSectionSnippet(containerLocal, rootObjectName(xml), newName, newName, "")
       );
     });
   }
@@ -381,6 +381,10 @@ public final class MdObjectChildMutations {
     } catch (XMLStreamException e) {
       throw new IOException("Не удалось разобрать XML для мутации: " + e.getMessage(), e);
     }
+    // Вставки собираются с LF: приводим весь результат к переводу строки исходного файла.
+    if (original.contains("\r\n")) {
+      updated = updated.replace("\r\n", "\n").replace("\n", "\r\n");
+    }
     MdObjectStructureRead.read(updated.getBytes(StandardCharsets.UTF_8), version);
     Files.writeString(objectXml, updated, StandardCharsets.UTF_8);
   }
@@ -404,7 +408,32 @@ public final class MdObjectChildMutations {
     }
     String nodeXml = xml.substring(target.start(), target.end());
     String replaced = replaceName(nodeXml, oldName, newName);
+    replaced = renameGeneratedTypeTail(replaced, oldName, newName);
     return xml.substring(0, target.start()) + replaced + xml.substring(target.end());
+  }
+
+  /**
+   * Обновляет хвост имени в {@code xr:GeneratedType name="...Тип.Объект.Старое"} блока
+   * (актуально для табличных частей; у реквизитов GeneratedType нет).
+   */
+  private static String renameGeneratedTypeTail(String nodeXml, String oldName, String newName) {
+    Pattern generated = Pattern.compile("(<xr:GeneratedType name=\"[^\"]*\\.)" + Pattern.quote(oldName) + "\"");
+    Matcher m = generated.matcher(nodeXml);
+    StringBuilder sb = new StringBuilder();
+    while (m.find()) {
+      m.appendReplacement(sb, Matcher.quoteReplacement(m.group(1) + escapeXml(newName) + "\""));
+    }
+    m.appendTail(sb);
+    return sb.toString();
+  }
+
+  /** Имя корневого объекта: первый тег Name в файле (Properties объекта). */
+  private static String rootObjectName(String xml) {
+    Matcher matcher = NAME_TAG.matcher(xml);
+    if (!matcher.find()) {
+      throw new IllegalArgumentException("Не найдено имя объекта.");
+    }
+    return unescapeXml(matcher.group(1));
   }
 
   private static String deleteNamedChild(
@@ -457,6 +486,7 @@ public final class MdObjectChildMutations {
   private static String duplicateRegion(String xml, MdObjectXmlRegions.Region source, String oldName, String newName) {
     String sourceXml = xml.substring(source.start(), source.end());
     String copy = replaceName(DistinctUuidRewrite.remap(sourceXml), oldName, newName);
+    copy = renameGeneratedTypeTail(copy, oldName, newName);
     String indent = currentLineIndent(xml, source.start());
     String normalizedCopy = normalizeBlockIndent(copy, indent);
     return xml.substring(0, source.end()) + "\n" + normalizedCopy + xml.substring(source.end());
@@ -475,7 +505,9 @@ public final class MdObjectChildMutations {
     String parentIndent = currentLineIndent(xml, insertAt);
     String childIndent = parentIndent + "\t";
     String normalized = normalizeBlockIndent(snippet, childIndent);
-    return xml.substring(0, insertAt) + "\n" + normalized + "\n" + parentIndent + xml.substring(insertAt);
+    int prefixEnd = lineStartBeforeIndent(xml, insertAt);
+    String lead = prefixEnd == insertAt ? "\n" : "";
+    return xml.substring(0, prefixEnd) + lead + normalized + "\n" + parentIndent + xml.substring(insertAt);
   }
 
   private static String insertIntoTabularSectionChildObjects(String tabularSectionXml, String snippet)
@@ -508,8 +540,10 @@ public final class MdObjectChildMutations {
       String parentIndent = currentLineIndent(tabularSectionXml, insertAt);
       String childIndent = parentIndent + "\t";
       String normalized = normalizeBlockIndent(snippet, childIndent);
-      return tabularSectionXml.substring(0, insertAt)
-        + "\n"
+      int prefixEnd = lineStartBeforeIndent(tabularSectionXml, insertAt);
+      String lead = prefixEnd == insertAt ? "\n" : "";
+      return tabularSectionXml.substring(0, prefixEnd)
+        + lead
         + normalized
         + "\n"
         + parentIndent
@@ -547,10 +581,115 @@ public final class MdObjectChildMutations {
     return nodeXml.substring(0, matcher.start(1)) + escaped + nodeXml.substring(matcher.end(1));
   }
 
+  /**
+   * Переставляет реквизиты корневого {@code ChildObjects} в заданном порядке.
+   * Перечисленные блоки меняются местами между собой; не перечисленные остаются на своих местах.
+   */
+  public static void reorderAttributes(Path objectXml, SchemaVersion version, List<String> order)
+    throws IOException, JAXBException {
+    mutateAndWrite(objectXml, version, (xml, containerLocal) ->
+      reorderNamedRegions(xml, order, "Реквизит",
+        name -> MdObjectXmlRegions.findNamedChildObjectRegion(xml, containerLocal, "Attribute", name)));
+  }
+
+  /**
+   * Переставляет табличные части корневого {@code ChildObjects} в заданном порядке.
+   */
+  public static void reorderTabularSections(Path objectXml, SchemaVersion version, List<String> order)
+    throws IOException, JAXBException {
+    mutateAndWrite(objectXml, version, (xml, containerLocal) ->
+      reorderNamedRegions(xml, order, "Табличная часть",
+        name -> MdObjectXmlRegions.findNamedChildObjectRegion(xml, containerLocal, "TabularSection", name)));
+  }
+
+  /**
+   * Переставляет реквизиты табличной части в заданном порядке.
+   */
+  public static void reorderTabularAttributes(
+    Path objectXml,
+    SchemaVersion version,
+    String tabularSectionName,
+    List<String> order
+  ) throws IOException, JAXBException {
+    mutateAndWrite(objectXml, version, (xml, containerLocal) ->
+      reorderNamedRegions(xml, order, "Реквизит ТЧ",
+        name -> MdObjectXmlRegions.findNamedNestedChildObjectRegion(
+          xml, containerLocal, "TabularSection", tabularSectionName, "Attribute", name)));
+  }
+
+  private interface RegionByName {
+    MdObjectXmlRegions.Region find(String name) throws XMLStreamException;
+  }
+
+  private static String reorderNamedRegions(
+    String xml,
+    List<String> order,
+    String label,
+    RegionByName finder
+  ) throws XMLStreamException {
+    if (order == null || order.size() < 2) {
+      return xml;
+    }
+    List<MdObjectXmlRegions.Region> regions = new ArrayList<>();
+    List<String> blocks = new ArrayList<>();
+    for (String name : order) {
+      ensureNotBlank(name, "Пустое имя в порядке сортировки.");
+      MdObjectXmlRegions.Region region = finder.find(name);
+      if (!region.isValid()) {
+        throw new IllegalArgumentException(label + " не найден: " + name);
+      }
+      regions.add(region);
+      blocks.add(xml.substring(region.start(), region.end()));
+    }
+    List<Integer> byStart = new ArrayList<>();
+    for (int i = 0; i < regions.size(); i++) {
+      byStart.add(i);
+    }
+    byStart.sort((a, b) -> Integer.compare(regions.get(a).start(), regions.get(b).start()));
+    for (int i = 1; i < byStart.size(); i++) {
+      if (regions.get(byStart.get(i)).start() < regions.get(byStart.get(i - 1)).end()) {
+        throw new IllegalArgumentException("Пересечение блоков при сортировке (дубль имени?).");
+      }
+    }
+    StringBuilder out = new StringBuilder(xml.length());
+    int cursor = 0;
+    for (int k = 0; k < byStart.size(); k++) {
+      MdObjectXmlRegions.Region slot = regions.get(byStart.get(k));
+      out.append(xml, cursor, slot.start());
+      // k-я позиция по тексту получает k-й блок из желаемого порядка
+      out.append(blocks.get(k));
+      cursor = slot.end();
+    }
+    out.append(xml, cursor, xml.length());
+    return out.toString();
+  }
+
+  /** Начало строки перед позицией: срезает хвостовые пробелы/табы, если до них перевод строки. */
+  private static int lineStartBeforeIndent(String xml, int pos) {
+    int cut = pos;
+    while (cut > 0 && (xml.charAt(cut - 1) == '\t' || xml.charAt(cut - 1) == ' ')) {
+      cut--;
+    }
+    if (cut == 0 || xml.charAt(cut - 1) == '\n') {
+      return cut;
+    }
+    return pos;
+  }
+
   private static String removeRegion(String xml, MdObjectXmlRegions.Region region) {
     String left = xml.substring(0, region.start());
     String right = xml.substring(region.end());
-    if (left.endsWith("\n") && right.startsWith("\n")) {
+    // Блок занимал свои строки: убираем и отступ его первой строки, и перевод строки после него,
+    // иначе остаётся строка из одних табов.
+    int cut = left.length();
+    while (cut > 0 && (left.charAt(cut - 1) == '\t' || left.charAt(cut - 1) == ' ')) {
+      cut--;
+    }
+    boolean leftAtLineStart = cut == 0 || left.charAt(cut - 1) == '\n';
+    if (leftAtLineStart && (right.startsWith("\r\n") || right.startsWith("\n"))) {
+      left = left.substring(0, cut);
+      right = right.startsWith("\r\n") ? right.substring(2) : right.substring(1);
+    } else if (left.endsWith("\n") && right.startsWith("\n")) {
       right = right.substring(1);
     }
     return left + right;
@@ -573,8 +712,26 @@ public final class MdObjectChildMutations {
       + "</Attribute>";
   }
 
-  private static String buildTabularSectionSnippet(String name, String synonymRu, String comment) {
+  private static String buildTabularSectionSnippet(
+    String containerLocal,
+    String ownerName,
+    String name,
+    String synonymRu,
+    String comment
+  ) {
     return "<TabularSection uuid=\"" + UUID.randomUUID() + "\">\n"
+      + "\t<InternalInfo>\n"
+      + "\t\t<xr:GeneratedType name=\"" + containerLocal + "TabularSection." + escapeXml(ownerName) + "."
+      + escapeXml(name) + "\" category=\"TabularSection\">\n"
+      + "\t\t\t<xr:TypeId>" + UUID.randomUUID() + "</xr:TypeId>\n"
+      + "\t\t\t<xr:ValueId>" + UUID.randomUUID() + "</xr:ValueId>\n"
+      + "\t\t</xr:GeneratedType>\n"
+      + "\t\t<xr:GeneratedType name=\"" + containerLocal + "TabularSectionRow." + escapeXml(ownerName) + "."
+      + escapeXml(name) + "\" category=\"TabularSectionRow\">\n"
+      + "\t\t\t<xr:TypeId>" + UUID.randomUUID() + "</xr:TypeId>\n"
+      + "\t\t\t<xr:ValueId>" + UUID.randomUUID() + "</xr:ValueId>\n"
+      + "\t\t</xr:GeneratedType>\n"
+      + "\t</InternalInfo>\n"
       + "\t<Properties>\n"
       + "\t\t<Name>" + escapeXml(name) + "</Name>\n"
       + "\t\t<Synonym>\n"

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesDiff.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesDiff.java
@@ -12,7 +12,9 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -211,7 +213,110 @@ public final class MdObjectPropertiesDiff {
     if (na.replaceAll("\\s+", " ").equals(nb.replaceAll("\\s+", " "))) {
       return true;
     }
-    return na.replaceAll("\\s", "").equals(nb.replaceAll("\\s", ""));
+    if (na.replaceAll("\\s", "").equals(nb.replaceAll("\\s", ""))) {
+      return true;
+    }
+    return semanticXmlEquals(na, nb);
+  }
+
+  /**
+   * Семантическое сравнение XML: JAXB между запусками JVM по-разному раскладывает пространства имён
+   * (какому URI достанется default, какие префиксы получат остальные), текст при этом описывает те же данные.
+   */
+  private static boolean semanticXmlEquals(String a, String b) {
+    try {
+      javax.xml.parsers.DocumentBuilderFactory dbf = javax.xml.parsers.DocumentBuilderFactory.newInstance();
+      dbf.setNamespaceAware(true);
+      dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+      org.w3c.dom.Document d1 =
+        dbf.newDocumentBuilder().parse(new org.xml.sax.InputSource(new java.io.StringReader(a)));
+      org.w3c.dom.Document d2 =
+        dbf.newDocumentBuilder().parse(new org.xml.sax.InputSource(new java.io.StringReader(b)));
+      return domElementsEqual(d1.getDocumentElement(), d2.getDocumentElement());
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
+  private static final String XMLNS_NS = "http://www.w3.org/2000/xmlns/";
+  private static final String XSI_NS = "http://www.w3.org/2001/XMLSchema-instance";
+
+  private static boolean domElementsEqual(org.w3c.dom.Element x, org.w3c.dom.Element y) {
+    if (!Objects.equals(x.getLocalName(), y.getLocalName())
+      || !Objects.equals(nz(x.getNamespaceURI()), nz(y.getNamespaceURI()))) {
+      return false;
+    }
+    if (!domAttributes(x).equals(domAttributes(y))) {
+      return false;
+    }
+    List<org.w3c.dom.Element> cx = domChildElements(x);
+    List<org.w3c.dom.Element> cy = domChildElements(y);
+    if (cx.size() != cy.size()) {
+      return false;
+    }
+    for (int i = 0; i < cx.size(); i++) {
+      if (!domElementsEqual(cx.get(i), cy.get(i))) {
+        return false;
+      }
+    }
+    return domText(x).equals(domText(y));
+  }
+
+  private static java.util.SortedMap<String, String> domAttributes(org.w3c.dom.Element el) {
+    java.util.TreeMap<String, String> out = new java.util.TreeMap<>();
+    org.w3c.dom.NamedNodeMap attrs = el.getAttributes();
+    for (int i = 0; i < attrs.getLength(); i++) {
+      org.w3c.dom.Attr attr = (org.w3c.dom.Attr) attrs.item(i);
+      if (XMLNS_NS.equals(attr.getNamespaceURI())) {
+        continue;
+      }
+      String key = nz(attr.getNamespaceURI()) + "|" + (attr.getLocalName() == null ? attr.getName() : attr.getLocalName());
+      String value = attr.getValue();
+      if (XSI_NS.equals(attr.getNamespaceURI()) && "type".equals(attr.getLocalName())) {
+        value = resolveQNameValue(el, value);
+      }
+      out.put(key, value);
+    }
+    return out;
+  }
+
+  /** {@code xsi:type="prefix:Name"} → {@code {uri}Name}: имя префикса не несёт семантики. */
+  private static String resolveQNameValue(org.w3c.dom.Element scope, String value) {
+    int colon = value.indexOf(':');
+    if (colon <= 0) {
+      return "{" + nz(scope.lookupNamespaceURI(null)) + "}" + value;
+    }
+    String prefix = value.substring(0, colon);
+    String uri = scope.lookupNamespaceURI(prefix);
+    return uri == null ? value : "{" + uri + "}" + value.substring(colon + 1);
+  }
+
+  private static List<org.w3c.dom.Element> domChildElements(org.w3c.dom.Element el) {
+    List<org.w3c.dom.Element> out = new ArrayList<>();
+    org.w3c.dom.NodeList children = el.getChildNodes();
+    for (int i = 0; i < children.getLength(); i++) {
+      if (children.item(i) instanceof org.w3c.dom.Element child) {
+        out.add(child);
+      }
+    }
+    return out;
+  }
+
+  private static String domText(org.w3c.dom.Element el) {
+    StringBuilder sb = new StringBuilder();
+    org.w3c.dom.NodeList children = el.getChildNodes();
+    for (int i = 0; i < children.getLength(); i++) {
+      org.w3c.dom.Node node = children.item(i);
+      if (node.getNodeType() == org.w3c.dom.Node.TEXT_NODE
+        || node.getNodeType() == org.w3c.dom.Node.CDATA_SECTION_NODE) {
+        sb.append(node.getNodeValue());
+      }
+    }
+    return sb.toString().trim();
+  }
+
+  private static String nz(String s) {
+    return s == null ? "" : s;
   }
 
   /**

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesGranularPatch.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesGranularPatch.java
@@ -199,6 +199,7 @@ public final class MdObjectPropertiesGranularPatch {
       return replacementElementXml;
     }
     String indent = currentLineIndent(xmlUtf8, reg.start());
+    String eol = fileEol(xmlUtf8);
     String compact = INTER_TAG_WS.matcher(replacementElementXml.trim()).replaceAll("><");
     if (!compact.contains("><")) {
       return replacementElementXml;
@@ -213,7 +214,7 @@ public final class MdObjectPropertiesGranularPatch {
         depth = Math.max(0, depth - 1);
       }
       if (i > 0) {
-        out.append('\n');
+        out.append(eol);
         out.append(indent);
         for (int j = 0; j < depth; j++) {
           out.append('\t');
@@ -260,18 +261,24 @@ public final class MdObjectPropertiesGranularPatch {
     int insertPos,
     String replacementElementXml) {
     String parentIndent = currentLineIndent(xmlUtf8, insertPos);
+    String eol = fileEol(xmlUtf8);
     String childIndent = parentIndent + "\t";
     String compact = INTER_TAG_WS.matcher(replacementElementXml.trim()).replaceAll("><");
     String expanded = compact.replace("><", ">\n<");
     String[] lines = expanded.split("\n");
     StringBuilder out = new StringBuilder(expanded.length() + childIndent.length() * lines.length + 2);
-    out.append('\n');
+    out.append(eol);
     for (int i = 0; i < lines.length; i++) {
       if (i > 0) {
-        out.append('\n');
+        out.append(eol);
       }
       out.append(childIndent).append(lines[i].trim());
     }
     return out.toString();
+  }
+
+  /** Перевод строки исходного файла: не смешиваем CRLF и LF при точечных заменах. */
+  private static String fileEol(String xmlUtf8) {
+    return xmlUtf8.contains("\r\n") ? "\r\n" : "\n";
   }
 }

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesJsonCoalesce.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesJsonCoalesce.java
@@ -33,10 +33,10 @@ public final class MdObjectPropertiesJsonCoalesce {
     if (incoming.comment == null) {
       incoming.comment = baseline.comment;
     }
-    if (incoming.attributes == null) {
+    if (incoming.attributes == null || incoming.attributes.isEmpty()) {
       incoming.attributes = copyNamedList(baseline.attributes);
     }
-    if (incoming.tabularSections == null) {
+    if (incoming.tabularSections == null || incoming.tabularSections.isEmpty()) {
       incoming.tabularSections = copyNamedList(baseline.tabularSections);
     }
     if (incoming.nestedSubsystems == null) {

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/ProjectMetadataGraphBuilder.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/ProjectMetadataGraphBuilder.java
@@ -53,7 +53,15 @@ public final class ProjectMetadataGraphBuilder {
    * @param projectRoot корень проекта (где лежат {@code src/cf}, при наличии — {@code src/cfe}, {@code src/epf}, {@code src/erf})
    */
   public static ProjectMetadataGraphDto build(Path projectRoot) throws IOException {
-    ProjectMetadataTreeDto tree = ProjectMetadataTreeBuilder.build(projectRoot);
+    return build(projectRoot, ProjectSourceDirs.DEFAULTS);
+  }
+
+  /**
+   * @param projectRoot корень проекта
+   * @param dirs каталоги исходников (настраиваемые; относительные — от корня проекта)
+   */
+  public static ProjectMetadataGraphDto build(Path projectRoot, ProjectSourceDirs dirs) throws IOException {
+    ProjectMetadataTreeDto tree = ProjectMetadataTreeBuilder.build(projectRoot, dirs);
     Path normalized = Path.of(tree.projectRoot());
     Map<String, ProjectMetadataGraphDto.NodeDto> nodes = new LinkedHashMap<>();
     Map<String, List<String>> subsystemKeysByTarget = new LinkedHashMap<>();

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/ProjectMetadataTreeBuilder.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/ProjectMetadataTreeBuilder.java
@@ -29,11 +29,19 @@ public final class ProjectMetadataTreeBuilder {
   }
 
   /**
-   * @param projectRoot корень проекта (где лежат {@code src/cf}, при наличии — {@code src/cfe}, {@code src/epf}, {@code src/erf})
+   * @param projectRoot корень проекта со стандартной раскладкой ({@code src/cf}, {@code src/cfe}, {@code src/epf}, {@code src/erf})
    */
   public static ProjectMetadataTreeDto build(Path projectRoot) throws IOException {
+    return build(projectRoot, ProjectSourceDirs.DEFAULTS);
+  }
+
+  /**
+   * @param projectRoot корень проекта
+   * @param dirs каталоги исходников (настраиваемые; относительные — от корня проекта)
+   */
+  public static ProjectMetadataTreeDto build(Path projectRoot, ProjectSourceDirs dirs) throws IOException {
     Path normalized = projectRoot.toAbsolutePath().normalize();
-    Path mainCf = normalized.resolve("src").resolve("cf");
+    Path mainCf = dirs.cfPath(normalized);
     Path mainCfg = mainCf.resolve(CfLayout.CONFIGURATION_XML);
     if (!Files.isRegularFile(mainCfg)) {
       throw new IOException("Не найден файл основной выгрузки: " + mainCfg);
@@ -43,7 +51,7 @@ public final class ProjectMetadataTreeBuilder {
     String verFlag = MetaDataObjectHeadReader.toSchemaVersionFlag(ver);
     List<ProjectMetadataTreeDto.MetadataSourceDto> sources = new ArrayList<>();
     sources.add(buildMainSource(normalized, mainCf, mainCfg));
-    Path cfeRoot = normalized.resolve("src").resolve("cfe");
+    Path cfeRoot = dirs.cfePath(normalized);
     if (Files.isDirectory(cfeRoot)) {
       try (var stream = Files.list(cfeRoot)) {
         List<Path> extDirs = stream.filter(Files::isDirectory).sorted().collect(Collectors.toList());
@@ -55,8 +63,17 @@ public final class ProjectMetadataTreeBuilder {
         }
       }
     }
-    appendExternalArtifactSources(normalized, sources);
+    appendExternalArtifactSources(normalized, dirs, sources);
     return new ProjectMetadataTreeDto(normalized.toString(), ver, verFlag, sources);
+  }
+
+  /** Относительный путь от корня проекта; вне корня — абсолютный (для DTO). */
+  private static String relativeOrAbsolute(Path projectRoot, Path target) {
+    Path normalized = target.toAbsolutePath().normalize();
+    if (normalized.startsWith(projectRoot)) {
+      return projectRoot.relativize(normalized).toString().replace('\\', '/');
+    }
+    return normalized.toString().replace('\\', '/');
   }
 
   private static ProjectMetadataTreeDto.MetadataSourceDto buildMainSource(
@@ -168,20 +185,24 @@ public final class ProjectMetadataTreeBuilder {
 
   private static void appendExternalArtifactSources(
     Path projectRoot,
+    ProjectSourceDirs dirs,
     List<ProjectMetadataTreeDto.MetadataSourceDto> sources
   ) throws IOException {
-    List<ExternalArtifactLister.ExternalArtifactEntry> erf = ExternalArtifactLister.listErf(projectRoot);
+    List<ExternalArtifactLister.ExternalArtifactEntry> erf =
+      ExternalArtifactLister.listArtifacts(projectRoot, dirs.erfPath(projectRoot));
     if (!erf.isEmpty()) {
-      sources.add(buildExternalErfSource(erf));
+      sources.add(buildExternalErfSource(erf, relativeOrAbsolute(projectRoot, dirs.erfPath(projectRoot))));
     }
-    List<ExternalArtifactLister.ExternalArtifactEntry> epf = ExternalArtifactLister.listEpf(projectRoot);
+    List<ExternalArtifactLister.ExternalArtifactEntry> epf =
+      ExternalArtifactLister.listArtifacts(projectRoot, dirs.epfPath(projectRoot));
     if (!epf.isEmpty()) {
-      sources.add(buildExternalEpfSource(epf));
+      sources.add(buildExternalEpfSource(epf, relativeOrAbsolute(projectRoot, dirs.epfPath(projectRoot))));
     }
   }
 
   private static ProjectMetadataTreeDto.MetadataSourceDto buildExternalErfSource(
-    List<ExternalArtifactLister.ExternalArtifactEntry> entries
+    List<ExternalArtifactLister.ExternalArtifactEntry> entries,
+    String rootRelativePath
   ) {
     List<ProjectMetadataTreeDto.MetadataItemDto> items = new ArrayList<>();
     for (ExternalArtifactLister.ExternalArtifactEntry e : entries) {
@@ -195,13 +216,14 @@ public final class ProjectMetadataTreeBuilder {
       "external-erf",
       "Внешние отчёты",
       "",
-      "src/erf",
+      rootRelativePath,
       groups
     );
   }
 
   private static ProjectMetadataTreeDto.MetadataSourceDto buildExternalEpfSource(
-    List<ExternalArtifactLister.ExternalArtifactEntry> entries
+    List<ExternalArtifactLister.ExternalArtifactEntry> entries,
+    String rootRelativePath
   ) {
     List<ProjectMetadataTreeDto.MetadataItemDto> items = new ArrayList<>();
     for (ExternalArtifactLister.ExternalArtifactEntry e : entries) {
@@ -215,7 +237,7 @@ public final class ProjectMetadataTreeBuilder {
       "external-epf",
       "Внешние обработки",
       "",
-      "src/epf",
+      rootRelativePath,
       groups
     );
   }

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/ProjectSourceDirs.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/ProjectSourceDirs.java
@@ -1,0 +1,49 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+import java.nio.file.Path;
+
+/**
+ * Каталоги исходников проекта относительно его корня (абсолютные пути тоже допустимы).
+ * По умолчанию — стандартная раскладка {@code src/cf}, {@code src/cfe}, {@code src/epf}, {@code src/erf}.
+ */
+public record ProjectSourceDirs(String cf, String cfe, String epf, String erf) {
+
+  public static final ProjectSourceDirs DEFAULTS = new ProjectSourceDirs("src/cf", "src/cfe", "src/epf", "src/erf");
+
+  /** Значения из CLI: null/пустые заменяются дефолтами. */
+  public static ProjectSourceDirs fromNullable(String cf, String cfe, String epf, String erf) {
+    return new ProjectSourceDirs(
+      orDefault(cf, DEFAULTS.cf()),
+      orDefault(cfe, DEFAULTS.cfe()),
+      orDefault(epf, DEFAULTS.epf()),
+      orDefault(erf, DEFAULTS.erf()));
+  }
+
+  private static String orDefault(String value, String def) {
+    return value == null || value.isBlank() ? def : value.trim();
+  }
+
+  public Path cfPath(Path projectRoot) {
+    return projectRoot.resolve(cf).normalize();
+  }
+
+  public Path cfePath(Path projectRoot) {
+    return projectRoot.resolve(cfe).normalize();
+  }
+
+  public Path epfPath(Path projectRoot) {
+    return projectRoot.resolve(epf).normalize();
+  }
+
+  public Path erfPath(Path projectRoot) {
+    return projectRoot.resolve(erf).normalize();
+  }
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cli/ApplyMutationCmd.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cli/ApplyMutationCmd.java
@@ -35,6 +35,8 @@ import io.github.yellowhammer.designerxml.cf.ExternalArtifactPropertiesEdit;
 import io.github.yellowhammer.designerxml.cf.MdObjectAdd;
 import io.github.yellowhammer.designerxml.cf.MdObjectAddType;
 import io.github.yellowhammer.designerxml.cf.MdObjectChildMutations;
+import io.github.yellowhammer.designerxml.cf.MdObjectPropertiesDto;
+import io.github.yellowhammer.designerxml.cf.MdObjectPropertiesEdit;
 import io.github.yellowhammer.designerxml.cf.NewExternalArtifactXml;
 import jakarta.xml.bind.JAXBException;
 import picocli.CommandLine.Command;
@@ -166,6 +168,19 @@ final class ApplyMutationCmd implements Callable<Integer> {
         MdObjectChildMutations.deleteTabularAttribute(
           p.reqPath(p.objectXml, "objectXml"), p.version(), p.req(p.tabularSection, "tabularSection"), p.req(p.name, "name"));
         return "OK";
+      case "cf-md-attribute-reorder":
+        MdObjectChildMutations.reorderAttributes(
+          p.reqPath(p.objectXml, "objectXml"), p.version(), parseNameList(p));
+        return "OK";
+      case "cf-md-tabular-section-reorder":
+        MdObjectChildMutations.reorderTabularSections(
+          p.reqPath(p.objectXml, "objectXml"), p.version(), parseNameList(p));
+        return "OK";
+      case "cf-md-tabular-attribute-reorder":
+        MdObjectChildMutations.reorderTabularAttributes(
+          p.reqPath(p.objectXml, "objectXml"), p.version(), p.req(p.tabularSection, "tabularSection"), parseNameList(p));
+        return "OK";
+
       case "cf-md-tabular-attribute-duplicate":
         MdObjectChildMutations.duplicateTabularAttribute(
           p.reqPath(p.objectXml, "objectXml"), p.version(), p.req(p.tabularSection, "tabularSection"),
@@ -189,6 +204,11 @@ final class ApplyMutationCmd implements Callable<Integer> {
           p.version());
         return "OK";
 
+      case "cf-md-object-set": {
+        MdObjectPropertiesDto dto = parsePayload(p, MdObjectPropertiesDto.class);
+        MdObjectPropertiesEdit.writeDto(p.reqPath(p.objectXml, "objectXml"), p.version(), dto);
+        return "OK";
+      }
       case "external-artifact-properties-set": {
         ExternalArtifactPropertiesDto dto = parsePayload(p, ExternalArtifactPropertiesDto.class);
         ExternalArtifactPropertiesEdit.write(p.reqPath(p.objectXml, "objectXml"), p.version(), dto);
@@ -231,6 +251,12 @@ final class ApplyMutationCmd implements Callable<Integer> {
       default:
         throw new IllegalArgumentException("неизвестный op: " + p.op);
     }
+  }
+
+  /** Список имён из {@code payloadJson} (JSON-массив строк). */
+  private static java.util.List<String> parseNameList(CliParams p) {
+    String[] names = parsePayload(p, String[].class);
+    return java.util.Arrays.asList(names);
   }
 
   private static <T> T parsePayload(CliParams p, Class<T> type) {

--- a/src/main/java/io/github/yellowhammer/designerxml/cli/CliParams.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cli/CliParams.java
@@ -47,6 +47,11 @@ final class CliParams {
   String artifactsRoot;
   String targetCfRoot;
   String projectRoot;
+  /** Каталоги исходников относительно projectRoot (null — стандартные src/cf, src/cfe, src/epf, src/erf). */
+  String cfDir;
+  String cfeDir;
+  String epfDir;
+  String erfDir;
   String tag;
   String name;
   String oldName;

--- a/src/main/java/io/github/yellowhammer/designerxml/cli/ReadJsonCmd.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cli/ReadJsonCmd.java
@@ -40,6 +40,7 @@ import io.github.yellowhammer.designerxml.cf.ProjectMetadataGraphBuilder;
 import io.github.yellowhammer.designerxml.cf.ProjectMetadataGraphDto;
 import io.github.yellowhammer.designerxml.cf.ProjectMetadataTreeBuilder;
 import io.github.yellowhammer.designerxml.cf.ProjectMetadataTreeDto;
+import io.github.yellowhammer.designerxml.cf.ProjectSourceDirs;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
@@ -132,11 +133,15 @@ final class ReadJsonCmd implements Callable<Integer> {
         return ConfigurationCatalogLister.toJsonArray(names);
       }
       case "project-metadata-tree": {
-        ProjectMetadataTreeDto dto = ProjectMetadataTreeBuilder.build(p.reqPath(p.projectRoot, "projectRoot"));
+        ProjectMetadataTreeDto dto = ProjectMetadataTreeBuilder.build(
+          p.reqPath(p.projectRoot, "projectRoot"),
+          ProjectSourceDirs.fromNullable(p.cfDir, p.cfeDir, p.epfDir, p.erfDir));
         return gson.toJson(dto);
       }
       case "cf-md-graph": {
-        ProjectMetadataGraphDto dto = ProjectMetadataGraphBuilder.build(p.reqPath(p.projectRoot, "projectRoot"));
+        ProjectMetadataGraphDto dto = ProjectMetadataGraphBuilder.build(
+          p.reqPath(p.projectRoot, "projectRoot"),
+          ProjectSourceDirs.fromNullable(p.cfDir, p.cfeDir, p.epfDir, p.erfDir));
         return gson.toJson(dto);
       }
       default:

--- a/src/test/java/io/github/yellowhammer/designerxml/cf/ProjectSourceDirsTest.java
+++ b/src/test/java/io/github/yellowhammer/designerxml/cf/ProjectSourceDirsTest.java
@@ -1,0 +1,60 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Дерево метаданных с настраиваемыми каталогами исходников (нестандартная раскладка проекта).
+ */
+class ProjectSourceDirsTest {
+
+  @Test
+  void treeBuildsWithCustomSourceDirs() throws IOException {
+    Path ssl = Path.of(System.getProperty("fixtures.ssl31.root"));
+    Path project = Files.createTempDirectory("custom-dirs-");
+    // Конфигурация в нестандартном каталоге: конфигурация/исходники
+    Path cfDir = project.resolve("конфигурация").resolve("исходники");
+    Files.createDirectories(cfDir.getParent());
+    copyMinimalCf(ssl.resolve("src").resolve("cf"), cfDir);
+
+    ProjectSourceDirs dirs = ProjectSourceDirs.fromNullable("конфигурация/исходники", null, null, null);
+    ProjectMetadataTreeDto dto = ProjectMetadataTreeBuilder.build(project, dirs);
+
+    assertThat(dto.sources()).isNotEmpty();
+    ProjectMetadataTreeDto.MetadataSourceDto main = dto.sources().get(0);
+    assertThat(main.kind()).isEqualTo("main");
+    assertThat(main.metadataRootRelativePath()).isEqualTo("конфигурация/исходники");
+    assertThat(main.configurationXmlRelativePath()).isEqualTo("конфигурация/исходники/Configuration.xml");
+  }
+
+  @Test
+  void nullDirsFallBackToDefaults() {
+    ProjectSourceDirs dirs = ProjectSourceDirs.fromNullable(null, "", "  ", "custom/erf");
+    assertThat(dirs.cf()).isEqualTo("src/cf");
+    assertThat(dirs.cfe()).isEqualTo("src/cfe");
+    assertThat(dirs.epf()).isEqualTo("src/epf");
+    assertThat(dirs.erf()).isEqualTo("custom/erf");
+  }
+
+  /** Копирует минимум выгрузки: Configuration.xml и один справочник (без содержимого папок). */
+  private static void copyMinimalCf(Path srcCf, Path targetCf) throws IOException {
+    Files.createDirectories(targetCf.resolve("Catalogs"));
+    Files.copy(srcCf.resolve("Configuration.xml"), targetCf.resolve("Configuration.xml"));
+    Files.copy(
+      srcCf.resolve("Catalogs").resolve("_ДемоБанковскиеСчета.xml"),
+      targetCf.resolve("Catalogs").resolve("_ДемоБанковскиеСчета.xml"));
+  }
+}

--- a/src/test/java/io/github/yellowhammer/designerxml/cli/ApplyMutationCmdTest.java
+++ b/src/test/java/io/github/yellowhammer/designerxml/cli/ApplyMutationCmdTest.java
@@ -46,6 +46,195 @@ class ApplyMutationCmdTest {
   }
 
   @Test
+  void objectSet_viaParamsFile_updatesCatalogScalarsGranularly() throws Exception {
+    // Паттерн панели свойств: прочитать полный DTO, изменить поля, записать целиком.
+    Path objectXml = copyToTemp(sampleCatalogXml());
+    String before = Files.readString(objectXml, StandardCharsets.UTF_8);
+    io.github.yellowhammer.designerxml.cf.MdObjectPropertiesDto dto =
+      io.github.yellowhammer.designerxml.cf.MdObjectPropertiesEdit.readDto(
+        objectXml, io.github.yellowhammer.designerxml.SchemaVersion.V2_20);
+    String newSynonym = "Демо: Банковские счета (изменено)";
+    dto.synonymRu = newSynonym;
+    dto.catalog.choiceMode = "QUICK_CHOICE";
+    Path params = writeParams(
+      "{"
+        + "\"op\":\"cf-md-object-set\","
+        + "\"objectXml\":" + json(objectXml.toString()) + ","
+        + "\"schemaVersion\":\"V2_20\","
+        + "\"payloadJson\":" + json(new com.google.gson.Gson().toJson(dto))
+        + "}");
+
+    int exit = new CommandLine(new DesignerXmlCli()).execute("apply-mutation", "--params", params.toString());
+
+    assertThat(exit).isZero();
+    String after = Files.readString(objectXml, StandardCharsets.UTF_8);
+    assertThat(after).contains(newSynonym);
+    assertThat(after).contains("<ChoiceMode>QuickChoice</ChoiceMode>");
+    // Гранулярность: незатронутые узлы не переписаны, владельцы сохранены.
+    assertThat(after).contains("Catalog._ДемоОрганизации");
+    assertThat(countLines(after)).isEqualTo(countLines(before));
+  }
+
+  @Test
+  void objectSet_ownerAndInputByStringLists_writeGranularly() throws Exception {
+    Path objectXml = copyToTemp(sampleCatalogXml());
+    String before = Files.readString(objectXml, StandardCharsets.UTF_8);
+    io.github.yellowhammer.designerxml.cf.MdObjectPropertiesDto dto =
+      io.github.yellowhammer.designerxml.cf.MdObjectPropertiesEdit.readDto(
+        objectXml, io.github.yellowhammer.designerxml.SchemaVersion.V2_20);
+    dto.catalog.owners = java.util.List.of("Catalog._ДемоОрганизации");
+    dto.catalog.inputByString = java.util.List.of("Catalog._ДемоБанковскиеСчета.StandardAttribute.Code");
+    Path params = writeParams(
+      "{"
+        + "\"op\":\"cf-md-object-set\","
+        + "\"objectXml\":" + json(objectXml.toString()) + ","
+        + "\"schemaVersion\":\"V2_20\","
+        + "\"payloadJson\":" + json(new com.google.gson.Gson().toJson(dto))
+        + "}");
+
+    int exit = new CommandLine(new DesignerXmlCli()).execute("apply-mutation", "--params", params.toString());
+
+    assertThat(exit).isZero();
+    String after = Files.readString(objectXml, StandardCharsets.UTF_8);
+    assertThat(after).doesNotContain("Catalog._ДемоКонтрагенты</xr:Item>");
+    assertThat(after).contains("<xr:Field>Catalog._ДемоБанковскиеСчета.StandardAttribute.Code</xr:Field>");
+    // Гранулярность: из списков ушло по одной строке, остальной файл не переформатирован.
+    assertThat(countLines(before) - countLines(after)).isEqualTo(2);
+  }
+
+  @Test
+  void objectSet_scalarOnlyPayload_keepsAttributesAndOwners() throws Exception {
+    // Частичный payload без списков: реквизиты и владельцы не должны потеряться.
+    Path objectXml = copyToTemp(sampleCatalogXml());
+    Path params = writeParams(
+      "{"
+        + "\"op\":\"cf-md-object-set\","
+        + "\"objectXml\":" + json(objectXml.toString()) + ","
+        + "\"schemaVersion\":\"V2_20\","
+        + "\"payloadJson\":" + json(
+          "{"
+            + "\"kind\":\"catalog\","
+            + "\"internalName\":\"_ДемоБанковскиеСчета\","
+            + "\"synonymRu\":\"Демо: Банковские счета (частично)\""
+            + "}")
+        + "}");
+
+    int exit = new CommandLine(new DesignerXmlCli()).execute("apply-mutation", "--params", params.toString());
+
+    assertThat(exit).isZero();
+    String after = Files.readString(objectXml, StandardCharsets.UTF_8);
+    assertThat(after).contains("Демо: Банковские счета (частично)");
+    assertThat(after).contains("БИКБанка");
+    assertThat(after).contains("Catalog._ДемоОрганизации");
+  }
+
+  private static long countLines(String text) {
+    return text.lines().count();
+  }
+
+  @Test
+  void objectSet_blobPrefixesFromAnotherJvm_staysGranular() throws Exception {
+    // JAXB между запусками JVM назначает ns-префиксы в блобах по-разному: это не изменение данных.
+    Path objectXml = copyToTemp(sampleCatalogXml());
+    String before = Files.readString(objectXml, StandardCharsets.UTF_8);
+    io.github.yellowhammer.designerxml.cf.MdObjectPropertiesDto dto =
+      io.github.yellowhammer.designerxml.cf.MdObjectPropertiesEdit.readDto(
+        objectXml, io.github.yellowhammer.designerxml.SchemaVersion.V2_20);
+    dto.synonymRu = "Демо: Банковские счета (префиксы)";
+    dto.catalog.standardAttributesXml = dto.catalog.standardAttributesXml
+      .replace("ns9:", "nsTMP:").replace("xmlns:ns9=", "xmlns:nsTMP=");
+    Path params = writeParams(
+      "{"
+        + "\"op\":\"cf-md-object-set\","
+        + "\"objectXml\":" + json(objectXml.toString()) + ","
+        + "\"schemaVersion\":\"V2_20\","
+        + "\"payloadJson\":" + json(new com.google.gson.Gson().toJson(dto))
+        + "}");
+
+    int exit = new CommandLine(new DesignerXmlCli()).execute("apply-mutation", "--params", params.toString());
+
+    assertThat(exit).isZero();
+    String after = Files.readString(objectXml, StandardCharsets.UTF_8);
+    assertThat(after).contains("Демо: Банковские счета (префиксы)");
+    assertThat(countLines(after)).isEqualTo(countLines(before));
+  }
+
+  @Test
+  void attributeReorder_swapsBlocksGranularly() throws Exception {
+    Path objectXml = copyToTemp(sampleCatalogXml());
+    String before = Files.readString(objectXml, StandardCharsets.UTF_8);
+    Path params = writeParams(
+      "{"
+        + "\"op\":\"cf-md-attribute-reorder\","
+        + "\"objectXml\":" + json(objectXml.toString()) + ","
+        + "\"schemaVersion\":\"V2_20\","
+        + "\"payloadJson\":" + json("[\"БИКБанка\",\"Валюта\"]")
+        + "}");
+
+    int exit = new CommandLine(new DesignerXmlCli()).execute("apply-mutation", "--params", params.toString());
+
+    assertThat(exit).isZero();
+    String after = Files.readString(objectXml, StandardCharsets.UTF_8);
+    assertThat(countLines(after)).isEqualTo(countLines(before));
+    assertThat(after.indexOf("<Name>БИКБанка</Name>")).isLessThan(after.indexOf("<Name>Валюта</Name>"));
+  }
+
+  @Test
+  void objectSet_clearDefaultForm_writesEmptyElement() throws Exception {
+    Path objectXml = copyToTemp(sampleCatalogXml());
+    String before = Files.readString(objectXml, StandardCharsets.UTF_8);
+    io.github.yellowhammer.designerxml.cf.MdObjectPropertiesDto dto =
+      io.github.yellowhammer.designerxml.cf.MdObjectPropertiesEdit.readDto(
+        objectXml, io.github.yellowhammer.designerxml.SchemaVersion.V2_20);
+    dto.catalog.defaultObjectForm = "";
+    Path params = writeParams(
+      "{"
+        + "\"op\":\"cf-md-object-set\","
+        + "\"objectXml\":" + json(objectXml.toString()) + ","
+        + "\"schemaVersion\":\"V2_20\","
+        + "\"payloadJson\":" + json(new com.google.gson.Gson().toJson(dto))
+        + "}");
+
+    int exit = new CommandLine(new DesignerXmlCli()).execute("apply-mutation", "--params", params.toString());
+
+    assertThat(exit).isZero();
+    String after = Files.readString(objectXml, StandardCharsets.UTF_8);
+    assertThat(after).contains("<DefaultObjectForm/>");
+    assertThat(after).doesNotContain("<DefaultObjectForm>Catalog.");
+    assertThat(countLines(after)).isEqualTo(countLines(before));
+  }
+
+  @Test
+  void tabularSectionAdd_writesInternalInfoAndRenameUpdatesIt() throws Exception {
+    Path objectXml = copyToTemp(sampleCatalogXml());
+    Path addParams = writeParams(
+      "{"
+        + "\"op\":\"cf-md-tabular-section-add\","
+        + "\"objectXml\":" + json(objectXml.toString()) + ","
+        + "\"name\":\"НоваяТЧ\","
+        + "\"schemaVersion\":\"V2_20\""
+        + "}");
+    assertThat(new CommandLine(new DesignerXmlCli()).execute("apply-mutation", "--params", addParams.toString())).isZero();
+    String afterAdd = Files.readString(objectXml, StandardCharsets.UTF_8);
+    assertThat(afterAdd).contains("name=\"CatalogTabularSection._ДемоБанковскиеСчета.НоваяТЧ\" category=\"TabularSection\"");
+    assertThat(afterAdd).contains("name=\"CatalogTabularSectionRow._ДемоБанковскиеСчета.НоваяТЧ\" category=\"TabularSectionRow\"");
+
+    Path renameParams = writeParams(
+      "{"
+        + "\"op\":\"cf-md-tabular-section-rename\","
+        + "\"objectXml\":" + json(objectXml.toString()) + ","
+        + "\"oldName\":\"НоваяТЧ\","
+        + "\"newName\":\"Переименованная\","
+        + "\"schemaVersion\":\"V2_20\""
+        + "}");
+    assertThat(new CommandLine(new DesignerXmlCli()).execute("apply-mutation", "--params", renameParams.toString())).isZero();
+    String afterRename = Files.readString(objectXml, StandardCharsets.UTF_8);
+    assertThat(afterRename).contains("name=\"CatalogTabularSection._ДемоБанковскиеСчета.Переименованная\"");
+    assertThat(afterRename).doesNotContain(".НоваяТЧ\"");
+    assertThat(afterRename).doesNotContain("<Name>НоваяТЧ</Name>");
+  }
+
+  @Test
   void unknownOp_returnsError() throws Exception {
     Path params = writeParams("{\"op\":\"no-such-op\"}");
     int exit = new CommandLine(new DesignerXmlCli()).execute("apply-mutation", "--params", params.toString());
@@ -109,5 +298,14 @@ class ApplyMutationCmdTest {
       .resolve("cf")
       .resolve("Documents")
       .resolve("_ДемоЗаказПокупателя.xml");
+  }
+
+  private static Path sampleCatalogXml() {
+    String fixturesRoot = System.getProperty("fixtures.ssl31.root");
+    return Path.of(fixturesRoot)
+      .resolve("src")
+      .resolve("cf")
+      .resolve("Catalogs")
+      .resolve("_ДемоБанковскиеСчета.xml");
   }
 }


### PR DESCRIPTION
## Что сделано

**Запись свойств объекта** — `cf-md-object-set` заведён в канал `apply-mutation --params` (`payloadJson`, гранулярная запись по diff относительно XML на диске). Починена сама гранулярная запись:
- enum-значения DTO (`BOTH_WAYS`) конвертируются в текст схемы (`BothWays`);
- `InputByString`/`DataLockFields` пишутся с префиксом `xr:`;
- точечные замены сохраняют перевод строки файла (CRLF/LF);
- XML-блобы (`StandardAttributes`, `Characteristics`) сравниваются семантически через DOM: JAXB между запусками JVM недетерминированно раскладывает пространства имён, из-за чего запись случайно падала в полную пересборку блока Properties;
- пустое значение `textElement` пишется самозакрытым тегом (очистка основных форм).

**Структура** — операции сортировки `cf-md-attribute-reorder` / `cf-md-tabular-section-reorder` / `cf-md-tabular-attribute-reorder` (блоки переставляются местами, файл не переформатируется). Новые табличные части получают `InternalInfo` с `GeneratedType` — без него платформа отклоняла загрузку конфигурации; rename/duplicate обновляют имена в `GeneratedType`. Вставка/удаление узлов ChildObjects больше не оставляют строк из отступов и LF-примесей.

**Каталоги исходников** — `project-metadata-tree` и `cf-md-graph` принимают `cfDir`/`cfeDir`/`epfDir`/`erfDir` (по умолчанию прежние `src/*`).

## Проверка
- Все тесты зелёные, добавлены регрессионные: гранулярность скаляров/списков/blob-префиксов, InternalInfo и rename ТЧ, reorder, нестандартные каталоги исходников.
- Приёмка на живой конфигурации ssl_3_1: серия правок через панель VS Code, `vrunner infobase update --src src/cf` проходит.

Используется расширением vscode-1c-platform-tools (yellow-hammer/vscode-1c-platform-tools#215): после слияния нужен релиз jar.

