### PR TITLE
feat(cf): зачистка привязок в формах при удалении и переименовании реквизитов

### DIFF
--- a/src/main/java/io/github/yellowhammer/designerxml/cf/FormDataPathCleanup.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/FormDataPathCleanup.java
@@ -1,0 +1,253 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+import com.ctc.wstx.stax.WstxInputFactory;
+
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Deque;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Зачистка привязок в формах объекта при удалении и переименовании реквизитов и табличных частей
+ * (поведение конфигуратора): элементы формы с {@code DataPath} на удалённый реквизит убираются,
+ * при переименовании пути обновляются. Обрабатываются пути через главные реквизиты формы
+ * ({@code MainAttribute}): {@code Объект.<Реквизит>}, {@code Список.<Реквизит>} и т. п.
+ */
+public final class FormDataPathCleanup {
+
+  private static final Pattern MAIN_ATTRIBUTE_NAME = Pattern.compile(
+    "<Attribute name=\"([^\"]+)\"[^>]*>(?:(?!</Attribute>).)*?<MainAttribute>true</MainAttribute>",
+    Pattern.DOTALL);
+
+  private FormDataPathCleanup() {
+  }
+
+  /**
+   * Убирает из форм объекта элементы, привязанные к удалённому реквизиту.
+   *
+   * @param objectXml путь к XML объекта метаданных
+   * @param pathTail хвост пути данных: {@code Имя}, {@code ТЧ} или {@code ТЧ.Имя}
+   */
+  public static void afterChildDelete(Path objectXml, String pathTail) throws IOException {
+    for (Path formXml : objectFormXmlFiles(objectXml)) {
+      String xml = Files.readString(formXml, StandardCharsets.UTF_8);
+      Set<String> targets = targetsFor(xml, pathTail);
+      if (targets.isEmpty()) {
+        continue;
+      }
+      String updated;
+      try {
+        updated = removeBoundItems(xml, targets);
+      } catch (XMLStreamException e) {
+        throw new IOException("Не удалось разобрать форму " + formXml + ": " + e.getMessage(), e);
+      }
+      writeIfChangedAndValid(formXml, xml, updated);
+    }
+  }
+
+  /**
+   * Обновляет пути данных в формах объекта при переименовании реквизита или табличной части.
+   *
+   * @param objectXml путь к XML объекта метаданных
+   * @param oldTail старый хвост пути данных ({@code Имя}, {@code ТЧ} или {@code ТЧ.Имя})
+   * @param newTail новый хвост пути данных
+   */
+  public static void afterChildRename(Path objectXml, String oldTail, String newTail) throws IOException {
+    for (Path formXml : objectFormXmlFiles(objectXml)) {
+      String xml = Files.readString(formXml, StandardCharsets.UTF_8);
+      String updated = xml;
+      for (String main : mainAttributeNames(xml)) {
+        String oldPath = main + "." + oldTail;
+        String newPath = main + "." + newTail;
+        updated = updated.replace("<DataPath>" + oldPath + "</DataPath>", "<DataPath>" + newPath + "</DataPath>");
+        updated = updated.replace("<DataPath>" + oldPath + ".", "<DataPath>" + newPath + ".");
+      }
+      writeIfChangedAndValid(formXml, xml, updated);
+    }
+  }
+
+  /** {@code Forms/<Имя>/Ext/Form.xml} рядом с XML объекта. */
+  private static List<Path> objectFormXmlFiles(Path objectXml) throws IOException {
+    String stem = objectXml.getFileName().toString().replaceFirst("\\.xml$", "");
+    Path formsDir = objectXml.resolveSibling(stem).resolve("Forms");
+    if (!Files.isDirectory(formsDir)) {
+      return List.of();
+    }
+    List<Path> out = new ArrayList<>();
+    try (DirectoryStream<Path> ds = Files.newDirectoryStream(formsDir, Files::isDirectory)) {
+      for (Path formDir : ds) {
+        Path formXml = formDir.resolve("Ext").resolve("Form.xml");
+        if (Files.isRegularFile(formXml)) {
+          out.add(formXml);
+        }
+      }
+    }
+    out.sort(Comparator.comparing(Path::toString));
+    return out;
+  }
+
+  private static Set<String> targetsFor(String formXml, String pathTail) {
+    Set<String> targets = new LinkedHashSet<>();
+    for (String main : mainAttributeNames(formXml)) {
+      targets.add(main + "." + pathTail);
+    }
+    return targets;
+  }
+
+  private static List<String> mainAttributeNames(String formXml) {
+    List<String> out = new ArrayList<>();
+    Matcher m = MAIN_ATTRIBUTE_NAME.matcher(formXml);
+    while (m.find()) {
+      out.add(m.group(1));
+    }
+    return out;
+  }
+
+  /**
+   * Убирает элементы формы, у которых прямой дочерний {@code DataPath} равен цели или начинается с
+   * {@code цель.} (колонки таблицы удаляемой ТЧ и т. п.).
+   */
+  private static String removeBoundItems(String xml, Set<String> targets) throws XMLStreamException {
+    List<int[]> removals = boundItemRegions(xml, targets);
+    if (removals.isEmpty()) {
+      return xml;
+    }
+    // Вложенные регионы поглощаются внешними.
+    removals.sort(Comparator.comparingInt(a -> a[0]));
+    List<int[]> flat = new ArrayList<>();
+    int lastEnd = -1;
+    for (int[] region : removals) {
+      if (region[0] >= lastEnd) {
+        flat.add(region);
+        lastEnd = region[1];
+      }
+    }
+    String out = xml;
+    for (int i = flat.size() - 1; i >= 0; i--) {
+      out = removeRegionWithLine(out, flat.get(i)[0], flat.get(i)[1]);
+    }
+    return out;
+  }
+
+  private static List<int[]> boundItemRegions(String xml, Set<String> targets) throws XMLStreamException {
+    XMLInputFactory f = new WstxInputFactory();
+    f.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, Boolean.TRUE);
+    XMLStreamReader r = f.createXMLStreamReader(new StringReader(xml));
+    // Элемент стека: [смещение начала тега, признак совпавшего DataPath]
+    Deque<int[]> stack = new ArrayDeque<>();
+    List<int[]> removals = new ArrayList<>();
+    try {
+      while (r.hasNext()) {
+        int ev = r.next();
+        if (ev == XMLStreamConstants.START_ELEMENT) {
+          if ("DataPath".equals(r.getLocalName()) && !stack.isEmpty()) {
+            String text = r.getElementText().trim();
+            if (matchesTarget(text, targets)) {
+              stack.peek()[1] = 1;
+            }
+            continue;
+          }
+          int start = safeCharOffset(r);
+          stack.push(new int[]{start, 0});
+        } else if (ev == XMLStreamConstants.END_ELEMENT) {
+          if (stack.isEmpty()) {
+            continue;
+          }
+          int[] top = stack.pop();
+          if (top[1] == 1 && top[0] >= 0) {
+            int endTagStart = safeCharOffset(r);
+            int gt = endTagStart >= 0 ? xml.indexOf('>', endTagStart) : -1;
+            if (gt >= 0) {
+              removals.add(new int[]{top[0], gt + 1});
+            }
+          }
+        }
+      }
+    } finally {
+      r.close();
+    }
+    return removals;
+  }
+
+  private static boolean matchesTarget(String dataPath, Set<String> targets) {
+    for (String target : targets) {
+      if (dataPath.equals(target) || dataPath.startsWith(target + ".")) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /** Удаляет регион вместе со строкой, если блок занимал свои строки (без остаточных отступов). */
+  private static String removeRegionWithLine(String xml, int start, int end) {
+    String left = xml.substring(0, start);
+    String right = xml.substring(end);
+    int cut = left.length();
+    while (cut > 0 && (left.charAt(cut - 1) == '\t' || left.charAt(cut - 1) == ' ')) {
+      cut--;
+    }
+    boolean leftAtLineStart = cut == 0 || left.charAt(cut - 1) == '\n';
+    if (leftAtLineStart && (right.startsWith("\r\n") || right.startsWith("\n"))) {
+      left = left.substring(0, cut);
+      right = right.startsWith("\r\n") ? right.substring(2) : right.substring(1);
+    }
+    return left + right;
+  }
+
+  private static void writeIfChangedAndValid(Path formXml, String original, String updated) throws IOException {
+    if (updated.equals(original)) {
+      return;
+    }
+    try {
+      requireWellFormed(updated);
+    } catch (XMLStreamException e) {
+      throw new IOException("Зачистка сломала форму " + formXml + ": " + e.getMessage(), e);
+    }
+    Files.writeString(formXml, updated, StandardCharsets.UTF_8);
+  }
+
+  private static void requireWellFormed(String xml) throws XMLStreamException {
+    XMLInputFactory f = new WstxInputFactory();
+    f.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, Boolean.TRUE);
+    XMLStreamReader r = f.createXMLStreamReader(new StringReader(xml));
+    try {
+      while (r.hasNext()) {
+        r.next();
+      }
+    } finally {
+      r.close();
+    }
+  }
+
+  private static int safeCharOffset(XMLStreamReader r) {
+    javax.xml.stream.Location loc = r.getLocation();
+    if (loc == null) {
+      return -1;
+    }
+    return loc.getCharacterOffset();
+  }
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectChildMutations.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectChildMutations.java
@@ -66,14 +66,12 @@ public final class MdObjectChildMutations {
    */
   public static void renameAttribute(Path objectXml, SchemaVersion version, String oldName, String newName)
     throws IOException, JAXBException {
-    mutateAndWrite(objectXml, version, (xml, containerLocal) -> renameNamedChild(
-      xml,
-      containerLocal,
-      "Attribute",
+    mutateAndWrite(objectXml, version, (xml, containerLocal) -> renameAttributeFieldRefs(
+      renameNamedChild(xml, containerLocal, "Attribute", oldName, newName, "Реквизит"),
       oldName,
-      newName,
-      "Реквизит"
+      newName
     ));
+    FormDataPathCleanup.afterChildRename(objectXml, oldName, newName);
   }
 
   /**
@@ -87,13 +85,11 @@ public final class MdObjectChildMutations {
    */
   public static void deleteAttribute(Path objectXml, SchemaVersion version, String name)
     throws IOException, JAXBException {
-    mutateAndWrite(objectXml, version, (xml, containerLocal) -> deleteNamedChild(
-      xml,
-      containerLocal,
-      "Attribute",
-      name,
-      "Реквизит"
+    mutateAndWrite(objectXml, version, (xml, containerLocal) -> removeAttributeFieldRefs(
+      deleteNamedChild(xml, containerLocal, "Attribute", name, "Реквизит"),
+      name
     ));
+    FormDataPathCleanup.afterChildDelete(objectXml, name);
   }
 
   /**
@@ -160,6 +156,7 @@ public final class MdObjectChildMutations {
       newName,
       "Табличная часть"
     ));
+    FormDataPathCleanup.afterChildRename(objectXml, oldName, newName);
   }
 
   /**
@@ -180,6 +177,7 @@ public final class MdObjectChildMutations {
       name,
       "Табличная часть"
     ));
+    FormDataPathCleanup.afterChildDelete(objectXml, name);
   }
 
   /**
@@ -289,6 +287,8 @@ public final class MdObjectChildMutations {
       String replaced = replaceName(nodeXml, oldName, newName);
       return xml.substring(0, target.start()) + replaced + xml.substring(target.end());
     });
+    FormDataPathCleanup.afterChildRename(
+      objectXml, tabularSectionName + "." + oldName, tabularSectionName + "." + newName);
   }
 
   /**
@@ -317,6 +317,7 @@ public final class MdObjectChildMutations {
       }
       return removeRegion(xml, target);
     });
+    FormDataPathCleanup.afterChildDelete(objectXml, tabularSectionName + "." + name);
   }
 
   /**
@@ -662,6 +663,26 @@ public final class MdObjectChildMutations {
     }
     out.append(xml, cursor, xml.length());
     return out.toString();
+  }
+
+  /** Убирает из свойств объекта ссылки на удалённый реквизит ({@code xr:Field ...Attribute.Имя}). */
+  private static String removeAttributeFieldRefs(String xml, String attrName) {
+    Pattern refPattern = Pattern.compile("<xr:Field>[^<]*\\.Attribute\\." + Pattern.quote(attrName) + "</xr:Field>");
+    Matcher m = refPattern.matcher(xml);
+    List<MdObjectXmlRegions.Region> regions = new ArrayList<>();
+    while (m.find()) {
+      regions.add(new MdObjectXmlRegions.Region(m.start(), m.end()));
+    }
+    String out = xml;
+    for (int i = regions.size() - 1; i >= 0; i--) {
+      out = removeRegion(out, regions.get(i));
+    }
+    return out;
+  }
+
+  /** Обновляет ссылки на переименованный реквизит в свойствах объекта. */
+  private static String renameAttributeFieldRefs(String xml, String oldName, String newName) {
+    return xml.replace(".Attribute." + oldName + "</xr:Field>", ".Attribute." + newName + "</xr:Field>");
   }
 
   /** Начало строки перед позицией: срезает хвостовые пробелы/табы, если до них перевод строки. */

--- a/src/test/java/io/github/yellowhammer/designerxml/cf/FormDataPathCleanupTest.java
+++ b/src/test/java/io/github/yellowhammer/designerxml/cf/FormDataPathCleanupTest.java
@@ -1,0 +1,132 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+import io.github.yellowhammer.designerxml.SchemaVersion;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Зачистка привязок в формах при удалении и переименовании реквизитов (поведение конфигуратора).
+ */
+class FormDataPathCleanupTest {
+
+  @Test
+  void deleteAttribute_removesBoundFormItemsAndPropertyRefs() throws Exception {
+    Path objectXml = copyCatalogWithForms();
+    // Искусственно добавляем ссылку на удаляемый реквизит во «Ввод по строке».
+    String xml = Files.readString(objectXml, StandardCharsets.UTF_8);
+    xml = xml.replace(
+      "<xr:Field>Catalog._ДемоБанковскиеСчета.StandardAttribute.Code</xr:Field>",
+      "<xr:Field>Catalog._ДемоБанковскиеСчета.StandardAttribute.Code</xr:Field>\r\n"
+        + "\t\t\t\t<xr:Field>Catalog._ДемоБанковскиеСчета.Attribute.Комментарий</xr:Field>");
+    Files.writeString(objectXml, xml, StandardCharsets.UTF_8);
+
+    MdObjectChildMutations.deleteAttribute(objectXml, SchemaVersion.V2_20, "Комментарий");
+
+    String objectAfter = Files.readString(objectXml, StandardCharsets.UTF_8);
+    assertThat(objectAfter).doesNotContain(".Attribute.Комментарий</xr:Field>");
+
+    String itemForm = readForm(objectXml, "ФормаЭлемента");
+    assertThat(itemForm).doesNotContain("<DataPath>Объект.Комментарий</DataPath>");
+    assertThat(itemForm).doesNotContain("<InputField name=\"Комментарий\"");
+    // Целостность: другие элементы не задеты.
+    assertThat(itemForm).contains("<DataPath>Объект.НомерСчета</DataPath>");
+  }
+
+  @Test
+  void renameAttribute_updatesDataPathsInAllForms() throws Exception {
+    Path objectXml = copyCatalogWithForms();
+
+    MdObjectChildMutations.renameAttribute(objectXml, SchemaVersion.V2_20, "Валюта", "ВалютаНовая");
+
+    String itemForm = readForm(objectXml, "ФормаЭлемента");
+    assertThat(itemForm).contains("<DataPath>Объект.ВалютаНовая</DataPath>");
+    assertThat(itemForm).doesNotContain("<DataPath>Объект.Валюта</DataPath>");
+    String listForm = readForm(objectXml, "ФормаСписка");
+    assertThat(listForm).contains("<DataPath>Список.ВалютаНовая</DataPath>");
+    assertThat(listForm).doesNotContain("<DataPath>Список.Валюта</DataPath>");
+  }
+
+  @Test
+  void deleteTabularSection_removesTableWithColumns() throws Exception {
+    // ТЧ «Сотрудники» с таблицей на форме элемента.
+    Path objectXml = copyObjectWithForms("_ДемоПодразделения");
+    boolean hasBoundTable = false;
+    try (Stream<Path> forms = Files.walk(objectXml.resolveSibling("_ДемоПодразделения").resolve("Forms"))) {
+      hasBoundTable = forms
+        .filter(p -> p.getFileName().toString().equals("Form.xml"))
+        .anyMatch(p -> {
+          try {
+            return Files.readString(p, StandardCharsets.UTF_8).contains("<DataPath>Объект.Сотрудники</DataPath>");
+          } catch (IOException e) {
+            return false;
+          }
+        });
+    }
+    MdObjectChildMutations.deleteTabularSection(objectXml, SchemaVersion.V2_20, "Сотрудники");
+
+    assertThat(hasBoundTable).as("фикстура должна содержать таблицу, привязанную к ТЧ").isTrue();
+    try (Stream<Path> forms = Files.walk(objectXml.resolveSibling("_ДемоПодразделения").resolve("Forms"))) {
+      forms.filter(p -> p.getFileName().toString().equals("Form.xml")).forEach(p -> {
+        try {
+          String text = Files.readString(p, StandardCharsets.UTF_8);
+          assertThat(text).doesNotContain("<DataPath>Объект.Сотрудники</DataPath>");
+          assertThat(text).doesNotContain("<DataPath>Объект.Сотрудники.");
+        } catch (IOException e) {
+          throw new IllegalStateException(e);
+        }
+      });
+    }
+  }
+
+  private static String readForm(Path objectXml, String formName) throws IOException {
+    String stem = objectXml.getFileName().toString().replaceFirst("\\.xml$", "");
+    return Files.readString(
+      objectXml.resolveSibling(stem).resolve("Forms").resolve(formName).resolve("Ext").resolve("Form.xml"),
+      StandardCharsets.UTF_8);
+  }
+
+  private static Path copyCatalogWithForms() throws IOException {
+    return copyObjectWithForms("_ДемоБанковскиеСчета");
+  }
+
+  private static Path copyObjectWithForms(String name) throws IOException {
+    Path src = Path.of(System.getProperty("fixtures.ssl31.root"), "src", "cf", "Catalogs");
+    Path dir = Files.createTempDirectory("form-cleanup-");
+    Path objectXml = dir.resolve(name + ".xml");
+    Files.copy(src.resolve(name + ".xml"), objectXml);
+    Path formsSrc = src.resolve(name).resolve("Forms");
+    if (Files.isDirectory(formsSrc)) {
+      try (Stream<Path> walk = Files.walk(formsSrc)) {
+        walk.forEach(p -> {
+          try {
+            Path target = dir.resolve(name).resolve("Forms").resolve(formsSrc.relativize(p).toString());
+            if (Files.isDirectory(p)) {
+              Files.createDirectories(target);
+            } else {
+              Files.createDirectories(target.getParent());
+              Files.copy(p, target);
+            }
+          } catch (IOException e) {
+            throw new IllegalStateException(e);
+          }
+        });
+      }
+    }
+    return objectXml;
+  }
+}


### PR DESCRIPTION
## Что сделано

Зачистка привязок в формах объекта при операциях над структурой (поведение конфигуратора):

- **Удаление реквизита/ТЧ/реквизита ТЧ** — из всех форм объекта убираются элементы, чей `DataPath` указывает на удаляемый узел (включая колонки таблиц удаляемой ТЧ). Пути распознаются через главные реквизиты формы (`MainAttribute`): `Объект.<Реквизит>`, `Список.<Реквизит>` и т. п.
- **Переименование** — `DataPath` в формах обновляются, включая вложенные пути (`Объект.ТЧ.Реквизит` при переименовании ТЧ).
- **Свойства самого объекта** — ссылки `xr:Field ...Attribute.<Имя>` (ввод по строке, поля блокировки) при удалении реквизита вычищаются, при переименовании обновляются.
- Формы проверяются на корректность XML перед записью; переводы строк и отступы файлов сохраняются.

Расширению правки не требуются — операции те же, зачистка внутри md-sparrow.

## Проверка
Тесты: удаление реквизита с привязкой в форме элемента и ссылкой во «Вводе по строке», переименование с обновлением путей в форме элемента и колонках динамического списка, удаление ТЧ с таблицей и колонками на форме. Весь набор зелёный.

Закрывает yellow-hammer/vscode-1c-platform-tools#213
