### PR TITLE
feat(cf): гранулярный DTO свойств документа

### DIFF
--- a/src/main/java/io/github/yellowhammer/designerxml/cf/ConfigurationChildObjectLister.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/ConfigurationChildObjectLister.java
@@ -32,7 +32,8 @@ public final class ConfigurationChildObjectLister {
     "Catalog", "Document", "Enum", "Constant", "Report", "DataProcessor", "Task",
     "ChartOfAccounts", "ChartOfCharacteristicTypes", "ChartOfCalculationTypes", "CommonModule",
     "Subsystem", "SessionParameter", "ExchangePlan", "CommonAttribute", "CommonPicture",
-    "DocumentNumerator", "ExternalDataSource", "Role");
+    "DocumentNumerator", "ExternalDataSource", "Role",
+    "InformationRegister", "AccumulationRegister", "AccountingRegister", "CalculationRegister");
 
   /**
    * @param childTag например {@code Catalog}, {@code Document}, {@code Enum}, {@code Constant}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdCatalogPropertiesGranularSerial.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdCatalogPropertiesGranularSerial.java
@@ -266,7 +266,7 @@ public final class MdCatalogPropertiesGranularSerial {
     }
   }
 
-  private static String nz(String s) {
+  static String nz(String s) {
     return s == null ? "" : s;
   }
 
@@ -370,11 +370,11 @@ public final class MdCatalogPropertiesGranularSerial {
     return mdListTypeRefsElement("Owners", owners);
   }
 
-  private static String basedOnElement(List<String> items) {
+  static String basedOnElement(List<String> items) {
     return mdListTypeRefsElement("BasedOn", items);
   }
 
-  private static String inputByStringElement(List<String> fields) {
+  static String inputByStringElement(List<String> fields) {
     StringBuilder sb = new StringBuilder("<InputByString>");
     if (fields != null) {
       for (String f : fields) {
@@ -388,7 +388,7 @@ public final class MdCatalogPropertiesGranularSerial {
     return sb.toString();
   }
 
-  private static String dataLockFieldsElement(List<String> fields) {
+  static String dataLockFieldsElement(List<String> fields) {
     StringBuilder sb = new StringBuilder("<DataLockFields>");
     if (fields != null) {
       for (String f : fields) {

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdDocumentPropertiesBridge.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdDocumentPropertiesBridge.java
@@ -1,0 +1,229 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+import io.github.yellowhammer.designerxml.SchemaVersion;
+import io.github.yellowhammer.designerxml.reflect.JaxbReflect;
+
+import jakarta.xml.bind.JAXBException;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/**
+ * Чтение и запись {@code DocumentProperties} через JAXB-рефлексию (гранулярный DTO документа).
+ */
+public final class MdDocumentPropertiesBridge {
+
+  private MdDocumentPropertiesBridge() {
+  }
+
+  /**
+   * Читает {@code DocumentProperties} ({@code p}, любой версии) в {@code dto.document}.
+   */
+  public static void read(SchemaVersion version, Object p, MdObjectPropertiesDto dto) {
+    MdDocumentPropertiesDto d = new MdDocumentPropertiesDto();
+    d.objectBelonging = en(p, "getObjectBelonging");
+    d.extendedConfigurationObject = nullIfBlankUuid(JaxbReflect.getStringOptional(p, "getExtendedConfigurationObject"));
+    d.useStandardCommands = JaxbReflect.getBooleanOptional(p, "isUseStandardCommands");
+    d.numerator = JaxbReflect.getStringOptional(p, "getNumerator");
+    d.numberType = en(p, "getNumberType");
+    d.numberLength = dec(p, "getNumberLength");
+    d.numberAllowedLength = en(p, "getNumberAllowedLength");
+    d.numberPeriodicity = en(p, "getNumberPeriodicity");
+    d.checkUnique = JaxbReflect.getBooleanOptional(p, "isCheckUnique");
+    d.autonumbering = JaxbReflect.getBooleanOptional(p, "isAutonumbering");
+    d.standardAttributesXml = tryMarshalStandardAttributes(version, JaxbReflect.getOptional(p, "getStandardAttributes"));
+    d.characteristicsXml = tryMarshalCharacteristics(version, JaxbReflect.getOptional(p, "getCharacteristics"));
+    addItems(d.basedOn, JaxbReflect.getOptional(p, "getBasedOn"));
+    addFields(d.inputByString, JaxbReflect.getOptional(p, "getInputByString"));
+    d.createOnInput = en(p, "getCreateOnInput");
+    d.searchStringModeOnInputByString = en(p, "getSearchStringModeOnInputByString");
+    d.fullTextSearchOnInputByString = en(p, "getFullTextSearchOnInputByString");
+    d.choiceDataGetModeOnInputByString = en(p, "getChoiceDataGetModeOnInputByString");
+    d.choiceHistoryOnInput = en(p, "getChoiceHistoryOnInput");
+    d.defaultObjectForm = JaxbReflect.getStringOptional(p, "getDefaultObjectForm");
+    d.defaultListForm = JaxbReflect.getStringOptional(p, "getDefaultListForm");
+    d.defaultChoiceForm = JaxbReflect.getStringOptional(p, "getDefaultChoiceForm");
+    d.auxiliaryObjectForm = JaxbReflect.getStringOptional(p, "getAuxiliaryObjectForm");
+    d.auxiliaryListForm = JaxbReflect.getStringOptional(p, "getAuxiliaryListForm");
+    d.auxiliaryChoiceForm = JaxbReflect.getStringOptional(p, "getAuxiliaryChoiceForm");
+    d.objectModule = JaxbReflect.getStringOptional(p, "getObjectModule");
+    d.managerModule = JaxbReflect.getStringOptional(p, "getManagerModule");
+    d.posting = en(p, "getPosting");
+    d.realTimePosting = en(p, "getRealTimePosting");
+    d.registerRecordsDeletion = en(p, "getRegisterRecordsDeletion");
+    d.registerRecordsWritingOnPost = en(p, "getRegisterRecordsWritingOnPost");
+    d.sequenceFilling = en(p, "getSequenceFilling");
+    addItems(d.registerRecords, JaxbReflect.getOptional(p, "getRegisterRecords"));
+    d.postInPrivilegedMode = JaxbReflect.getBooleanOptional(p, "isPostInPrivilegedMode");
+    d.unpostInPrivilegedMode = JaxbReflect.getBooleanOptional(p, "isUnpostInPrivilegedMode");
+    d.includeHelpInContents = JaxbReflect.getBooleanOptional(p, "isIncludeHelpInContents");
+    d.help = JaxbReflect.getStringOptional(p, "getHelp");
+    addFields(d.dataLockFields, JaxbReflect.getOptional(p, "getDataLockFields"));
+    d.dataLockControlMode = en(p, "getDataLockControlMode");
+    d.fullTextSearch = en(p, "getFullTextSearch");
+    d.objectPresentationRu = LocalStringSync.firstRu(JaxbReflect.getOptional(p, "getObjectPresentation"));
+    d.extendedObjectPresentationRu = LocalStringSync.firstRu(JaxbReflect.getOptional(p, "getExtendedObjectPresentation"));
+    d.listPresentationRu = LocalStringSync.firstRu(JaxbReflect.getOptional(p, "getListPresentation"));
+    d.extendedListPresentationRu = LocalStringSync.firstRu(JaxbReflect.getOptional(p, "getExtendedListPresentation"));
+    d.explanationRu = LocalStringSync.firstRu(JaxbReflect.getOptional(p, "getExplanation"));
+    d.dataHistory = en(p, "getDataHistory");
+    d.updateDataHistoryImmediatelyAfterWrite = JaxbReflect.getBooleanOptional(p, "isUpdateDataHistoryImmediatelyAfterWrite");
+    d.executeAfterWriteDataHistoryVersionProcessing =
+      JaxbReflect.getBooleanOptional(p, "isExecuteAfterWriteDataHistoryVersionProcessing");
+    d.additionalIndexes = JaxbReflect.getStringOptional(p, "getAdditionalIndexes");
+    dto.document = d;
+  }
+
+  /**
+   * Применяет {@code dto.document} к {@code DocumentProperties} ({@code p}, любой версии).
+   */
+  public static void apply(SchemaVersion version, Object p, MdObjectPropertiesDto dto) {
+    MdDocumentPropertiesDto d = dto.document;
+    if (d == null) {
+      throw new IllegalArgumentException("document required");
+    }
+    if (!dto.internalName.equals(JaxbReflect.getStringOptional(p, "getName"))) {
+      throw new IllegalArgumentException("internalName mismatch with XML");
+    }
+    String syn = dto.synonymRu == null ? "" : dto.synonymRu;
+    LocalStringSync.setOrPutRu(JaxbReflect.getOptional(p, "getSynonym"), syn);
+    JaxbReflect.setOptional(p, "setComment", dto.comment == null ? "" : dto.comment);
+    JaxbReflect.setEnumOrKeep(p, "setObjectBelonging", d.objectBelonging);
+    JaxbReflect.setOptional(p, "setExtendedConfigurationObject", nullIfBlankUuid(d.extendedConfigurationObject));
+    JaxbReflect.setOptional(p, "setUseStandardCommands", d.useStandardCommands);
+    JaxbReflect.setOptional(p, "setNumerator", d.numerator);
+    JaxbReflect.setEnumOrKeep(p, "setNumberType", d.numberType);
+    JaxbReflect.setOptional(p, "setNumberLength", new BigDecimal(nzDecimal(d.numberLength)));
+    JaxbReflect.setEnumOrKeep(p, "setNumberAllowedLength", d.numberAllowedLength);
+    JaxbReflect.setEnumOrKeep(p, "setNumberPeriodicity", d.numberPeriodicity);
+    JaxbReflect.setOptional(p, "setCheckUnique", d.checkUnique);
+    JaxbReflect.setOptional(p, "setAutonumbering", d.autonumbering);
+    if (d.standardAttributesXml != null && !d.standardAttributesXml.isBlank()) {
+      try {
+        JaxbReflect.setOptional(p, "setStandardAttributes",
+          MdCfCatalogSubtreeXml.unmarshalStandardAttributes(version, d.standardAttributesXml.trim()));
+      } catch (JAXBException e) {
+        throw new IllegalArgumentException("standardAttributesXml: " + e.getMessage(), e);
+      }
+    }
+    if (d.characteristicsXml != null && !d.characteristicsXml.isBlank()) {
+      try {
+        JaxbReflect.setOptional(p, "setCharacteristics",
+          MdCfCatalogSubtreeXml.unmarshalCharacteristics(version, d.characteristicsXml.trim()));
+      } catch (JAXBException e) {
+        throw new IllegalArgumentException("characteristicsXml: " + e.getMessage(), e);
+      }
+    }
+    MdListTypeRefs.replaceItems(JaxbReflect.getOptional(p, "getBasedOn"), d.basedOn);
+    setFields(JaxbReflect.getOptional(p, "getInputByString"), d.inputByString);
+    JaxbReflect.setEnumOrKeep(p, "setCreateOnInput", d.createOnInput);
+    JaxbReflect.setEnumOrKeep(p, "setSearchStringModeOnInputByString", d.searchStringModeOnInputByString);
+    JaxbReflect.setEnumOrKeep(p, "setFullTextSearchOnInputByString", d.fullTextSearchOnInputByString);
+    JaxbReflect.setEnumOrKeep(p, "setChoiceDataGetModeOnInputByString", d.choiceDataGetModeOnInputByString);
+    JaxbReflect.setEnumOrKeep(p, "setChoiceHistoryOnInput", d.choiceHistoryOnInput);
+    JaxbReflect.setOptional(p, "setDefaultObjectForm", d.defaultObjectForm);
+    JaxbReflect.setOptional(p, "setDefaultListForm", d.defaultListForm);
+    JaxbReflect.setOptional(p, "setDefaultChoiceForm", d.defaultChoiceForm);
+    JaxbReflect.setOptional(p, "setAuxiliaryObjectForm", d.auxiliaryObjectForm);
+    JaxbReflect.setOptional(p, "setAuxiliaryListForm", d.auxiliaryListForm);
+    JaxbReflect.setOptional(p, "setAuxiliaryChoiceForm", d.auxiliaryChoiceForm);
+    JaxbReflect.setOptional(p, "setObjectModule", d.objectModule);
+    JaxbReflect.setOptional(p, "setManagerModule", d.managerModule);
+    JaxbReflect.setEnumOrKeep(p, "setPosting", d.posting);
+    JaxbReflect.setEnumOrKeep(p, "setRealTimePosting", d.realTimePosting);
+    JaxbReflect.setEnumOrKeep(p, "setRegisterRecordsDeletion", d.registerRecordsDeletion);
+    JaxbReflect.setEnumOrKeep(p, "setRegisterRecordsWritingOnPost", d.registerRecordsWritingOnPost);
+    JaxbReflect.setEnumOrKeep(p, "setSequenceFilling", d.sequenceFilling);
+    MdListTypeRefs.replaceItems(JaxbReflect.getOptional(p, "getRegisterRecords"), d.registerRecords);
+    JaxbReflect.setOptional(p, "setPostInPrivilegedMode", d.postInPrivilegedMode);
+    JaxbReflect.setOptional(p, "setUnpostInPrivilegedMode", d.unpostInPrivilegedMode);
+    JaxbReflect.setOptional(p, "setIncludeHelpInContents", d.includeHelpInContents);
+    JaxbReflect.setOptional(p, "setHelp", d.help);
+    setFields(JaxbReflect.getOptional(p, "getDataLockFields"), d.dataLockFields);
+    JaxbReflect.setEnumOrKeep(p, "setDataLockControlMode", d.dataLockControlMode);
+    JaxbReflect.setEnumOrKeep(p, "setFullTextSearch", d.fullTextSearch);
+    ensureAndSetRu(p, "getObjectPresentation", "setObjectPresentation", d.objectPresentationRu);
+    ensureAndSetRu(p, "getExtendedObjectPresentation", "setExtendedObjectPresentation", d.extendedObjectPresentationRu);
+    ensureAndSetRu(p, "getListPresentation", "setListPresentation", d.listPresentationRu);
+    ensureAndSetRu(p, "getExtendedListPresentation", "setExtendedListPresentation", d.extendedListPresentationRu);
+    ensureAndSetRu(p, "getExplanation", "setExplanation", d.explanationRu);
+    JaxbReflect.setEnumOrKeep(p, "setDataHistory", d.dataHistory);
+    JaxbReflect.setOptional(p, "setUpdateDataHistoryImmediatelyAfterWrite", d.updateDataHistoryImmediatelyAfterWrite);
+    JaxbReflect.setOptional(p, "setExecuteAfterWriteDataHistoryVersionProcessing",
+      d.executeAfterWriteDataHistoryVersionProcessing);
+    JaxbReflect.setOptional(p, "setAdditionalIndexes", d.additionalIndexes);
+  }
+
+  private static void ensureAndSetRu(Object p, String getter, String setter, String ru) {
+    Object ls = JaxbReflect.ensureOptional(p, getter, setter);
+    LocalStringSync.setOrPutRu(ls, ru == null ? "" : ru);
+  }
+
+  private static String nullIfBlankUuid(String s) {
+    if (s == null || s.isBlank()) {
+      return null;
+    }
+    return s;
+  }
+
+  private static String nzDecimal(String s) {
+    return s == null || s.isBlank() ? "0" : s;
+  }
+
+  private static String en(Object p, String getter) {
+    Object v = JaxbReflect.getOptional(p, getter);
+    return v == null ? null : ((Enum<?>) v).name();
+  }
+
+  private static String dec(Object p, String getter) {
+    Object v = JaxbReflect.getOptional(p, getter);
+    return v == null ? "0" : ((BigDecimal) v).toPlainString();
+  }
+
+  private static void addItems(List<String> out, Object mdListType) {
+    if (mdListType != null) {
+      out.addAll(MdListTypeRefs.readItemTexts(JaxbReflect.list(mdListType, "getItem")));
+    }
+  }
+
+  private static void addFields(List<String> out, Object fieldList) {
+    if (fieldList != null) {
+      out.addAll(JaxbReflect.<String>list(fieldList, "getField"));
+    }
+  }
+
+  private static void setFields(Object fieldList, List<String> values) {
+    if (fieldList == null) {
+      return;
+    }
+    List<Object> field = JaxbReflect.list(fieldList, "getField");
+    field.clear();
+    if (values != null) {
+      field.addAll(values);
+    }
+  }
+
+  private static String tryMarshalStandardAttributes(SchemaVersion version, Object value) {
+    try {
+      return MdCfCatalogSubtreeXml.marshalStandardAttributes(version, value);
+    } catch (JAXBException e) {
+      return "";
+    }
+  }
+
+  private static String tryMarshalCharacteristics(SchemaVersion version, Object value) {
+    try {
+      return MdCfCatalogSubtreeXml.marshalCharacteristics(version, value);
+    } catch (JAXBException e) {
+      return "";
+    }
+  }
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdDocumentPropertiesDto.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdDocumentPropertiesDto.java
@@ -1,0 +1,78 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Поля {@code DocumentProperties} для {@code cf-md-object-get/set} ({@code kind=document}).
+ * Enum-значения — имена Java-констант ({@code ALLOW}, {@code NONPERIODICAL}).
+ */
+public final class MdDocumentPropertiesDto {
+
+  public String objectBelonging;
+  public String extendedConfigurationObject;
+  public boolean useStandardCommands;
+  /** Ссылка на нумератор ({@code DocumentNumerator.Имя}) либо пустая строка. */
+  public String numerator;
+  public String numberType;
+  public String numberLength;
+  public String numberAllowedLength;
+  public String numberPeriodicity;
+  public boolean checkUnique;
+  public boolean autonumbering;
+  public String standardAttributesXml;
+  public String characteristicsXml;
+  public List<String> basedOn;
+  public List<String> inputByString;
+  public String createOnInput;
+  public String searchStringModeOnInputByString;
+  public String fullTextSearchOnInputByString;
+  public String choiceDataGetModeOnInputByString;
+  public String choiceHistoryOnInput;
+  public String defaultObjectForm;
+  public String defaultListForm;
+  public String defaultChoiceForm;
+  public String auxiliaryObjectForm;
+  public String auxiliaryListForm;
+  public String auxiliaryChoiceForm;
+  public String objectModule;
+  public String managerModule;
+  public String posting;
+  public String realTimePosting;
+  public String registerRecordsDeletion;
+  public String registerRecordsWritingOnPost;
+  public String sequenceFilling;
+  /** Состав движений: ссылки на регистры ({@code AccumulationRegister.Имя} и т. п.). */
+  public List<String> registerRecords;
+  public boolean postInPrivilegedMode;
+  public boolean unpostInPrivilegedMode;
+  public boolean includeHelpInContents;
+  public String help;
+  public List<String> dataLockFields;
+  public String dataLockControlMode;
+  public String fullTextSearch;
+  public String objectPresentationRu;
+  public String extendedObjectPresentationRu;
+  public String listPresentationRu;
+  public String extendedListPresentationRu;
+  public String explanationRu;
+  public String dataHistory;
+  public boolean updateDataHistoryImmediatelyAfterWrite;
+  public boolean executeAfterWriteDataHistoryVersionProcessing;
+  public String additionalIndexes;
+
+  public MdDocumentPropertiesDto() {
+    this.basedOn = new ArrayList<>();
+    this.inputByString = new ArrayList<>();
+    this.registerRecords = new ArrayList<>();
+    this.dataLockFields = new ArrayList<>();
+  }
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdDocumentPropertiesGranularSerial.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdDocumentPropertiesGranularSerial.java
@@ -1,0 +1,246 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+import java.util.List;
+import java.util.Objects;
+
+import static io.github.yellowhammer.designerxml.cf.MdCatalogPropertiesGranularSerial.basedOnElement;
+import static io.github.yellowhammer.designerxml.cf.MdCatalogPropertiesGranularSerial.boolElement;
+import static io.github.yellowhammer.designerxml.cf.MdCatalogPropertiesGranularSerial.dataLockFieldsElement;
+import static io.github.yellowhammer.designerxml.cf.MdCatalogPropertiesGranularSerial.enumTextElement;
+import static io.github.yellowhammer.designerxml.cf.MdCatalogPropertiesGranularSerial.inputByStringElement;
+import static io.github.yellowhammer.designerxml.cf.MdCatalogPropertiesGranularSerial.localStringRuElement;
+import static io.github.yellowhammer.designerxml.cf.MdCatalogPropertiesGranularSerial.mdListTypeRefsElement;
+import static io.github.yellowhammer.designerxml.cf.MdCatalogPropertiesGranularSerial.nz;
+import static io.github.yellowhammer.designerxml.cf.MdCatalogPropertiesGranularSerial.textElement;
+
+/**
+ * Сериализация отдельных прямых дочерних элементов {@code DocumentProperties} для гранулярной замены.
+ */
+public final class MdDocumentPropertiesGranularSerial {
+
+  private MdDocumentPropertiesGranularSerial() {
+  }
+
+  static void appendDocumentScalarChanges(
+    MdDocumentPropertiesDto b,
+    MdDocumentPropertiesDto i,
+    List<MdObjectPropertiesLeafDiff.GranularPatchChange> out) {
+    if (!Objects.equals(b.objectBelonging, i.objectBelonging)) {
+      out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
+        "ObjectBelonging", enumTextElement("ObjectBelonging", nz(i.objectBelonging))));
+    }
+    if (b.useStandardCommands != i.useStandardCommands) {
+      out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
+        "UseStandardCommands", boolElement("UseStandardCommands", i.useStandardCommands)));
+    }
+    if (!Objects.equals(b.numerator, i.numerator)) {
+      out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
+        "Numerator", textElement("Numerator", nz(i.numerator))));
+    }
+    if (!Objects.equals(b.numberType, i.numberType)) {
+      out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
+        "NumberType", enumTextElement("NumberType", nz(i.numberType))));
+    }
+    if (!Objects.equals(b.numberLength, i.numberLength)) {
+      out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
+        "NumberLength", textElement("NumberLength", nz(i.numberLength))));
+    }
+    if (!Objects.equals(b.numberAllowedLength, i.numberAllowedLength)) {
+      out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
+        "NumberAllowedLength", enumTextElement("NumberAllowedLength", nz(i.numberAllowedLength))));
+    }
+    if (!Objects.equals(b.numberPeriodicity, i.numberPeriodicity)) {
+      out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
+        "NumberPeriodicity", enumTextElement("NumberPeriodicity", nz(i.numberPeriodicity))));
+    }
+    if (b.checkUnique != i.checkUnique) {
+      out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
+        "CheckUnique", boolElement("CheckUnique", i.checkUnique)));
+    }
+    if (b.autonumbering != i.autonumbering) {
+      out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
+        "Autonumbering", boolElement("Autonumbering", i.autonumbering)));
+    }
+    if (!MdObjectPropertiesDiff.looseXmlBlobEquals(b.standardAttributesXml, i.standardAttributesXml)) {
+      out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
+        "StandardAttributes", blobElement("StandardAttributes", i.standardAttributesXml)));
+    }
+    if (!MdObjectPropertiesDiff.looseXmlBlobEquals(b.characteristicsXml, i.characteristicsXml)) {
+      out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
+        "Characteristics", blobElement("Characteristics", i.characteristicsXml)));
+    }
+    if (!MdObjectPropertiesDiff.listStringEquals(b.basedOn, i.basedOn)) {
+      out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
+        "BasedOn", basedOnElement(i.basedOn)));
+    }
+    if (!MdObjectPropertiesDiff.listStringEquals(b.inputByString, i.inputByString)) {
+      out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
+        "InputByString", inputByStringElement(i.inputByString)));
+    }
+    if (!Objects.equals(b.createOnInput, i.createOnInput)) {
+      out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
+        "CreateOnInput", enumTextElement("CreateOnInput", nz(i.createOnInput))));
+    }
+    if (!Objects.equals(b.searchStringModeOnInputByString, i.searchStringModeOnInputByString)) {
+      out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
+        "SearchStringModeOnInputByString",
+        enumTextElement("SearchStringModeOnInputByString", nz(i.searchStringModeOnInputByString))));
+    }
+    if (!Objects.equals(b.fullTextSearchOnInputByString, i.fullTextSearchOnInputByString)) {
+      out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
+        "FullTextSearchOnInputByString",
+        enumTextElement("FullTextSearchOnInputByString", nz(i.fullTextSearchOnInputByString))));
+    }
+    if (!Objects.equals(b.choiceDataGetModeOnInputByString, i.choiceDataGetModeOnInputByString)) {
+      out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
+        "ChoiceDataGetModeOnInputByString",
+        enumTextElement("ChoiceDataGetModeOnInputByString", nz(i.choiceDataGetModeOnInputByString))));
+    }
+    if (!Objects.equals(b.choiceHistoryOnInput, i.choiceHistoryOnInput)) {
+      out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
+        "ChoiceHistoryOnInput", enumTextElement("ChoiceHistoryOnInput", nz(i.choiceHistoryOnInput))));
+    }
+    if (!Objects.equals(b.defaultObjectForm, i.defaultObjectForm)) {
+      out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
+        "DefaultObjectForm", textElement("DefaultObjectForm", nz(i.defaultObjectForm))));
+    }
+    if (!Objects.equals(b.defaultListForm, i.defaultListForm)) {
+      out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
+        "DefaultListForm", textElement("DefaultListForm", nz(i.defaultListForm))));
+    }
+    if (!Objects.equals(b.defaultChoiceForm, i.defaultChoiceForm)) {
+      out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
+        "DefaultChoiceForm", textElement("DefaultChoiceForm", nz(i.defaultChoiceForm))));
+    }
+    if (!Objects.equals(b.auxiliaryObjectForm, i.auxiliaryObjectForm)) {
+      out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
+        "AuxiliaryObjectForm", textElement("AuxiliaryObjectForm", nz(i.auxiliaryObjectForm))));
+    }
+    if (!Objects.equals(b.auxiliaryListForm, i.auxiliaryListForm)) {
+      out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
+        "AuxiliaryListForm", textElement("AuxiliaryListForm", nz(i.auxiliaryListForm))));
+    }
+    if (!Objects.equals(b.auxiliaryChoiceForm, i.auxiliaryChoiceForm)) {
+      out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
+        "AuxiliaryChoiceForm", textElement("AuxiliaryChoiceForm", nz(i.auxiliaryChoiceForm))));
+    }
+    if (!Objects.equals(b.objectModule, i.objectModule)) {
+      out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
+        "ObjectModule", textElement("ObjectModule", nz(i.objectModule))));
+    }
+    if (!Objects.equals(b.managerModule, i.managerModule)) {
+      out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
+        "ManagerModule", textElement("ManagerModule", nz(i.managerModule))));
+    }
+    if (!Objects.equals(b.posting, i.posting)) {
+      out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
+        "Posting", enumTextElement("Posting", nz(i.posting))));
+    }
+    if (!Objects.equals(b.realTimePosting, i.realTimePosting)) {
+      out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
+        "RealTimePosting", enumTextElement("RealTimePosting", nz(i.realTimePosting))));
+    }
+    if (!Objects.equals(b.registerRecordsDeletion, i.registerRecordsDeletion)) {
+      out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
+        "RegisterRecordsDeletion", enumTextElement("RegisterRecordsDeletion", nz(i.registerRecordsDeletion))));
+    }
+    if (!Objects.equals(b.registerRecordsWritingOnPost, i.registerRecordsWritingOnPost)) {
+      out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
+        "RegisterRecordsWritingOnPost",
+        enumTextElement("RegisterRecordsWritingOnPost", nz(i.registerRecordsWritingOnPost))));
+    }
+    if (!Objects.equals(b.sequenceFilling, i.sequenceFilling)) {
+      out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
+        "SequenceFilling", enumTextElement("SequenceFilling", nz(i.sequenceFilling))));
+    }
+    if (!MdObjectPropertiesDiff.listStringEquals(b.registerRecords, i.registerRecords)) {
+      out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
+        "RegisterRecords", mdListTypeRefsElement("RegisterRecords", i.registerRecords)));
+    }
+    if (b.postInPrivilegedMode != i.postInPrivilegedMode) {
+      out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
+        "PostInPrivilegedMode", boolElement("PostInPrivilegedMode", i.postInPrivilegedMode)));
+    }
+    if (b.unpostInPrivilegedMode != i.unpostInPrivilegedMode) {
+      out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
+        "UnpostInPrivilegedMode", boolElement("UnpostInPrivilegedMode", i.unpostInPrivilegedMode)));
+    }
+    if (b.includeHelpInContents != i.includeHelpInContents) {
+      out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
+        "IncludeHelpInContents", boolElement("IncludeHelpInContents", i.includeHelpInContents)));
+    }
+    if (!Objects.equals(b.help, i.help)) {
+      out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
+        "Help", textElement("Help", nz(i.help))));
+    }
+    if (!MdObjectPropertiesDiff.listStringEquals(b.dataLockFields, i.dataLockFields)) {
+      out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
+        "DataLockFields", dataLockFieldsElement(i.dataLockFields)));
+    }
+    if (!Objects.equals(b.dataLockControlMode, i.dataLockControlMode)) {
+      out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
+        "DataLockControlMode", enumTextElement("DataLockControlMode", nz(i.dataLockControlMode))));
+    }
+    if (!Objects.equals(b.fullTextSearch, i.fullTextSearch)) {
+      out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
+        "FullTextSearch", enumTextElement("FullTextSearch", nz(i.fullTextSearch))));
+    }
+    if (!Objects.equals(b.objectPresentationRu, i.objectPresentationRu)) {
+      out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
+        "ObjectPresentation", localStringRuElement("ObjectPresentation", i.objectPresentationRu)));
+    }
+    if (!Objects.equals(b.extendedObjectPresentationRu, i.extendedObjectPresentationRu)) {
+      out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
+        "ExtendedObjectPresentation",
+        localStringRuElement("ExtendedObjectPresentation", i.extendedObjectPresentationRu)));
+    }
+    if (!Objects.equals(b.listPresentationRu, i.listPresentationRu)) {
+      out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
+        "ListPresentation", localStringRuElement("ListPresentation", i.listPresentationRu)));
+    }
+    if (!Objects.equals(b.extendedListPresentationRu, i.extendedListPresentationRu)) {
+      out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
+        "ExtendedListPresentation",
+        localStringRuElement("ExtendedListPresentation", i.extendedListPresentationRu)));
+    }
+    if (!Objects.equals(b.explanationRu, i.explanationRu)) {
+      out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
+        "Explanation", localStringRuElement("Explanation", i.explanationRu)));
+    }
+    if (!Objects.equals(b.dataHistory, i.dataHistory)) {
+      out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
+        "DataHistory", enumTextElement("DataHistory", nz(i.dataHistory))));
+    }
+    if (b.updateDataHistoryImmediatelyAfterWrite != i.updateDataHistoryImmediatelyAfterWrite) {
+      out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
+        "UpdateDataHistoryImmediatelyAfterWrite",
+        boolElement("UpdateDataHistoryImmediatelyAfterWrite", i.updateDataHistoryImmediatelyAfterWrite)));
+    }
+    if (b.executeAfterWriteDataHistoryVersionProcessing != i.executeAfterWriteDataHistoryVersionProcessing) {
+      out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
+        "ExecuteAfterWriteDataHistoryVersionProcessing",
+        boolElement("ExecuteAfterWriteDataHistoryVersionProcessing",
+          i.executeAfterWriteDataHistoryVersionProcessing)));
+    }
+    if (!Objects.equals(b.additionalIndexes, i.additionalIndexes)) {
+      out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
+        "AdditionalIndexes", textElement("AdditionalIndexes", nz(i.additionalIndexes))));
+    }
+  }
+
+  private static String blobElement(String wrapperLocalName, String xml) {
+    String x = xml == null ? "" : xml.trim();
+    if (x.isEmpty()) {
+      return "<" + wrapperLocalName + "/>";
+    }
+    return x;
+  }
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesDiff.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesDiff.java
@@ -81,7 +81,8 @@ public final class MdObjectPropertiesDiff {
     if (!listStringEquals(a.contentRefs, b.contentRefs)) {
       return false;
     }
-    return catalogEquals(a.catalog, b.catalog, lenientCatalogXmlBlobs);
+    return catalogEquals(a.catalog, b.catalog, lenientCatalogXmlBlobs)
+      && documentEquals(a.document, b.document, lenientCatalogXmlBlobs);
   }
 
   /**
@@ -196,7 +197,72 @@ public final class MdObjectPropertiesDiff {
     if (!listStringEquals(a.contentRefs, b.contentRefs)) {
       return false;
     }
-    return catalogEquals(a.catalog, b.catalog, lenientCatalogXmlBlobs);
+    return catalogEquals(a.catalog, b.catalog, lenientCatalogXmlBlobs)
+      && documentEquals(a.document, b.document, lenientCatalogXmlBlobs);
+  }
+
+  static boolean documentEquals(MdDocumentPropertiesDto a, MdDocumentPropertiesDto b, boolean lenientXmlBlobs) {
+    if (a == b) {
+      return true;
+    }
+    if (a == null || b == null) {
+      return false;
+    }
+    boolean stdEq = lenientXmlBlobs
+      ? looseXmlBlobEquals(a.standardAttributesXml, b.standardAttributesXml)
+      : Objects.equals(a.standardAttributesXml, b.standardAttributesXml);
+    boolean charEq = lenientXmlBlobs
+      ? looseXmlBlobEquals(a.characteristicsXml, b.characteristicsXml)
+      : Objects.equals(a.characteristicsXml, b.characteristicsXml);
+    return Objects.equals(a.objectBelonging, b.objectBelonging)
+      && Objects.equals(a.extendedConfigurationObject, b.extendedConfigurationObject)
+      && a.useStandardCommands == b.useStandardCommands
+      && Objects.equals(a.numerator, b.numerator)
+      && Objects.equals(a.numberType, b.numberType)
+      && Objects.equals(a.numberLength, b.numberLength)
+      && Objects.equals(a.numberAllowedLength, b.numberAllowedLength)
+      && Objects.equals(a.numberPeriodicity, b.numberPeriodicity)
+      && a.checkUnique == b.checkUnique
+      && a.autonumbering == b.autonumbering
+      && stdEq
+      && charEq
+      && listStringEquals(a.basedOn, b.basedOn)
+      && listStringEquals(a.inputByString, b.inputByString)
+      && Objects.equals(a.createOnInput, b.createOnInput)
+      && Objects.equals(a.searchStringModeOnInputByString, b.searchStringModeOnInputByString)
+      && Objects.equals(a.fullTextSearchOnInputByString, b.fullTextSearchOnInputByString)
+      && Objects.equals(a.choiceDataGetModeOnInputByString, b.choiceDataGetModeOnInputByString)
+      && Objects.equals(a.choiceHistoryOnInput, b.choiceHistoryOnInput)
+      && Objects.equals(a.defaultObjectForm, b.defaultObjectForm)
+      && Objects.equals(a.defaultListForm, b.defaultListForm)
+      && Objects.equals(a.defaultChoiceForm, b.defaultChoiceForm)
+      && Objects.equals(a.auxiliaryObjectForm, b.auxiliaryObjectForm)
+      && Objects.equals(a.auxiliaryListForm, b.auxiliaryListForm)
+      && Objects.equals(a.auxiliaryChoiceForm, b.auxiliaryChoiceForm)
+      && Objects.equals(a.objectModule, b.objectModule)
+      && Objects.equals(a.managerModule, b.managerModule)
+      && Objects.equals(a.posting, b.posting)
+      && Objects.equals(a.realTimePosting, b.realTimePosting)
+      && Objects.equals(a.registerRecordsDeletion, b.registerRecordsDeletion)
+      && Objects.equals(a.registerRecordsWritingOnPost, b.registerRecordsWritingOnPost)
+      && Objects.equals(a.sequenceFilling, b.sequenceFilling)
+      && listStringEquals(a.registerRecords, b.registerRecords)
+      && a.postInPrivilegedMode == b.postInPrivilegedMode
+      && a.unpostInPrivilegedMode == b.unpostInPrivilegedMode
+      && a.includeHelpInContents == b.includeHelpInContents
+      && Objects.equals(a.help, b.help)
+      && listStringEquals(a.dataLockFields, b.dataLockFields)
+      && Objects.equals(a.dataLockControlMode, b.dataLockControlMode)
+      && Objects.equals(a.fullTextSearch, b.fullTextSearch)
+      && Objects.equals(a.objectPresentationRu, b.objectPresentationRu)
+      && Objects.equals(a.extendedObjectPresentationRu, b.extendedObjectPresentationRu)
+      && Objects.equals(a.listPresentationRu, b.listPresentationRu)
+      && Objects.equals(a.extendedListPresentationRu, b.extendedListPresentationRu)
+      && Objects.equals(a.explanationRu, b.explanationRu)
+      && Objects.equals(a.dataHistory, b.dataHistory)
+      && a.updateDataHistoryImmediatelyAfterWrite == b.updateDataHistoryImmediatelyAfterWrite
+      && a.executeAfterWriteDataHistoryVersionProcessing == b.executeAfterWriteDataHistoryVersionProcessing
+      && Objects.equals(a.additionalIndexes, b.additionalIndexes);
   }
 
   static boolean looseXmlBlobEquals(String x, String y) {
@@ -329,7 +395,8 @@ public final class MdObjectPropertiesDiff {
     }
     return switch (kind) {
       case "catalog" -> catalogMask(baseline, incoming);
-      case "document", "exchangePlan" -> docLikeMask(baseline, incoming);
+      case "document" -> documentMask(baseline, incoming);
+      case "exchangePlan" -> docLikeMask(baseline, incoming);
       case "constant", "enum", "report", "dataProcessor", "task", "chartOfAccounts",
            "chartOfCharacteristicTypes", "chartOfCalculationTypes", "commonModule",
            "sessionParameter", "commonAttribute", "commonPicture", "documentNumerator",
@@ -347,6 +414,17 @@ public final class MdObjectPropertiesDiff {
       !Objects.equals(baseline.synonymRu, incoming.synonymRu)
         || !Objects.equals(baseline.comment, incoming.comment)
         || !catalogEquals(baseline.catalog, incoming.catalog, false);
+    return new ChangeMask(props, child);
+  }
+
+  private static ChangeMask documentMask(MdObjectPropertiesDto baseline, MdObjectPropertiesDto incoming) {
+    boolean child =
+      !namedListEquals(baseline.attributes, incoming.attributes)
+        || !namedListEquals(baseline.tabularSections, incoming.tabularSections);
+    boolean props =
+      !Objects.equals(baseline.synonymRu, incoming.synonymRu)
+        || !Objects.equals(baseline.comment, incoming.comment)
+        || !documentEquals(baseline.document, incoming.document, false);
     return new ChangeMask(props, child);
   }
 

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesDto.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesDto.java
@@ -37,6 +37,8 @@ public final class MdObjectPropertiesDto {
   public List<String> contentRefs;
   /** Поля {@code CatalogProperties} для {@code kind=catalog}; иначе {@code null}. */
   public MdCatalogPropertiesDto catalog;
+  /** Поля {@code DocumentProperties} для {@code kind=document}; иначе {@code null}. */
+  public MdDocumentPropertiesDto document;
 
   public MdObjectPropertiesDto() {
     this.attributes = new ArrayList<>();

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesEdit.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesEdit.java
@@ -184,6 +184,9 @@ public final class MdObjectPropertiesEdit {
     if (catalog) {
       MdCatalogPropertiesBridge.read(version, props, dto);
     }
+    if ("document".equals(kind)) {
+      MdDocumentPropertiesBridge.read(version, props, dto);
+    }
     Object co = JaxbReflect.get(node, "getChildObjects");
     if (co != null) {
       for (Object a : JaxbReflect.<Object>list(co, "getAttribute")) {
@@ -252,7 +255,12 @@ public final class MdObjectPropertiesEdit {
       }
       case "document" -> {
         Object doc = require(mdo, "getDocument", "Document");
-        applyCatalogLike(JaxbReflect.get(doc, "getProperties"), dto);
+        Object docProps = JaxbReflect.get(doc, "getProperties");
+        if (dto.document != null) {
+          MdDocumentPropertiesBridge.apply(version, docProps, dto);
+        } else {
+          applyCatalogLike(docProps, dto);
+        }
         applyAttrs(JaxbReflect.get(doc, "getChildObjects"), dto);
       }
       case "exchangePlan" -> {

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesJsonCoalesce.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesJsonCoalesce.java
@@ -56,6 +56,207 @@ public final class MdObjectPropertiesJsonCoalesce {
         coalesceCatalog(incoming.catalog, baseline.catalog);
       }
     }
+    if ("document".equals(incoming.kind) && baseline.document != null) {
+      if (incoming.document == null) {
+        incoming.document = copyDocumentFull(baseline.document);
+      } else {
+        coalesceDocument(incoming.document, baseline.document);
+      }
+    }
+  }
+
+  private static MdDocumentPropertiesDto copyDocumentFull(MdDocumentPropertiesDto s) {
+    MdDocumentPropertiesDto d = new MdDocumentPropertiesDto();
+    d.objectBelonging = s.objectBelonging;
+    d.extendedConfigurationObject = s.extendedConfigurationObject;
+    d.useStandardCommands = s.useStandardCommands;
+    d.numerator = s.numerator;
+    d.numberType = s.numberType;
+    d.numberLength = s.numberLength;
+    d.numberAllowedLength = s.numberAllowedLength;
+    d.numberPeriodicity = s.numberPeriodicity;
+    d.checkUnique = s.checkUnique;
+    d.autonumbering = s.autonumbering;
+    d.standardAttributesXml = s.standardAttributesXml;
+    d.characteristicsXml = s.characteristicsXml;
+    d.basedOn = s.basedOn == null ? new ArrayList<>() : new ArrayList<>(s.basedOn);
+    d.inputByString = s.inputByString == null ? new ArrayList<>() : new ArrayList<>(s.inputByString);
+    d.createOnInput = s.createOnInput;
+    d.searchStringModeOnInputByString = s.searchStringModeOnInputByString;
+    d.fullTextSearchOnInputByString = s.fullTextSearchOnInputByString;
+    d.choiceDataGetModeOnInputByString = s.choiceDataGetModeOnInputByString;
+    d.choiceHistoryOnInput = s.choiceHistoryOnInput;
+    d.defaultObjectForm = s.defaultObjectForm;
+    d.defaultListForm = s.defaultListForm;
+    d.defaultChoiceForm = s.defaultChoiceForm;
+    d.auxiliaryObjectForm = s.auxiliaryObjectForm;
+    d.auxiliaryListForm = s.auxiliaryListForm;
+    d.auxiliaryChoiceForm = s.auxiliaryChoiceForm;
+    d.objectModule = s.objectModule;
+    d.managerModule = s.managerModule;
+    d.posting = s.posting;
+    d.realTimePosting = s.realTimePosting;
+    d.registerRecordsDeletion = s.registerRecordsDeletion;
+    d.registerRecordsWritingOnPost = s.registerRecordsWritingOnPost;
+    d.sequenceFilling = s.sequenceFilling;
+    d.registerRecords = s.registerRecords == null ? new ArrayList<>() : new ArrayList<>(s.registerRecords);
+    d.postInPrivilegedMode = s.postInPrivilegedMode;
+    d.unpostInPrivilegedMode = s.unpostInPrivilegedMode;
+    d.includeHelpInContents = s.includeHelpInContents;
+    d.help = s.help;
+    d.dataLockFields = s.dataLockFields == null ? new ArrayList<>() : new ArrayList<>(s.dataLockFields);
+    d.dataLockControlMode = s.dataLockControlMode;
+    d.fullTextSearch = s.fullTextSearch;
+    d.objectPresentationRu = s.objectPresentationRu;
+    d.extendedObjectPresentationRu = s.extendedObjectPresentationRu;
+    d.listPresentationRu = s.listPresentationRu;
+    d.extendedListPresentationRu = s.extendedListPresentationRu;
+    d.explanationRu = s.explanationRu;
+    d.dataHistory = s.dataHistory;
+    d.updateDataHistoryImmediatelyAfterWrite = s.updateDataHistoryImmediatelyAfterWrite;
+    d.executeAfterWriteDataHistoryVersionProcessing = s.executeAfterWriteDataHistoryVersionProcessing;
+    d.additionalIndexes = s.additionalIndexes;
+    return d;
+  }
+
+  private static void coalesceDocument(MdDocumentPropertiesDto d, MdDocumentPropertiesDto b) {
+    if (d.objectBelonging == null) {
+      d.objectBelonging = b.objectBelonging;
+    }
+    if (d.extendedConfigurationObject == null) {
+      d.extendedConfigurationObject = b.extendedConfigurationObject;
+    }
+    if (d.numerator == null) {
+      d.numerator = b.numerator;
+    }
+    if (d.numberType == null) {
+      d.numberType = b.numberType;
+    }
+    if (d.numberLength == null) {
+      d.numberLength = b.numberLength;
+    }
+    if (d.numberAllowedLength == null) {
+      d.numberAllowedLength = b.numberAllowedLength;
+    }
+    if (d.numberPeriodicity == null) {
+      d.numberPeriodicity = b.numberPeriodicity;
+    }
+    if (d.standardAttributesXml == null) {
+      d.standardAttributesXml = b.standardAttributesXml;
+    }
+    if (d.characteristicsXml == null) {
+      d.characteristicsXml = b.characteristicsXml;
+    }
+    if (d.basedOn == null) {
+      d.basedOn = b.basedOn == null ? new ArrayList<>() : new ArrayList<>(b.basedOn);
+    }
+    if (d.inputByString == null) {
+      d.inputByString = b.inputByString == null ? new ArrayList<>() : new ArrayList<>(b.inputByString);
+    }
+    if (d.createOnInput == null) {
+      d.createOnInput = b.createOnInput;
+    }
+    if (d.searchStringModeOnInputByString == null) {
+      d.searchStringModeOnInputByString = b.searchStringModeOnInputByString;
+    }
+    if (d.fullTextSearchOnInputByString == null) {
+      d.fullTextSearchOnInputByString = b.fullTextSearchOnInputByString;
+    }
+    if (d.choiceDataGetModeOnInputByString == null) {
+      d.choiceDataGetModeOnInputByString = b.choiceDataGetModeOnInputByString;
+    }
+    if (d.choiceHistoryOnInput == null) {
+      d.choiceHistoryOnInput = b.choiceHistoryOnInput;
+    }
+    if (d.defaultObjectForm == null) {
+      d.defaultObjectForm = b.defaultObjectForm;
+    }
+    if (d.defaultListForm == null) {
+      d.defaultListForm = b.defaultListForm;
+    }
+    if (d.defaultChoiceForm == null) {
+      d.defaultChoiceForm = b.defaultChoiceForm;
+    }
+    if (d.auxiliaryObjectForm == null) {
+      d.auxiliaryObjectForm = b.auxiliaryObjectForm;
+    }
+    if (d.auxiliaryListForm == null) {
+      d.auxiliaryListForm = b.auxiliaryListForm;
+    }
+    if (d.auxiliaryChoiceForm == null) {
+      d.auxiliaryChoiceForm = b.auxiliaryChoiceForm;
+    }
+    if (d.objectModule == null) {
+      d.objectModule = b.objectModule;
+    }
+    if (d.managerModule == null) {
+      d.managerModule = b.managerModule;
+    }
+    if (d.posting == null) {
+      d.posting = b.posting;
+    }
+    if (d.realTimePosting == null) {
+      d.realTimePosting = b.realTimePosting;
+    }
+    if (d.registerRecordsDeletion == null) {
+      d.registerRecordsDeletion = b.registerRecordsDeletion;
+    }
+    if (d.registerRecordsWritingOnPost == null) {
+      d.registerRecordsWritingOnPost = b.registerRecordsWritingOnPost;
+    }
+    if (d.sequenceFilling == null) {
+      d.sequenceFilling = b.sequenceFilling;
+    }
+    if (d.registerRecords == null) {
+      d.registerRecords = b.registerRecords == null ? new ArrayList<>() : new ArrayList<>(b.registerRecords);
+    }
+    if (d.help == null) {
+      d.help = b.help;
+    }
+    if (d.dataLockFields == null) {
+      d.dataLockFields = b.dataLockFields == null ? new ArrayList<>() : new ArrayList<>(b.dataLockFields);
+    }
+    if (d.dataLockControlMode == null) {
+      d.dataLockControlMode = b.dataLockControlMode;
+    }
+    if (d.fullTextSearch == null) {
+      d.fullTextSearch = b.fullTextSearch;
+    }
+    if (d.objectPresentationRu == null) {
+      d.objectPresentationRu = b.objectPresentationRu;
+    }
+    if (d.extendedObjectPresentationRu == null) {
+      d.extendedObjectPresentationRu = b.extendedObjectPresentationRu;
+    }
+    if (d.listPresentationRu == null) {
+      d.listPresentationRu = b.listPresentationRu;
+    }
+    if (d.extendedListPresentationRu == null) {
+      d.extendedListPresentationRu = b.extendedListPresentationRu;
+    }
+    if (d.explanationRu == null) {
+      d.explanationRu = b.explanationRu;
+    }
+    if (d.dataHistory == null) {
+      d.dataHistory = b.dataHistory;
+    }
+    if (d.additionalIndexes == null) {
+      d.additionalIndexes = b.additionalIndexes;
+    }
+    canonicalizeDocumentXmlBlobsFromBaselineIfLooseEqual(d, b);
+  }
+
+  private static void canonicalizeDocumentXmlBlobsFromBaselineIfLooseEqual(
+    MdDocumentPropertiesDto d,
+    MdDocumentPropertiesDto b) {
+    if (d.standardAttributesXml != null && b.standardAttributesXml != null
+      && MdObjectPropertiesDiff.looseXmlBlobEquals(d.standardAttributesXml, b.standardAttributesXml)) {
+      d.standardAttributesXml = b.standardAttributesXml;
+    }
+    if (d.characteristicsXml != null && b.characteristicsXml != null
+      && MdObjectPropertiesDiff.looseXmlBlobEquals(d.characteristicsXml, b.characteristicsXml)) {
+      d.characteristicsXml = b.characteristicsXml;
+    }
   }
 
   private static MdCatalogPropertiesDto copyCatalogFull(MdCatalogPropertiesDto s) {

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesLeafDiff.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesLeafDiff.java
@@ -78,7 +78,8 @@ public final class MdObjectPropertiesLeafDiff {
     return switch (kind) {
       case "subsystem" -> subsystemPropertyChanges(baseline, incoming);
       case "catalog" -> catalogPropertyChanges(baseline, incoming);
-      case "document", "exchangePlan" -> docLikePropertyChanges(baseline, incoming);
+      case "document" -> documentPropertyChanges(baseline, incoming);
+      case "exchangePlan" -> docLikePropertyChanges(baseline, incoming);
       case "constant", "enum", "report", "dataProcessor", "task", "chartOfAccounts",
            "chartOfCharacteristicTypes", "chartOfCalculationTypes", "commonModule",
            "sessionParameter", "commonAttribute", "commonPicture", "documentNumerator",
@@ -137,6 +138,31 @@ public final class MdObjectPropertiesLeafDiff {
           MdCatalogPropertiesGranularSerial.commentElement(y.comment)));
       }
     }
+  }
+
+  private static List<GranularPatchChange> documentPropertyChanges(
+    MdObjectPropertiesDto baseline,
+    MdObjectPropertiesDto incoming) {
+    if (incoming.document == null) {
+      return docLikePropertyChanges(baseline, incoming);
+    }
+    List<GranularPatchChange> out = new ArrayList<>();
+    if (!Objects.equals(baseline.synonymRu, incoming.synonymRu)) {
+      out.add(GranularPatchChange.objectProperty(
+        "Synonym",
+        MdCatalogPropertiesGranularSerial.synonymElementRu(incoming.synonymRu)));
+    }
+    if (!Objects.equals(baseline.comment, incoming.comment)) {
+      out.add(GranularPatchChange.objectProperty(
+        "Comment",
+        MdCatalogPropertiesGranularSerial.commentElement(incoming.comment)));
+    }
+    if (baseline.document != null) {
+      MdDocumentPropertiesGranularSerial.appendDocumentScalarChanges(baseline.document, incoming.document, out);
+    }
+    appendNamedChildSynonymComment("Attribute", baseline.attributes, incoming.attributes, out);
+    appendNamedChildSynonymComment("TabularSection", baseline.tabularSections, incoming.tabularSections, out);
+    return out;
   }
 
   private static List<GranularPatchChange> docLikePropertyChanges(

--- a/src/test/java/io/github/yellowhammer/designerxml/cli/ApplyMutationCmdTest.java
+++ b/src/test/java/io/github/yellowhammer/designerxml/cli/ApplyMutationCmdTest.java
@@ -235,6 +235,40 @@ class ApplyMutationCmdTest {
   }
 
   @Test
+  void objectSet_documentScalarsAndRegisterRecords_writeGranularly() throws Exception {
+    Path objectXml = copyToTemp(sampleDocumentXml());
+    String before = Files.readString(objectXml, StandardCharsets.UTF_8);
+    io.github.yellowhammer.designerxml.cf.MdObjectPropertiesDto dto =
+      io.github.yellowhammer.designerxml.cf.MdObjectPropertiesEdit.readDto(
+        objectXml, io.github.yellowhammer.designerxml.SchemaVersion.V2_20);
+    assertThat(dto.document).as("документ должен читаться гранулярно").isNotNull();
+    dto.synonymRu = "Демо: Заказ покупателя 222";
+    dto.document.numberLength = "15";
+    dto.document.posting = "DENY";
+    dto.document.registerRecords = new java.util.ArrayList<>(dto.document.registerRecords);
+    if (!dto.document.registerRecords.isEmpty()) {
+      dto.document.registerRecords.remove(dto.document.registerRecords.size() - 1);
+    }
+    Path params = writeParams(
+      "{"
+        + "\"op\":\"cf-md-object-set\","
+        + "\"objectXml\":" + json(objectXml.toString()) + ","
+        + "\"schemaVersion\":\"V2_20\","
+        + "\"payloadJson\":" + json(new com.google.gson.Gson().toJson(dto))
+        + "}");
+
+    int exit = new CommandLine(new DesignerXmlCli()).execute("apply-mutation", "--params", params.toString());
+
+    assertThat(exit).isZero();
+    String after = Files.readString(objectXml, StandardCharsets.UTF_8);
+    assertThat(after).contains("Демо: Заказ покупателя 222");
+    assertThat(after).contains("<NumberLength>15</NumberLength>");
+    assertThat(after).contains("<Posting>Deny</Posting>");
+    // Гранулярность: файл не переформатирован (могла уйти строка из RegisterRecords).
+    assertThat(countLines(before) - countLines(after)).isBetween(0L, 1L);
+  }
+
+  @Test
   void unknownOp_returnsError() throws Exception {
     Path params = writeParams("{\"op\":\"no-such-op\"}");
     int exit = new CommandLine(new DesignerXmlCli()).execute("apply-mutation", "--params", params.toString());


### PR DESCRIPTION
## Что сделано

Гранулярный DTO свойств документа — первый шаг распространения редактирования на остальные типы объектов (yellow-hammer/vscode-1c-platform-tools#195):

- `MdDocumentPropertiesDto` покрывает весь `DocumentProperties`: нумерация (тип/длина/допустимая длина/периодичность/нумератор), проведение (проведение, оперативное, удаление и запись движений, последовательности, привилегированные режимы), состав движений `RegisterRecords`, представления, поле ввода, блокировки, полнотекстовый поиск, история данных, формы, модули, ввод на основании;
- чтение в `cf-md-object-get` (`dto.document`) и гранулярная запись в `cf-md-object-set` по той же механике, что у справочника: coalesce от baseline, diff, точечные замены с верификацией;
- `cf-list-child-objects` дополнен тегами регистров (`InformationRegister`, `AccumulationRegister`, `AccountingRegister`, `CalculationRegister`) для подбора состава движений.

## Проверка
Тест: чтение документа, правка синонима + длины номера + проведения + состава движений — запись гранулярная, файл не переформатирован. Весь набор зелёный.

Используется расширением (PR последует). Релиз jar — в конце, как договорились.
