### PR TITLE
feat(cf): гранулярные свойства перечисления, константы, общего модуля и регистров

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ repositories {
 }
 
 group = "io.github.yellowhammer"
-version = "0.3.2"
+version = "0.4.0"
 
 // Корень XSD: каталог submodule `resources/namespace-forest/` (см. .gitmodules, gradle.properties `xsd.root`).
 val xsdRootPath = (findProperty("xsd.root") as String?) ?: "resources/namespace-forest"

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdCatalogPropertiesGranularSerial.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdCatalogPropertiesGranularSerial.java
@@ -285,7 +285,7 @@ public final class MdCatalogPropertiesGranularSerial {
     return textElement(localName, enumConstantToXmlText(constantName));
   }
 
-  private static String enumConstantToXmlText(String constantName) {
+  static String enumConstantToXmlText(String constantName) {
     if (constantName == null || constantName.isEmpty() || !constantName.equals(constantName.toUpperCase())) {
       return constantName == null ? "" : constantName;
     }

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdCommonModulePropertiesBridge.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdCommonModulePropertiesBridge.java
@@ -1,0 +1,58 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+import io.github.yellowhammer.designerxml.reflect.JaxbReflect;
+
+import static io.github.yellowhammer.designerxml.cf.MdPropertiesBridgeSupport.enumName;
+import static io.github.yellowhammer.designerxml.cf.MdPropertiesBridgeSupport.nullIfBlank;
+
+/**
+ * Чтение и запись {@code CommonModuleProperties} через JAXB-рефлексию.
+ */
+public final class MdCommonModulePropertiesBridge {
+
+  private MdCommonModulePropertiesBridge() {
+  }
+
+  public static void read(Object p, MdObjectPropertiesDto dto) {
+    MdCommonModulePropertiesDto d = new MdCommonModulePropertiesDto();
+    d.objectBelonging = enumName(p, "getObjectBelonging");
+    d.extendedConfigurationObject = nullIfBlank(JaxbReflect.getStringOptional(p, "getExtendedConfigurationObject"));
+    d.global = JaxbReflect.getBooleanOptional(p, "isGlobal");
+    d.clientManagedApplication = JaxbReflect.getBooleanOptional(p, "isClientManagedApplication");
+    d.server = JaxbReflect.getBooleanOptional(p, "isServer");
+    d.externalConnection = JaxbReflect.getBooleanOptional(p, "isExternalConnection");
+    d.clientOrdinaryApplication = JaxbReflect.getBooleanOptional(p, "isClientOrdinaryApplication");
+    d.client = JaxbReflect.getBooleanOptional(p, "isClient");
+    d.serverCall = JaxbReflect.getBooleanOptional(p, "isServerCall");
+    d.privileged = JaxbReflect.getBooleanOptional(p, "isPrivileged");
+    d.returnValuesReuse = enumName(p, "getReturnValuesReuse");
+    dto.commonModule = d;
+  }
+
+  public static void apply(Object p, MdObjectPropertiesDto dto) {
+    MdCommonModulePropertiesDto d = dto.commonModule;
+    if (d == null) {
+      throw new IllegalArgumentException("commonModule required");
+    }
+    MdPropertiesBridgeSupport.applyCommon(p, dto);
+    JaxbReflect.setEnumOrKeep(p, "setObjectBelonging", d.objectBelonging);
+    JaxbReflect.setOptional(p, "setExtendedConfigurationObject", nullIfBlank(d.extendedConfigurationObject));
+    JaxbReflect.setOptional(p, "setGlobal", d.global);
+    JaxbReflect.setOptional(p, "setClientManagedApplication", d.clientManagedApplication);
+    JaxbReflect.setOptional(p, "setServer", d.server);
+    JaxbReflect.setOptional(p, "setExternalConnection", d.externalConnection);
+    JaxbReflect.setOptional(p, "setClientOrdinaryApplication", d.clientOrdinaryApplication);
+    JaxbReflect.setOptional(p, "setClient", d.client);
+    JaxbReflect.setOptional(p, "setServerCall", d.serverCall);
+    JaxbReflect.setOptional(p, "setPrivileged", d.privileged);
+    JaxbReflect.setEnumOrKeep(p, "setReturnValuesReuse", d.returnValuesReuse);
+  }
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdCommonModulePropertiesDto.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdCommonModulePropertiesDto.java
@@ -1,0 +1,28 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+/**
+ * Поля {@code CommonModuleProperties} для {@code cf-md-object-get/set} ({@code kind=commonModule}).
+ * Enum-значения — имена Java-констант ({@code DONT_USE}).
+ */
+public final class MdCommonModulePropertiesDto {
+
+  public String objectBelonging;
+  public String extendedConfigurationObject;
+  public boolean global;
+  public boolean clientManagedApplication;
+  public boolean server;
+  public boolean externalConnection;
+  public boolean clientOrdinaryApplication;
+  public boolean client;
+  public boolean serverCall;
+  public boolean privileged;
+  public String returnValuesReuse;
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdConstantPropertiesBridge.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdConstantPropertiesBridge.java
@@ -26,6 +26,7 @@ public final class MdConstantPropertiesBridge {
     MdConstantPropertiesDto d = new MdConstantPropertiesDto();
     d.objectBelonging = enumName(p, "getObjectBelonging");
     d.extendedConfigurationObject = nullIfBlank(JaxbReflect.getStringOptional(p, "getExtendedConfigurationObject"));
+    d.type = MdTypeDescriptionBridge.read(JaxbReflect.getOptional(p, "getType"));
     d.useStandardCommands = JaxbReflect.getBooleanOptional(p, "isUseStandardCommands");
     d.defaultForm = JaxbReflect.getStringOptional(p, "getDefaultForm");
     d.extendedPresentationRu = LocalStringSync.firstRu(JaxbReflect.getOptional(p, "getExtendedPresentation"));
@@ -62,6 +63,9 @@ public final class MdConstantPropertiesBridge {
     MdPropertiesBridgeSupport.applyCommon(p, dto);
     JaxbReflect.setEnumOrKeep(p, "setObjectBelonging", d.objectBelonging);
     JaxbReflect.setOptional(p, "setExtendedConfigurationObject", nullIfBlank(d.extendedConfigurationObject));
+    if (d.type != null) {
+      MdTypeDescriptionBridge.apply(JaxbReflect.ensureOptional(p, "getType", "setType"), d.type);
+    }
     JaxbReflect.setOptional(p, "setUseStandardCommands", d.useStandardCommands);
     JaxbReflect.setOptional(p, "setDefaultForm", d.defaultForm);
     ensureAndSetRu(p, "getExtendedPresentation", "setExtendedPresentation", d.extendedPresentationRu);

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdConstantPropertiesBridge.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdConstantPropertiesBridge.java
@@ -1,0 +1,90 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+import io.github.yellowhammer.designerxml.reflect.JaxbReflect;
+
+import static io.github.yellowhammer.designerxml.cf.MdPropertiesBridgeSupport.enumName;
+import static io.github.yellowhammer.designerxml.cf.MdPropertiesBridgeSupport.ensureAndSetRu;
+import static io.github.yellowhammer.designerxml.cf.MdPropertiesBridgeSupport.nullIfBlank;
+
+/**
+ * Чтение и запись {@code ConstantProperties} через JAXB-рефлексию.
+ */
+public final class MdConstantPropertiesBridge {
+
+  private MdConstantPropertiesBridge() {
+  }
+
+  public static void read(Object p, MdObjectPropertiesDto dto) {
+    MdConstantPropertiesDto d = new MdConstantPropertiesDto();
+    d.objectBelonging = enumName(p, "getObjectBelonging");
+    d.extendedConfigurationObject = nullIfBlank(JaxbReflect.getStringOptional(p, "getExtendedConfigurationObject"));
+    d.useStandardCommands = JaxbReflect.getBooleanOptional(p, "isUseStandardCommands");
+    d.defaultForm = JaxbReflect.getStringOptional(p, "getDefaultForm");
+    d.extendedPresentationRu = LocalStringSync.firstRu(JaxbReflect.getOptional(p, "getExtendedPresentation"));
+    d.explanationRu = LocalStringSync.firstRu(JaxbReflect.getOptional(p, "getExplanation"));
+    d.passwordMode = JaxbReflect.getBooleanOptional(p, "isPasswordMode");
+    d.formatRu = LocalStringSync.firstRu(JaxbReflect.getOptional(p, "getFormat"));
+    d.editFormatRu = LocalStringSync.firstRu(JaxbReflect.getOptional(p, "getEditFormat"));
+    d.toolTipRu = LocalStringSync.firstRu(JaxbReflect.getOptional(p, "getToolTip"));
+    d.markNegatives = JaxbReflect.getBooleanOptional(p, "isMarkNegatives");
+    d.mask = JaxbReflect.getStringOptional(p, "getMask");
+    d.multiLine = JaxbReflect.getBooleanOptional(p, "isMultiLine");
+    d.extendedEdit = JaxbReflect.getBooleanOptional(p, "isExtendedEdit");
+    d.fillChecking = enumName(p, "getFillChecking");
+    d.choiceFoldersAndItems = enumName(p, "getChoiceFoldersAndItems");
+    d.quickChoice = enumName(p, "getQuickChoice");
+    d.choiceForm = JaxbReflect.getStringOptional(p, "getChoiceForm");
+    d.choiceHistoryOnInput = enumName(p, "getChoiceHistoryOnInput");
+    d.valueManagerModule = JaxbReflect.getStringOptional(p, "getValueManagerModule");
+    d.managerModule = JaxbReflect.getStringOptional(p, "getManagerModule");
+    d.dataLockControlMode = enumName(p, "getDataLockControlMode");
+    d.dataHistory = enumName(p, "getDataHistory");
+    d.updateDataHistoryImmediatelyAfterWrite =
+      JaxbReflect.getBooleanOptional(p, "isUpdateDataHistoryImmediatelyAfterWrite");
+    d.executeAfterWriteDataHistoryVersionProcessing =
+      JaxbReflect.getBooleanOptional(p, "isExecuteAfterWriteDataHistoryVersionProcessing");
+    dto.constant = d;
+  }
+
+  public static void apply(Object p, MdObjectPropertiesDto dto) {
+    MdConstantPropertiesDto d = dto.constant;
+    if (d == null) {
+      throw new IllegalArgumentException("constant required");
+    }
+    MdPropertiesBridgeSupport.applyCommon(p, dto);
+    JaxbReflect.setEnumOrKeep(p, "setObjectBelonging", d.objectBelonging);
+    JaxbReflect.setOptional(p, "setExtendedConfigurationObject", nullIfBlank(d.extendedConfigurationObject));
+    JaxbReflect.setOptional(p, "setUseStandardCommands", d.useStandardCommands);
+    JaxbReflect.setOptional(p, "setDefaultForm", d.defaultForm);
+    ensureAndSetRu(p, "getExtendedPresentation", "setExtendedPresentation", d.extendedPresentationRu);
+    ensureAndSetRu(p, "getExplanation", "setExplanation", d.explanationRu);
+    JaxbReflect.setOptional(p, "setPasswordMode", d.passwordMode);
+    ensureAndSetRu(p, "getFormat", "setFormat", d.formatRu);
+    ensureAndSetRu(p, "getEditFormat", "setEditFormat", d.editFormatRu);
+    ensureAndSetRu(p, "getToolTip", "setToolTip", d.toolTipRu);
+    JaxbReflect.setOptional(p, "setMarkNegatives", d.markNegatives);
+    JaxbReflect.setOptional(p, "setMask", d.mask);
+    JaxbReflect.setOptional(p, "setMultiLine", d.multiLine);
+    JaxbReflect.setOptional(p, "setExtendedEdit", d.extendedEdit);
+    JaxbReflect.setEnumOrKeep(p, "setFillChecking", d.fillChecking);
+    JaxbReflect.setEnumOrKeep(p, "setChoiceFoldersAndItems", d.choiceFoldersAndItems);
+    JaxbReflect.setEnumOrKeep(p, "setQuickChoice", d.quickChoice);
+    JaxbReflect.setOptional(p, "setChoiceForm", d.choiceForm);
+    JaxbReflect.setEnumOrKeep(p, "setChoiceHistoryOnInput", d.choiceHistoryOnInput);
+    JaxbReflect.setOptional(p, "setValueManagerModule", d.valueManagerModule);
+    JaxbReflect.setOptional(p, "setManagerModule", d.managerModule);
+    JaxbReflect.setEnumOrKeep(p, "setDataLockControlMode", d.dataLockControlMode);
+    JaxbReflect.setEnumOrKeep(p, "setDataHistory", d.dataHistory);
+    JaxbReflect.setOptional(p, "setUpdateDataHistoryImmediatelyAfterWrite", d.updateDataHistoryImmediatelyAfterWrite);
+    JaxbReflect.setOptional(p, "setExecuteAfterWriteDataHistoryVersionProcessing",
+      d.executeAfterWriteDataHistoryVersionProcessing);
+  }
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdConstantPropertiesDto.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdConstantPropertiesDto.java
@@ -1,0 +1,45 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+/**
+ * Поля {@code ConstantProperties} для {@code cf-md-object-get/set} ({@code kind=constant}).
+ * Enum-значения — имена Java-констант ({@code DONT_CHECK}, {@code AUTO}).
+ *
+ * <p>Тип значения ({@code Type}), границы, параметры выбора и связь по типу здесь не представлены:
+ * они правятся палитрой типов и при записи остаются нетронутыми.
+ */
+public final class MdConstantPropertiesDto {
+
+  public String objectBelonging;
+  public String extendedConfigurationObject;
+  public boolean useStandardCommands;
+  public String defaultForm;
+  public String extendedPresentationRu;
+  public String explanationRu;
+  public boolean passwordMode;
+  public String formatRu;
+  public String editFormatRu;
+  public String toolTipRu;
+  public boolean markNegatives;
+  public String mask;
+  public boolean multiLine;
+  public boolean extendedEdit;
+  public String fillChecking;
+  public String choiceFoldersAndItems;
+  public String quickChoice;
+  public String choiceForm;
+  public String choiceHistoryOnInput;
+  public String valueManagerModule;
+  public String managerModule;
+  public String dataLockControlMode;
+  public String dataHistory;
+  public boolean updateDataHistoryImmediatelyAfterWrite;
+  public boolean executeAfterWriteDataHistoryVersionProcessing;
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdConstantPropertiesDto.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdConstantPropertiesDto.java
@@ -12,13 +12,15 @@ package io.github.yellowhammer.designerxml.cf;
  * Поля {@code ConstantProperties} для {@code cf-md-object-get/set} ({@code kind=constant}).
  * Enum-значения — имена Java-констант ({@code DONT_CHECK}, {@code AUTO}).
  *
- * <p>Тип значения ({@code Type}), границы, параметры выбора и связь по типу здесь не представлены:
- * они правятся палитрой типов и при записи остаются нетронутыми.
+ * <p>Границы, параметры выбора и связь по типу здесь не представлены: при записи они остаются
+ * нетронутыми.
  */
 public final class MdConstantPropertiesDto {
 
   public String objectBelonging;
   public String extendedConfigurationObject;
+  /** Описание типа значения константы. */
+  public MdTypeDescriptionDto type;
   public boolean useStandardCommands;
   public String defaultForm;
   public String extendedPresentationRu;

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdEnumPropertiesBridge.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdEnumPropertiesBridge.java
@@ -1,0 +1,98 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+import io.github.yellowhammer.designerxml.SchemaVersion;
+import io.github.yellowhammer.designerxml.reflect.JaxbReflect;
+
+import jakarta.xml.bind.JAXBException;
+
+import static io.github.yellowhammer.designerxml.cf.MdPropertiesBridgeSupport.enumName;
+import static io.github.yellowhammer.designerxml.cf.MdPropertiesBridgeSupport.ensureAndSetRu;
+import static io.github.yellowhammer.designerxml.cf.MdPropertiesBridgeSupport.nullIfBlank;
+
+/**
+ * Чтение и запись {@code EnumProperties} через JAXB-рефлексию.
+ */
+public final class MdEnumPropertiesBridge {
+
+  private MdEnumPropertiesBridge() {
+  }
+
+  public static void read(SchemaVersion version, Object p, MdObjectPropertiesDto dto) {
+    MdEnumPropertiesDto d = new MdEnumPropertiesDto();
+    d.objectBelonging = enumName(p, "getObjectBelonging");
+    d.extendedConfigurationObject = nullIfBlank(JaxbReflect.getStringOptional(p, "getExtendedConfigurationObject"));
+    d.useStandardCommands = JaxbReflect.getBooleanOptional(p, "isUseStandardCommands");
+    d.standardAttributesXml = MdPropertiesBridgeSupport.marshalStandardAttributesOrEmpty(
+      version, JaxbReflect.getOptional(p, "getStandardAttributes"));
+    d.characteristicsXml = MdPropertiesBridgeSupport.marshalCharacteristicsOrEmpty(
+      version, JaxbReflect.getOptional(p, "getCharacteristics"));
+    d.quickChoice = JaxbReflect.getBooleanOptional(p, "isQuickChoice");
+    d.choiceMode = enumName(p, "getChoiceMode");
+    d.defaultListForm = JaxbReflect.getStringOptional(p, "getDefaultListForm");
+    d.defaultChoiceForm = JaxbReflect.getStringOptional(p, "getDefaultChoiceForm");
+    d.auxiliaryListForm = JaxbReflect.getStringOptional(p, "getAuxiliaryListForm");
+    d.auxiliaryChoiceForm = JaxbReflect.getStringOptional(p, "getAuxiliaryChoiceForm");
+    d.managerModule = JaxbReflect.getStringOptional(p, "getManagerModule");
+    d.listPresentationRu = LocalStringSync.firstRu(JaxbReflect.getOptional(p, "getListPresentation"));
+    d.extendedListPresentationRu = LocalStringSync.firstRu(JaxbReflect.getOptional(p, "getExtendedListPresentation"));
+    d.explanationRu = LocalStringSync.firstRu(JaxbReflect.getOptional(p, "getExplanation"));
+    d.choiceHistoryOnInput = enumName(p, "getChoiceHistoryOnInput");
+    dto.enumeration = d;
+  }
+
+  public static void apply(SchemaVersion version, Object p, MdObjectPropertiesDto dto) {
+    MdEnumPropertiesDto d = dto.enumeration;
+    if (d == null) {
+      throw new IllegalArgumentException("enum required");
+    }
+    MdPropertiesBridgeSupport.applyCommon(p, dto);
+    JaxbReflect.setEnumOrKeep(p, "setObjectBelonging", d.objectBelonging);
+    JaxbReflect.setOptional(p, "setExtendedConfigurationObject", nullIfBlank(d.extendedConfigurationObject));
+    JaxbReflect.setOptional(p, "setUseStandardCommands", d.useStandardCommands);
+    applyStandardAttributes(version, p, d);
+    applyCharacteristics(version, p, d);
+    JaxbReflect.setOptional(p, "setQuickChoice", d.quickChoice);
+    JaxbReflect.setEnumOrKeep(p, "setChoiceMode", d.choiceMode);
+    JaxbReflect.setOptional(p, "setDefaultListForm", d.defaultListForm);
+    JaxbReflect.setOptional(p, "setDefaultChoiceForm", d.defaultChoiceForm);
+    JaxbReflect.setOptional(p, "setAuxiliaryListForm", d.auxiliaryListForm);
+    JaxbReflect.setOptional(p, "setAuxiliaryChoiceForm", d.auxiliaryChoiceForm);
+    JaxbReflect.setOptional(p, "setManagerModule", d.managerModule);
+    ensureAndSetRu(p, "getListPresentation", "setListPresentation", d.listPresentationRu);
+    ensureAndSetRu(p, "getExtendedListPresentation", "setExtendedListPresentation", d.extendedListPresentationRu);
+    ensureAndSetRu(p, "getExplanation", "setExplanation", d.explanationRu);
+    JaxbReflect.setEnumOrKeep(p, "setChoiceHistoryOnInput", d.choiceHistoryOnInput);
+  }
+
+  private static void applyStandardAttributes(SchemaVersion version, Object p, MdEnumPropertiesDto d) {
+    if (d.standardAttributesXml == null || d.standardAttributesXml.isBlank()) {
+      return;
+    }
+    try {
+      JaxbReflect.setOptional(p, "setStandardAttributes",
+        MdCfCatalogSubtreeXml.unmarshalStandardAttributes(version, d.standardAttributesXml.trim()));
+    } catch (JAXBException e) {
+      throw new IllegalArgumentException("standardAttributesXml: " + e.getMessage(), e);
+    }
+  }
+
+  private static void applyCharacteristics(SchemaVersion version, Object p, MdEnumPropertiesDto d) {
+    if (d.characteristicsXml == null || d.characteristicsXml.isBlank()) {
+      return;
+    }
+    try {
+      JaxbReflect.setOptional(p, "setCharacteristics",
+        MdCfCatalogSubtreeXml.unmarshalCharacteristics(version, d.characteristicsXml.trim()));
+    } catch (JAXBException e) {
+      throw new IllegalArgumentException("characteristicsXml: " + e.getMessage(), e);
+    }
+  }
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdEnumPropertiesDto.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdEnumPropertiesDto.java
@@ -1,0 +1,33 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+/**
+ * Поля {@code EnumProperties} для {@code cf-md-object-get/set} ({@code kind=enum}).
+ * Enum-значения — имена Java-констант ({@code BOTH_WAYS}, {@code AUTO}).
+ */
+public final class MdEnumPropertiesDto {
+
+  public String objectBelonging;
+  public String extendedConfigurationObject;
+  public boolean useStandardCommands;
+  public String standardAttributesXml;
+  public String characteristicsXml;
+  public boolean quickChoice;
+  public String choiceMode;
+  public String defaultListForm;
+  public String defaultChoiceForm;
+  public String auxiliaryListForm;
+  public String auxiliaryChoiceForm;
+  public String managerModule;
+  public String listPresentationRu;
+  public String extendedListPresentationRu;
+  public String explanationRu;
+  public String choiceHistoryOnInput;
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdFlatDtoSupport.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdFlatDtoSupport.java
@@ -1,0 +1,138 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Копирование, восполнение из базовой версии и сравнение плоских DTO свойств: публичные поля
+ * {@code String}, {@code boolean} и {@code List<String>}. Поля с именем на {@code Xml} —
+ * маршалированные поддеревья, сравниваются как XML.
+ */
+final class MdFlatDtoSupport {
+
+  private MdFlatDtoSupport() {
+  }
+
+  /** Полная копия (списки — новые экземпляры). */
+  static <T> T copy(T source) {
+    if (source == null) {
+      return null;
+    }
+    T target = newInstance(source);
+    for (Field field : fields(source.getClass())) {
+      write(field, target, read(field, source));
+    }
+    return target;
+  }
+
+  /**
+   * Поля, не переданные в JSON ({@code null}), берём из прочитанного XML: пустое значение и
+   * «не передавали» должны различаться.
+   */
+  static <T> void coalesce(T incoming, T baseline) {
+    if (incoming == null || baseline == null) {
+      return;
+    }
+    for (Field field : fields(incoming.getClass())) {
+      if (field.getType() == boolean.class) {
+        continue;
+      }
+      if (read(field, incoming) == null) {
+        write(field, incoming, read(field, baseline));
+      }
+    }
+  }
+
+  /**
+   * @param lenientXmlBlobs сравнивать поля {@code *Xml} без учёта префиксов пространств имён
+   *   (JAXB расставляет их по-разному от запуска к запуску)
+   */
+  static <T> boolean equalsFlat(T a, T b, boolean lenientXmlBlobs) {
+    if (a == b) {
+      return true;
+    }
+    if (a == null || b == null) {
+      return false;
+    }
+    for (Field field : fields(a.getClass())) {
+      if (!fieldEquals(field, a, b, lenientXmlBlobs)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static boolean fieldEquals(Field field, Object a, Object b, boolean lenientXmlBlobs) {
+    Object x = read(field, a);
+    Object y = read(field, b);
+    if (x instanceof List<?> || y instanceof List<?>) {
+      return MdObjectPropertiesDiff.listStringEquals(stringList(x), stringList(y));
+    }
+    if (lenientXmlBlobs && field.getName().endsWith("Xml")) {
+      return MdObjectPropertiesDiff.looseXmlBlobEquals((String) x, (String) y);
+    }
+    return Objects.equals(x, y);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static List<String> stringList(Object value) {
+    return value == null ? new ArrayList<>() : new ArrayList<>((List<String>) value);
+  }
+
+  private static Object read(Field field, Object target) {
+    try {
+      Object value = field.get(target);
+      if (value instanceof List<?> list) {
+        return new ArrayList<>(list);
+      }
+      return value;
+    } catch (IllegalAccessException e) {
+      throw new IllegalStateException("cannot read " + field.getName(), e);
+    }
+  }
+
+  private static void write(Field field, Object target, Object value) {
+    try {
+      if (value == null && field.getType() == boolean.class) {
+        return;
+      }
+      if (value == null && List.class.isAssignableFrom(field.getType())) {
+        field.set(target, new ArrayList<>());
+        return;
+      }
+      field.set(target, value);
+    } catch (IllegalAccessException e) {
+      throw new IllegalStateException("cannot write " + field.getName(), e);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> T newInstance(T source) {
+    try {
+      return (T) source.getClass().getDeclaredConstructor().newInstance();
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException("cannot create " + source.getClass().getName(), e);
+    }
+  }
+
+  private static List<Field> fields(Class<?> type) {
+    List<Field> out = new ArrayList<>();
+    for (Field field : type.getFields()) {
+      if (!Modifier.isStatic(field.getModifiers()) && !field.isSynthetic()) {
+        out.add(field);
+      }
+    }
+    return out;
+  }
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdFlatDtoSupport.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdFlatDtoSupport.java
@@ -15,9 +15,9 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * Копирование, восполнение из базовой версии и сравнение плоских DTO свойств: публичные поля
- * {@code String}, {@code boolean} и {@code List<String>}. Поля с именем на {@code Xml} —
- * маршалированные поддеревья, сравниваются как XML.
+ * Копирование, восполнение из базовой версии и сравнение DTO свойств: публичные поля
+ * {@code String}, {@code boolean}, {@code List<String>} и вложенные DTO этого же пакета.
+ * Поля с именем на {@code Xml} — маршалированные поддеревья, сравниваются как XML.
  */
 final class MdFlatDtoSupport {
 
@@ -31,7 +31,7 @@ final class MdFlatDtoSupport {
     }
     T target = newInstance(source);
     for (Field field : fields(source.getClass())) {
-      write(field, target, read(field, source));
+      write(field, target, copyValue(field, read(field, source)));
     }
     return target;
   }
@@ -49,7 +49,7 @@ final class MdFlatDtoSupport {
         continue;
       }
       if (read(field, incoming) == null) {
-        write(field, incoming, read(field, baseline));
+        write(field, incoming, copyValue(field, read(field, baseline)));
       }
     }
   }
@@ -79,10 +79,18 @@ final class MdFlatDtoSupport {
     if (x instanceof List<?> || y instanceof List<?>) {
       return MdObjectPropertiesDiff.listStringEquals(stringList(x), stringList(y));
     }
+    if (isNestedDto(field.getType())) {
+      return equalsFlat(x, y, lenientXmlBlobs);
+    }
     if (lenientXmlBlobs && field.getName().endsWith("Xml")) {
       return MdObjectPropertiesDiff.looseXmlBlobEquals((String) x, (String) y);
     }
     return Objects.equals(x, y);
+  }
+
+  /** Вложенное DTO этого пакета: сравниваем и копируем по значению, а не по ссылке. */
+  private static boolean isNestedDto(Class<?> type) {
+    return type.getName().startsWith("io.github.yellowhammer.designerxml.cf.") && type.getName().endsWith("Dto");
   }
 
   @SuppressWarnings("unchecked")
@@ -100,6 +108,13 @@ final class MdFlatDtoSupport {
     } catch (IllegalAccessException e) {
       throw new IllegalStateException("cannot read " + field.getName(), e);
     }
+  }
+
+  private static Object copyValue(Field field, Object value) {
+    if (value != null && isNestedDto(field.getType())) {
+      return copy(value);
+    }
+    return value;
   }
 
   private static void write(Field field, Object target, Object value) {

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdNamedPropertyDto.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdNamedPropertyDto.java
@@ -9,13 +9,18 @@
 package io.github.yellowhammer.designerxml.cf;
 
 /**
- * Реквизит или табличная часть: имя не меняется через DTO, только синоним ru и комментарий.
+ * Реквизит, табличная часть, значение перечисления, измерение или ресурс: имя не меняется через DTO,
+ * только синоним ru, комментарий и тип.
+ *
+ * <p>{@link #type} есть у того, у чего платформа его требует; у табличных частей и значений
+ * перечисления он {@code null}.
  */
 public final class MdNamedPropertyDto {
 
   public String name;
   public String synonymRu;
   public String comment;
+  public MdTypeDescriptionDto type;
 
   public MdNamedPropertyDto() {
   }

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectChildMutations.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectChildMutations.java
@@ -115,6 +115,191 @@ public final class MdObjectChildMutations {
   }
 
   /**
+   * Добавляет измерение регистра в корневой {@code ChildObjects}.
+   *
+   * @param objectXml путь к XML регистра
+   * @param version версия схемы Designer XML
+   * @param newName имя нового измерения
+   * @throws IOException если не удалось прочитать/записать XML
+   * @throws JAXBException если итоговый XML невалиден для JAXB-модели
+   */
+  public static void addDimension(Path objectXml, SchemaVersion version, String newName)
+    throws IOException, JAXBException {
+    addRegisterChild(objectXml, version, "Dimension", "Измерение", newName);
+  }
+
+  /**
+   * Переименовывает измерение регистра.
+   *
+   * @param objectXml путь к XML регистра
+   * @param version версия схемы Designer XML
+   * @param oldName текущее имя
+   * @param newName новое имя
+   * @throws IOException если не удалось прочитать/записать XML
+   * @throws JAXBException если итоговый XML невалиден для JAXB-модели
+   */
+  public static void renameDimension(Path objectXml, SchemaVersion version, String oldName, String newName)
+    throws IOException, JAXBException {
+    renameRegisterChild(objectXml, version, "Dimension", "Измерение", oldName, newName);
+  }
+
+  /**
+   * Удаляет измерение регистра.
+   *
+   * @param objectXml путь к XML регистра
+   * @param version версия схемы Designer XML
+   * @param name имя измерения
+   * @throws IOException если не удалось прочитать/записать XML
+   * @throws JAXBException если итоговый XML невалиден для JAXB-модели
+   */
+  public static void deleteDimension(Path objectXml, SchemaVersion version, String name)
+    throws IOException, JAXBException {
+    deleteRegisterChild(objectXml, version, "Dimension", "Измерение", name);
+  }
+
+  /**
+   * Создаёт копию измерения регистра.
+   *
+   * @param objectXml путь к XML регистра
+   * @param version версия схемы Designer XML
+   * @param sourceName имя исходного измерения
+   * @param newName имя копии
+   * @throws IOException если не удалось прочитать/записать XML
+   * @throws JAXBException если итоговый XML невалиден для JAXB-модели
+   */
+  public static void duplicateDimension(Path objectXml, SchemaVersion version, String sourceName, String newName)
+    throws IOException, JAXBException {
+    mutateAndWrite(objectXml, version, (xml, containerLocal) ->
+      duplicateNamedChild(xml, containerLocal, "Dimension", sourceName, newName, "Измерение"));
+  }
+
+  /**
+   * Переставляет измерения регистра в заданном порядке.
+   */
+  public static void reorderDimensions(Path objectXml, SchemaVersion version, List<String> order)
+    throws IOException, JAXBException {
+    reorderRegisterChildren(objectXml, version, "Dimension", "Измерение", order);
+  }
+
+  /**
+   * Добавляет ресурс регистра в корневой {@code ChildObjects}.
+   *
+   * @param objectXml путь к XML регистра
+   * @param version версия схемы Designer XML
+   * @param newName имя нового ресурса
+   * @throws IOException если не удалось прочитать/записать XML
+   * @throws JAXBException если итоговый XML невалиден для JAXB-модели
+   */
+  public static void addResource(Path objectXml, SchemaVersion version, String newName)
+    throws IOException, JAXBException {
+    addRegisterChild(objectXml, version, "Resource", "Ресурс", newName);
+  }
+
+  /**
+   * Переименовывает ресурс регистра.
+   *
+   * @param objectXml путь к XML регистра
+   * @param version версия схемы Designer XML
+   * @param oldName текущее имя
+   * @param newName новое имя
+   * @throws IOException если не удалось прочитать/записать XML
+   * @throws JAXBException если итоговый XML невалиден для JAXB-модели
+   */
+  public static void renameResource(Path objectXml, SchemaVersion version, String oldName, String newName)
+    throws IOException, JAXBException {
+    renameRegisterChild(objectXml, version, "Resource", "Ресурс", oldName, newName);
+  }
+
+  /**
+   * Удаляет ресурс регистра.
+   *
+   * @param objectXml путь к XML регистра
+   * @param version версия схемы Designer XML
+   * @param name имя ресурса
+   * @throws IOException если не удалось прочитать/записать XML
+   * @throws JAXBException если итоговый XML невалиден для JAXB-модели
+   */
+  public static void deleteResource(Path objectXml, SchemaVersion version, String name)
+    throws IOException, JAXBException {
+    deleteRegisterChild(objectXml, version, "Resource", "Ресурс", name);
+  }
+
+  /**
+   * Создаёт копию ресурса регистра.
+   *
+   * @param objectXml путь к XML регистра
+   * @param version версия схемы Designer XML
+   * @param sourceName имя исходного ресурса
+   * @param newName имя копии
+   * @throws IOException если не удалось прочитать/записать XML
+   * @throws JAXBException если итоговый XML невалиден для JAXB-модели
+   */
+  public static void duplicateResource(Path objectXml, SchemaVersion version, String sourceName, String newName)
+    throws IOException, JAXBException {
+    mutateAndWrite(objectXml, version, (xml, containerLocal) ->
+      duplicateNamedChild(xml, containerLocal, "Resource", sourceName, newName, "Ресурс"));
+  }
+
+  /**
+   * Переставляет ресурсы регистра в заданном порядке.
+   */
+  public static void reorderResources(Path objectXml, SchemaVersion version, List<String> order)
+    throws IOException, JAXBException {
+    reorderRegisterChildren(objectXml, version, "Resource", "Ресурс", order);
+  }
+
+  private static void addRegisterChild(
+    Path objectXml,
+    SchemaVersion version,
+    String childLocal,
+    String label,
+    String newName
+  ) throws IOException, JAXBException {
+    mutateAndWrite(objectXml, version, (xml, containerLocal) -> {
+      ensureNotBlank(newName, "Введите имя: " + label.toLowerCase(java.util.Locale.ROOT) + ".");
+      ensureMissingNamedChild(xml, containerLocal, childLocal, newName, label + " уже существует: " + newName);
+      return insertIntoRootChildObjects(xml, containerLocal, buildNamedChildSnippet(childLocal, newName, newName, ""));
+    });
+  }
+
+  private static void renameRegisterChild(
+    Path objectXml,
+    SchemaVersion version,
+    String childLocal,
+    String label,
+    String oldName,
+    String newName
+  ) throws IOException, JAXBException {
+    mutateAndWrite(objectXml, version, (xml, containerLocal) ->
+      renameNamedChild(xml, containerLocal, childLocal, oldName, newName, label));
+    FormDataPathCleanup.afterChildRename(objectXml, oldName, newName);
+  }
+
+  private static void deleteRegisterChild(
+    Path objectXml,
+    SchemaVersion version,
+    String childLocal,
+    String label,
+    String name
+  ) throws IOException, JAXBException {
+    mutateAndWrite(objectXml, version, (xml, containerLocal) ->
+      deleteNamedChild(xml, containerLocal, childLocal, name, label));
+    FormDataPathCleanup.afterChildDelete(objectXml, name);
+  }
+
+  private static void reorderRegisterChildren(
+    Path objectXml,
+    SchemaVersion version,
+    String childLocal,
+    String label,
+    List<String> order
+  ) throws IOException, JAXBException {
+    mutateAndWrite(objectXml, version, (xml, containerLocal) ->
+      reorderNamedRegions(xml, order, label,
+        name -> MdObjectXmlRegions.findNamedChildObjectRegion(xml, containerLocal, childLocal, name)));
+  }
+
+  /**
    * Добавляет значение перечисления в корневой {@code ChildObjects}.
    *
    * @param objectXml путь к XML перечисления
@@ -809,7 +994,12 @@ public final class MdObjectChildMutations {
   }
 
   private static String buildEnumValueSnippet(String name, String synonymRu, String comment) {
-    return "<EnumValue uuid=\"" + UUID.randomUUID() + "\">\n"
+    return buildNamedChildSnippet("EnumValue", name, synonymRu, comment);
+  }
+
+  /** Именованный дочерний объект с именем, синонимом и комментарием: значение, измерение, ресурс. */
+  private static String buildNamedChildSnippet(String childLocal, String name, String synonymRu, String comment) {
+    return "<" + childLocal + " uuid=\"" + UUID.randomUUID() + "\">\n"
       + "\t<Properties>\n"
       + "\t\t<Name>" + escapeXml(name) + "</Name>\n"
       + "\t\t<Synonym>\n"
@@ -822,7 +1012,7 @@ public final class MdObjectChildMutations {
       ? "\t\t<Comment/>\n"
       : "\t\t<Comment>" + escapeXml(comment) + "</Comment>\n")
       + "\t</Properties>\n"
-      + "</EnumValue>";
+      + "</" + childLocal + ">";
   }
 
   private static String buildTabularSectionSnippet(

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectChildMutations.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectChildMutations.java
@@ -115,6 +115,71 @@ public final class MdObjectChildMutations {
   }
 
   /**
+   * Добавляет значение перечисления в корневой {@code ChildObjects}.
+   *
+   * @param objectXml путь к XML перечисления
+   * @param version версия схемы Designer XML
+   * @param newName имя нового значения
+   * @throws IOException если не удалось прочитать/записать XML
+   * @throws JAXBException если итоговый XML невалиден для JAXB-модели
+   */
+  public static void addEnumValue(Path objectXml, SchemaVersion version, String newName)
+    throws IOException, JAXBException {
+    mutateAndWrite(objectXml, version, (xml, containerLocal) -> {
+      ensureNotBlank(newName, "Введите имя значения.");
+      ensureMissingNamedChild(xml, containerLocal, "EnumValue", newName, "Значение уже существует: " + newName);
+      return insertIntoRootChildObjects(xml, containerLocal, buildEnumValueSnippet(newName, newName, ""));
+    });
+  }
+
+  /**
+   * Переименовывает значение перечисления в корневом {@code ChildObjects}.
+   *
+   * @param objectXml путь к XML перечисления
+   * @param version версия схемы Designer XML
+   * @param oldName текущее имя значения
+   * @param newName новое имя значения
+   * @throws IOException если не удалось прочитать/записать XML
+   * @throws JAXBException если итоговый XML невалиден для JAXB-модели
+   */
+  public static void renameEnumValue(Path objectXml, SchemaVersion version, String oldName, String newName)
+    throws IOException, JAXBException {
+    mutateAndWrite(objectXml, version, (xml, containerLocal) ->
+      renameNamedChild(xml, containerLocal, "EnumValue", oldName, newName, "Значение"));
+  }
+
+  /**
+   * Удаляет значение перечисления из корневого {@code ChildObjects}.
+   *
+   * @param objectXml путь к XML перечисления
+   * @param version версия схемы Designer XML
+   * @param name имя удаляемого значения
+   * @throws IOException если не удалось прочитать/записать XML
+   * @throws JAXBException если итоговый XML невалиден для JAXB-модели
+   */
+  public static void deleteEnumValue(Path objectXml, SchemaVersion version, String name)
+    throws IOException, JAXBException {
+    mutateAndWrite(objectXml, version, (xml, containerLocal) ->
+      deleteNamedChild(xml, containerLocal, "EnumValue", name, "Значение"));
+  }
+
+  /**
+   * Создаёт копию значения перечисления в корневом {@code ChildObjects}.
+   *
+   * @param objectXml путь к XML перечисления
+   * @param version версия схемы Designer XML
+   * @param sourceName имя исходного значения
+   * @param newName имя копии
+   * @throws IOException если не удалось прочитать/записать XML
+   * @throws JAXBException если итоговый XML невалиден для JAXB-модели
+   */
+  public static void duplicateEnumValue(Path objectXml, SchemaVersion version, String sourceName, String newName)
+    throws IOException, JAXBException {
+    mutateAndWrite(objectXml, version, (xml, containerLocal) ->
+      duplicateNamedChild(xml, containerLocal, "EnumValue", sourceName, newName, "Значение"));
+  }
+
+  /**
    * Добавляет табличную часть в корневой {@code ChildObjects}.
    *
    * @param objectXml путь к XML объекта метаданных
@@ -604,6 +669,16 @@ public final class MdObjectChildMutations {
   }
 
   /**
+   * Переставляет значения перечисления корневого {@code ChildObjects} в заданном порядке.
+   */
+  public static void reorderEnumValues(Path objectXml, SchemaVersion version, List<String> order)
+    throws IOException, JAXBException {
+    mutateAndWrite(objectXml, version, (xml, containerLocal) ->
+      reorderNamedRegions(xml, order, "Значение",
+        name -> MdObjectXmlRegions.findNamedChildObjectRegion(xml, containerLocal, "EnumValue", name)));
+  }
+
+  /**
    * Переставляет реквизиты табличной части в заданном порядке.
    */
   public static void reorderTabularAttributes(
@@ -731,6 +806,23 @@ public final class MdObjectChildMutations {
       : "\t\t<Comment>" + escapeXml(comment) + "</Comment>\n")
       + "\t</Properties>\n"
       + "</Attribute>";
+  }
+
+  private static String buildEnumValueSnippet(String name, String synonymRu, String comment) {
+    return "<EnumValue uuid=\"" + UUID.randomUUID() + "\">\n"
+      + "\t<Properties>\n"
+      + "\t\t<Name>" + escapeXml(name) + "</Name>\n"
+      + "\t\t<Synonym>\n"
+      + "\t\t\t<v8:item>\n"
+      + "\t\t\t\t<v8:lang>ru</v8:lang>\n"
+      + "\t\t\t\t<v8:content>" + escapeXml(synonymRu) + "</v8:content>\n"
+      + "\t\t\t</v8:item>\n"
+      + "\t\t</Synonym>\n"
+      + (comment == null || comment.isBlank()
+      ? "\t\t<Comment/>\n"
+      : "\t\t<Comment>" + escapeXml(comment) + "</Comment>\n")
+      + "\t</Properties>\n"
+      + "</EnumValue>";
   }
 
   private static String buildTabularSectionSnippet(

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectChildMutations.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectChildMutations.java
@@ -258,7 +258,8 @@ public final class MdObjectChildMutations {
     mutateAndWrite(objectXml, version, (xml, containerLocal) -> {
       ensureNotBlank(newName, "Введите имя: " + label.toLowerCase(java.util.Locale.ROOT) + ".");
       ensureMissingNamedChild(xml, containerLocal, childLocal, newName, label + " уже существует: " + newName);
-      return insertIntoRootChildObjects(xml, containerLocal, buildNamedChildSnippet(childLocal, newName, newName, ""));
+      return insertIntoRootChildObjects(
+        xml, containerLocal, buildNamedChildSnippet(childLocal, newName, newName, "", true));
     });
   }
 
@@ -977,28 +978,40 @@ public final class MdObjectChildMutations {
   }
 
   private static String buildAttributeSnippet(String name, String synonymRu, String comment) {
-    return "<Attribute uuid=\"" + UUID.randomUUID() + "\">\n"
-      + "\t<Properties>\n"
-      + "\t\t<Name>" + escapeXml(name) + "</Name>\n"
-      + "\t\t<Synonym>\n"
-      + "\t\t\t<v8:item>\n"
-      + "\t\t\t\t<v8:lang>ru</v8:lang>\n"
-      + "\t\t\t\t<v8:content>" + escapeXml(synonymRu) + "</v8:content>\n"
-      + "\t\t\t</v8:item>\n"
-      + "\t\t</Synonym>\n"
-      + (comment == null || comment.isBlank()
-      ? "\t\t<Comment/>\n"
-      : "\t\t<Comment>" + escapeXml(comment) + "</Comment>\n")
-      + "\t</Properties>\n"
-      + "</Attribute>";
+    return buildNamedChildSnippet("Attribute", name, synonymRu, comment, true);
+  }
+
+  /**
+   * Тип по умолчанию — строка переменной длины 10, как заводит конфигуратор.
+   * Платформа требует тип у реквизита, измерения и ресурса: без него объект не загрузится.
+   */
+  private static String defaultTypeBlock(String indent) {
+    return indent + "<Type>\n"
+      + indent + "\t<v8:Type xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">xs:string</v8:Type>\n"
+      + indent + "\t<v8:StringQualifiers>\n"
+      + indent + "\t\t<v8:Length>10</v8:Length>\n"
+      + indent + "\t\t<v8:AllowedLength>Variable</v8:AllowedLength>\n"
+      + indent + "\t</v8:StringQualifiers>\n"
+      + indent + "</Type>\n";
   }
 
   private static String buildEnumValueSnippet(String name, String synonymRu, String comment) {
-    return buildNamedChildSnippet("EnumValue", name, synonymRu, comment);
+    // У значения перечисления типа нет.
+    return buildNamedChildSnippet("EnumValue", name, synonymRu, comment, false);
   }
 
-  /** Именованный дочерний объект с именем, синонимом и комментарием: значение, измерение, ресурс. */
-  private static String buildNamedChildSnippet(String childLocal, String name, String synonymRu, String comment) {
+  /**
+   * Именованный дочерний объект: значение перечисления, реквизит, измерение, ресурс.
+   *
+   * @param withType добавить тип по умолчанию (у всего, кроме значения перечисления)
+   */
+  private static String buildNamedChildSnippet(
+    String childLocal,
+    String name,
+    String synonymRu,
+    String comment,
+    boolean withType
+  ) {
     return "<" + childLocal + " uuid=\"" + UUID.randomUUID() + "\">\n"
       + "\t<Properties>\n"
       + "\t\t<Name>" + escapeXml(name) + "</Name>\n"
@@ -1011,6 +1024,7 @@ public final class MdObjectChildMutations {
       + (comment == null || comment.isBlank()
       ? "\t\t<Comment/>\n"
       : "\t\t<Comment>" + escapeXml(comment) + "</Comment>\n")
+      + (withType ? defaultTypeBlock("\t\t") : "")
       + "\t</Properties>\n"
       + "</" + childLocal + ">";
   }

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesDiff.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesDiff.java
@@ -75,6 +75,9 @@ public final class MdObjectPropertiesDiff {
     if (!namedListEquals(a.tabularSections, b.tabularSections)) {
       return false;
     }
+    if (!namedListEquals(a.enumValues, b.enumValues)) {
+      return false;
+    }
     if (!listStringEquals(a.nestedSubsystems, b.nestedSubsystems)) {
       return false;
     }
@@ -190,6 +193,9 @@ public final class MdObjectPropertiesDiff {
       return false;
     }
     if (!namedListEquals(a.tabularSections, b.tabularSections)) {
+      return false;
+    }
+    if (!namedListEquals(a.enumValues, b.enumValues)) {
       return false;
     }
     if (!listStringEquals(a.nestedSubsystems, b.nestedSubsystems)) {
@@ -433,7 +439,8 @@ public final class MdObjectPropertiesDiff {
   private static ChangeMask docLikeMask(MdObjectPropertiesDto baseline, MdObjectPropertiesDto incoming) {
     boolean child =
       !namedListEquals(baseline.attributes, incoming.attributes)
-        || !namedListEquals(baseline.tabularSections, incoming.tabularSections);
+        || !namedListEquals(baseline.tabularSections, incoming.tabularSections)
+        || !namedListEquals(baseline.enumValues, incoming.enumValues);
     boolean props =
       !Objects.equals(baseline.synonymRu, incoming.synonymRu)
         || !Objects.equals(baseline.comment, incoming.comment)

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesDiff.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesDiff.java
@@ -78,6 +78,12 @@ public final class MdObjectPropertiesDiff {
     if (!namedListEquals(a.enumValues, b.enumValues)) {
       return false;
     }
+    if (!namedListEquals(a.dimensions, b.dimensions) || !namedListEquals(a.resources, b.resources)) {
+      return false;
+    }
+    if (!namedListEquals(a.dimensions, b.dimensions) || !namedListEquals(a.resources, b.resources)) {
+      return false;
+    }
     if (!listStringEquals(a.nestedSubsystems, b.nestedSubsystems)) {
       return false;
     }
@@ -441,7 +447,9 @@ public final class MdObjectPropertiesDiff {
     boolean child =
       !namedListEquals(baseline.attributes, incoming.attributes)
         || !namedListEquals(baseline.tabularSections, incoming.tabularSections)
-        || !namedListEquals(baseline.enumValues, incoming.enumValues);
+        || !namedListEquals(baseline.enumValues, incoming.enumValues)
+        || !namedListEquals(baseline.dimensions, incoming.dimensions)
+        || !namedListEquals(baseline.resources, incoming.resources);
     boolean props =
       !Objects.equals(baseline.synonymRu, incoming.synonymRu)
         || !Objects.equals(baseline.comment, incoming.comment)

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesDiff.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesDiff.java
@@ -82,7 +82,8 @@ public final class MdObjectPropertiesDiff {
       return false;
     }
     return catalogEquals(a.catalog, b.catalog, lenientCatalogXmlBlobs)
-      && documentEquals(a.document, b.document, lenientCatalogXmlBlobs);
+      && documentEquals(a.document, b.document, lenientCatalogXmlBlobs)
+      && simpleKindsEqual(a, b, lenientCatalogXmlBlobs);
   }
 
   /**
@@ -198,7 +199,8 @@ public final class MdObjectPropertiesDiff {
       return false;
     }
     return catalogEquals(a.catalog, b.catalog, lenientCatalogXmlBlobs)
-      && documentEquals(a.document, b.document, lenientCatalogXmlBlobs);
+      && documentEquals(a.document, b.document, lenientCatalogXmlBlobs)
+      && simpleKindsEqual(a, b, lenientCatalogXmlBlobs);
   }
 
   static boolean documentEquals(MdDocumentPropertiesDto a, MdDocumentPropertiesDto b, boolean lenientXmlBlobs) {
@@ -434,8 +436,16 @@ public final class MdObjectPropertiesDiff {
         || !namedListEquals(baseline.tabularSections, incoming.tabularSections);
     boolean props =
       !Objects.equals(baseline.synonymRu, incoming.synonymRu)
-        || !Objects.equals(baseline.comment, incoming.comment);
+        || !Objects.equals(baseline.comment, incoming.comment)
+        || !simpleKindsEqual(baseline, incoming, false);
     return new ChangeMask(props, child);
+  }
+
+  /** Плоские DTO перечисления, константы и общего модуля. */
+  private static boolean simpleKindsEqual(MdObjectPropertiesDto a, MdObjectPropertiesDto b, boolean lenientXmlBlobs) {
+    return MdFlatDtoSupport.equalsFlat(a.enumeration, b.enumeration, lenientXmlBlobs)
+      && MdFlatDtoSupport.equalsFlat(a.constant, b.constant, lenientXmlBlobs)
+      && MdFlatDtoSupport.equalsFlat(a.commonModule, b.commonModule, lenientXmlBlobs);
   }
 
   private static ChangeMask subsystemMask(MdObjectPropertiesDto baseline, MdObjectPropertiesDto incoming) {

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesDiff.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesDiff.java
@@ -407,6 +407,7 @@ public final class MdObjectPropertiesDiff {
       case "exchangePlan" -> docLikeMask(baseline, incoming);
       case "constant", "enum", "report", "dataProcessor", "task", "chartOfAccounts",
            "chartOfCharacteristicTypes", "chartOfCalculationTypes", "commonModule",
+           "informationRegister", "accumulationRegister",
            "sessionParameter", "commonAttribute", "commonPicture", "documentNumerator",
            "externalDataSource", "role" -> docLikeMask(baseline, incoming);
       case "subsystem" -> subsystemMask(baseline, incoming);
@@ -448,11 +449,12 @@ public final class MdObjectPropertiesDiff {
     return new ChangeMask(props, child);
   }
 
-  /** Плоские DTO перечисления, константы и общего модуля. */
+  /** Плоские DTO перечисления, константы, общего модуля и регистров. */
   private static boolean simpleKindsEqual(MdObjectPropertiesDto a, MdObjectPropertiesDto b, boolean lenientXmlBlobs) {
     return MdFlatDtoSupport.equalsFlat(a.enumeration, b.enumeration, lenientXmlBlobs)
       && MdFlatDtoSupport.equalsFlat(a.constant, b.constant, lenientXmlBlobs)
-      && MdFlatDtoSupport.equalsFlat(a.commonModule, b.commonModule, lenientXmlBlobs);
+      && MdFlatDtoSupport.equalsFlat(a.commonModule, b.commonModule, lenientXmlBlobs)
+      && MdFlatDtoSupport.equalsFlat(a.register, b.register, lenientXmlBlobs);
   }
 
   private static ChangeMask subsystemMask(MdObjectPropertiesDto baseline, MdObjectPropertiesDto incoming) {

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesDiff.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesDiff.java
@@ -562,7 +562,8 @@ public final class MdObjectPropertiesDiff {
       MdNamedPropertyDto y = b.get(i);
       if (!Objects.equals(x.name, y.name)
         || !Objects.equals(x.synonymRu, y.synonymRu)
-        || !Objects.equals(x.comment, y.comment)) {
+        || !Objects.equals(x.comment, y.comment)
+        || !MdFlatDtoSupport.equalsFlat(x.type, y.type, false)) {
         return false;
       }
     }

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesDto.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesDto.java
@@ -39,6 +39,12 @@ public final class MdObjectPropertiesDto {
   public MdCatalogPropertiesDto catalog;
   /** Поля {@code DocumentProperties} для {@code kind=document}; иначе {@code null}. */
   public MdDocumentPropertiesDto document;
+  /** Поля {@code EnumProperties} для {@code kind=enum}; иначе {@code null}. */
+  public MdEnumPropertiesDto enumeration;
+  /** Поля {@code ConstantProperties} для {@code kind=constant}; иначе {@code null}. */
+  public MdConstantPropertiesDto constant;
+  /** Поля {@code CommonModuleProperties} для {@code kind=commonModule}; иначе {@code null}. */
+  public MdCommonModulePropertiesDto commonModule;
 
   public MdObjectPropertiesDto() {
     this.attributes = new ArrayList<>();

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesDto.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesDto.java
@@ -31,6 +31,10 @@ public final class MdObjectPropertiesDto {
   public List<MdNamedPropertyDto> tabularSections;
   /** Значения перечисления (только для kind=enum). */
   public List<MdNamedPropertyDto> enumValues;
+  /** Измерения регистра. */
+  public List<MdNamedPropertyDto> dimensions;
+  /** Ресурсы регистра. */
+  public List<MdNamedPropertyDto> resources;
   /** Подсистемы, вложенные в данную (только для kind=subsystem). */
   public List<String> nestedSubsystems;
   /**
@@ -57,6 +61,8 @@ public final class MdObjectPropertiesDto {
     this.attributes = new ArrayList<>();
     this.tabularSections = new ArrayList<>();
     this.enumValues = new ArrayList<>();
+    this.dimensions = new ArrayList<>();
+    this.resources = new ArrayList<>();
     this.nestedSubsystems = new ArrayList<>();
     this.contentRefs = new ArrayList<>();
   }

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesDto.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesDto.java
@@ -29,6 +29,8 @@ public final class MdObjectPropertiesDto {
   public String comment;
   public List<MdNamedPropertyDto> attributes;
   public List<MdNamedPropertyDto> tabularSections;
+  /** Значения перечисления (только для kind=enum). */
+  public List<MdNamedPropertyDto> enumValues;
   /** Подсистемы, вложенные в данную (только для kind=subsystem). */
   public List<String> nestedSubsystems;
   /**
@@ -49,6 +51,7 @@ public final class MdObjectPropertiesDto {
   public MdObjectPropertiesDto() {
     this.attributes = new ArrayList<>();
     this.tabularSections = new ArrayList<>();
+    this.enumValues = new ArrayList<>();
     this.nestedSubsystems = new ArrayList<>();
     this.contentRefs = new ArrayList<>();
   }

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesDto.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesDto.java
@@ -19,7 +19,7 @@ import java.util.List;
  * {@code chartOfCalculationTypes} | {@code commonModule} | {@code subsystem} | {@code sessionParameter} |
  * {@code exchangePlan} | {@code commonAttribute} | {@code commonPicture} | {@code documentNumerator} |
  * {@code externalDataSource} | {@code role} | {@code eventSubscription} | {@code scheduledJob} |
- * {@code commonCommand}.
+ * {@code commonCommand} | {@code informationRegister} | {@code accumulationRegister}.
  */
 public final class MdObjectPropertiesDto {
 
@@ -47,6 +47,11 @@ public final class MdObjectPropertiesDto {
   public MdConstantPropertiesDto constant;
   /** Поля {@code CommonModuleProperties} для {@code kind=commonModule}; иначе {@code null}. */
   public MdCommonModulePropertiesDto commonModule;
+  /**
+   * Поля регистра для {@code kind=informationRegister} и {@code kind=accumulationRegister};
+   * иначе {@code null}.
+   */
+  public MdRegisterPropertiesDto register;
 
   public MdObjectPropertiesDto() {
     this.attributes = new ArrayList<>();

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesEdit.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesEdit.java
@@ -95,6 +95,9 @@ public final class MdObjectPropertiesEdit {
     if (dto.tabularSections == null) {
       dto.tabularSections = new ArrayList<>();
     }
+    if (dto.enumValues == null) {
+      dto.enumValues = new ArrayList<>();
+    }
     if (dto.nestedSubsystems == null) {
       dto.nestedSubsystems = new ArrayList<>();
     }
@@ -381,7 +384,10 @@ public final class MdObjectPropertiesEdit {
     dto.synonymRu = readLocalStringRu(invokeNoArgOrNull(props, "getSynonym"));
     dto.comment = toStringOrEmpty(invokeNoArgOrNull(props, "getComment"));
     switch (kind) {
-      case "enum" -> MdEnumPropertiesBridge.read(version, props, dto);
+      case "enum" -> {
+        MdEnumPropertiesBridge.read(version, props, dto);
+        readEnumValues(objectNode, dto);
+      }
       case "constant" -> MdConstantPropertiesBridge.read(props, dto);
       case "commonModule" -> MdCommonModulePropertiesBridge.read(props, dto);
       default -> {
@@ -394,6 +400,7 @@ public final class MdObjectPropertiesEdit {
     Object props = invokeNoArg(objectNode, "getProperties");
     if ("enum".equals(dto.kind) && dto.enumeration != null) {
       MdEnumPropertiesBridge.apply(version, props, dto);
+      applyEnumValues(objectNode, dto);
       return;
     }
     if ("constant".equals(dto.kind) && dto.constant != null) {
@@ -411,6 +418,28 @@ public final class MdObjectPropertiesEdit {
     String syn = dto.synonymRu == null ? "" : dto.synonymRu;
     writeLocalStringRu(props, syn);
     invokeSetterString(props, "setComment", dto.comment == null ? "" : dto.comment);
+  }
+
+  private static void readEnumValues(Object objectNode, MdObjectPropertiesDto dto) {
+    Object childObjects = invokeNoArgOrNull(objectNode, "getChildObjects");
+    if (childObjects == null) {
+      return;
+    }
+    for (Object value : JaxbReflect.<Object>list(childObjects, "getEnumValue")) {
+      dto.enumValues.add(namedDto(value));
+    }
+  }
+
+  private static void applyEnumValues(Object objectNode, MdObjectPropertiesDto dto) {
+    Object childObjects = invokeNoArgOrNull(objectNode, "getChildObjects");
+    if (childObjects == null) {
+      return;
+    }
+    List<Object> values = JaxbReflect.list(childObjects, "getEnumValue");
+    validateNamed(dto.enumValues, values, "enumValue");
+    for (int i = 0; i < values.size(); i++) {
+      applyNamedDto(values.get(i), dto.enumValues.get(i), "enum value");
+    }
   }
 
   private static String readLocalStringRu(Object localString) {

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesEdit.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesEdit.java
@@ -170,7 +170,7 @@ public final class MdObjectPropertiesEdit {
     if (ep != null) {
       return readCatalogLike(ep, "exchangePlan", false, version);
     }
-    MdObjectPropertiesDto simple = tryReadSimpleKind(mdo);
+    MdObjectPropertiesDto simple = tryReadSimpleKind(mdo, version);
     if (simple != null) {
       return simple;
     }
@@ -239,7 +239,7 @@ public final class MdObjectPropertiesEdit {
 
   private static void applyDto(JAXBElement<?> je, SchemaVersion version, MdObjectPropertiesDto dto) {
     Object mdo = je.getValue();
-    if (tryApplySimpleKind(mdo, dto)) {
+    if (tryApplySimpleKind(mdo, version, dto)) {
       return;
     }
     switch (dto.kind) {
@@ -350,17 +350,17 @@ public final class MdObjectPropertiesEdit {
     }
   }
 
-  private static MdObjectPropertiesDto tryReadSimpleKind(Object metaDataObject) {
+  private static MdObjectPropertiesDto tryReadSimpleKind(Object metaDataObject, SchemaVersion version) {
     for (SimpleKindDef def : SIMPLE_KINDS) {
       Object child = invokeNoArgOrNull(metaDataObject, def.getterName);
       if (child != null) {
-        return readSimpleDto(def.kind, child);
+        return readSimpleDto(def.kind, child, version);
       }
     }
     return null;
   }
 
-  private static boolean tryApplySimpleKind(Object metaDataObject, MdObjectPropertiesDto dto) {
+  private static boolean tryApplySimpleKind(Object metaDataObject, SchemaVersion version, MdObjectPropertiesDto dto) {
     SimpleKindDef def = simpleKindByName(dto.kind);
     if (def == null) {
       return false;
@@ -369,22 +369,41 @@ public final class MdObjectPropertiesEdit {
     if (child == null) {
       throw new IllegalArgumentException("MetaDataObject is not a " + dto.kind);
     }
-    applySimpleDto(child, dto);
+    applySimpleDto(child, version, dto);
     return true;
   }
 
-  private static MdObjectPropertiesDto readSimpleDto(String kind, Object objectNode) {
+  private static MdObjectPropertiesDto readSimpleDto(String kind, Object objectNode, SchemaVersion version) {
     Object props = invokeNoArg(objectNode, "getProperties");
     MdObjectPropertiesDto dto = new MdObjectPropertiesDto();
     dto.kind = kind;
     dto.internalName = toStringOrEmpty(invokeNoArg(props, "getName"));
     dto.synonymRu = readLocalStringRu(invokeNoArgOrNull(props, "getSynonym"));
     dto.comment = toStringOrEmpty(invokeNoArgOrNull(props, "getComment"));
+    switch (kind) {
+      case "enum" -> MdEnumPropertiesBridge.read(version, props, dto);
+      case "constant" -> MdConstantPropertiesBridge.read(props, dto);
+      case "commonModule" -> MdCommonModulePropertiesBridge.read(props, dto);
+      default -> {
+      }
+    }
     return dto;
   }
 
-  private static void applySimpleDto(Object objectNode, MdObjectPropertiesDto dto) {
+  private static void applySimpleDto(Object objectNode, SchemaVersion version, MdObjectPropertiesDto dto) {
     Object props = invokeNoArg(objectNode, "getProperties");
+    if ("enum".equals(dto.kind) && dto.enumeration != null) {
+      MdEnumPropertiesBridge.apply(version, props, dto);
+      return;
+    }
+    if ("constant".equals(dto.kind) && dto.constant != null) {
+      MdConstantPropertiesBridge.apply(props, dto);
+      return;
+    }
+    if ("commonModule".equals(dto.kind) && dto.commonModule != null) {
+      MdCommonModulePropertiesBridge.apply(props, dto);
+      return;
+    }
     String currentName = toStringOrEmpty(invokeNoArg(props, "getName"));
     if (!dto.internalName.equals(currentName)) {
       throw new IllegalArgumentException("internalName mismatch with XML");

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesEdit.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesEdit.java
@@ -223,10 +223,13 @@ public final class MdObjectPropertiesEdit {
   private static MdNamedPropertyDto namedDto(Object attrOrSection) {
     Object p = JaxbReflect.get(attrOrSection, "getProperties");
     String comment = JaxbReflect.getString(p, "getComment");
-    return new MdNamedPropertyDto(
+    MdNamedPropertyDto dto = new MdNamedPropertyDto(
       JaxbReflect.getString(p, "getName"),
       LocalStringSync.firstRu(JaxbReflect.get(p, "getSynonym")),
       comment == null ? "" : comment);
+    // У табличной части и значения перечисления типа нет — getType вернёт null.
+    dto.type = MdTypeDescriptionBridge.read(JaxbReflect.getOptional(p, "getType"));
+    return dto;
   }
 
   private static MdObjectPropertiesDto readSubsystem(Object sub) {
@@ -326,6 +329,9 @@ public final class MdObjectPropertiesEdit {
     Object p = JaxbReflect.get(node, "getProperties");
     if (d == null || d.name == null || !d.name.equals(JaxbReflect.getString(p, "getName"))) {
       throw new IllegalArgumentException(label + " name mismatch");
+    }
+    if (d.type != null) {
+      MdTypeDescriptionBridge.apply(JaxbReflect.ensureOptional(p, "getType", "setType"), d.type);
     }
     String syn = d.synonymRu == null ? "" : d.synonymRu;
     LocalStringSync.setOrPutRu(JaxbReflect.get(p, "getSynonym"), syn);

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesEdit.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesEdit.java
@@ -43,6 +43,8 @@ public final class MdObjectPropertiesEdit {
     new SimpleKindDef("chartOfCharacteristicTypes", "getChartOfCharacteristicTypes"),
     new SimpleKindDef("chartOfCalculationTypes", "getChartOfCalculationTypes"),
     new SimpleKindDef("commonModule", "getCommonModule"),
+    new SimpleKindDef("informationRegister", "getInformationRegister"),
+    new SimpleKindDef("accumulationRegister", "getAccumulationRegister"),
     new SimpleKindDef("sessionParameter", "getSessionParameter"),
     new SimpleKindDef("commonAttribute", "getCommonAttribute"),
     new SimpleKindDef("commonPicture", "getCommonPicture"),
@@ -390,6 +392,7 @@ public final class MdObjectPropertiesEdit {
       }
       case "constant" -> MdConstantPropertiesBridge.read(props, dto);
       case "commonModule" -> MdCommonModulePropertiesBridge.read(props, dto);
+      case "informationRegister", "accumulationRegister" -> MdRegisterPropertiesBridge.read(version, props, dto);
       default -> {
       }
     }
@@ -409,6 +412,10 @@ public final class MdObjectPropertiesEdit {
     }
     if ("commonModule".equals(dto.kind) && dto.commonModule != null) {
       MdCommonModulePropertiesBridge.apply(props, dto);
+      return;
+    }
+    if (("informationRegister".equals(dto.kind) || "accumulationRegister".equals(dto.kind)) && dto.register != null) {
+      MdRegisterPropertiesBridge.apply(version, props, dto);
       return;
     }
     String currentName = toStringOrEmpty(invokeNoArg(props, "getName"));

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesEdit.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesEdit.java
@@ -100,6 +100,12 @@ public final class MdObjectPropertiesEdit {
     if (dto.enumValues == null) {
       dto.enumValues = new ArrayList<>();
     }
+    if (dto.dimensions == null) {
+      dto.dimensions = new ArrayList<>();
+    }
+    if (dto.resources == null) {
+      dto.resources = new ArrayList<>();
+    }
     if (dto.nestedSubsystems == null) {
       dto.nestedSubsystems = new ArrayList<>();
     }
@@ -392,7 +398,10 @@ public final class MdObjectPropertiesEdit {
       }
       case "constant" -> MdConstantPropertiesBridge.read(props, dto);
       case "commonModule" -> MdCommonModulePropertiesBridge.read(props, dto);
-      case "informationRegister", "accumulationRegister" -> MdRegisterPropertiesBridge.read(version, props, dto);
+      case "informationRegister", "accumulationRegister" -> {
+        MdRegisterPropertiesBridge.read(version, props, dto);
+        readRegisterChildren(objectNode, dto);
+      }
       default -> {
       }
     }
@@ -416,6 +425,7 @@ public final class MdObjectPropertiesEdit {
     }
     if (("informationRegister".equals(dto.kind) || "accumulationRegister".equals(dto.kind)) && dto.register != null) {
       MdRegisterPropertiesBridge.apply(version, props, dto);
+      applyRegisterChildren(objectNode, dto);
       return;
     }
     String currentName = toStringOrEmpty(invokeNoArg(props, "getName"));
@@ -425,6 +435,39 @@ public final class MdObjectPropertiesEdit {
     String syn = dto.synonymRu == null ? "" : dto.synonymRu;
     writeLocalStringRu(props, syn);
     invokeSetterString(props, "setComment", dto.comment == null ? "" : dto.comment);
+  }
+
+  private static void readRegisterChildren(Object objectNode, MdObjectPropertiesDto dto) {
+    Object childObjects = invokeNoArgOrNull(objectNode, "getChildObjects");
+    if (childObjects == null) {
+      return;
+    }
+    for (Object dimension : JaxbReflect.<Object>list(childObjects, "getDimension")) {
+      dto.dimensions.add(namedDto(dimension));
+    }
+    for (Object resource : JaxbReflect.<Object>list(childObjects, "getResource")) {
+      dto.resources.add(namedDto(resource));
+    }
+    for (Object attribute : JaxbReflect.<Object>list(childObjects, "getAttribute")) {
+      dto.attributes.add(namedDto(attribute));
+    }
+  }
+
+  private static void applyRegisterChildren(Object objectNode, MdObjectPropertiesDto dto) {
+    Object childObjects = invokeNoArgOrNull(objectNode, "getChildObjects");
+    if (childObjects == null) {
+      return;
+    }
+    applyNamedList(JaxbReflect.list(childObjects, "getDimension"), dto.dimensions, "dimension");
+    applyNamedList(JaxbReflect.list(childObjects, "getResource"), dto.resources, "resource");
+    applyNamedList(JaxbReflect.list(childObjects, "getAttribute"), dto.attributes, "attribute");
+  }
+
+  private static void applyNamedList(List<Object> nodes, List<MdNamedPropertyDto> dtos, String label) {
+    validateNamed(dtos, nodes, label);
+    for (int i = 0; i < nodes.size(); i++) {
+      applyNamedDto(nodes.get(i), dtos.get(i), label);
+    }
   }
 
   private static void readEnumValues(Object objectNode, MdObjectPropertiesDto dto) {

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesGranularPatch.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesGranularPatch.java
@@ -174,6 +174,8 @@ public final class MdObjectPropertiesGranularPatch {
       case "chartOfCharacteristicTypes" -> "ChartOfCharacteristicTypes";
       case "chartOfCalculationTypes" -> "ChartOfCalculationTypes";
       case "commonModule" -> "CommonModule";
+      case "informationRegister" -> "InformationRegister";
+      case "accumulationRegister" -> "AccumulationRegister";
       case "exchangePlan" -> "ExchangePlan";
       case "subsystem" -> "Subsystem";
       case "sessionParameter" -> "SessionParameter";

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesJsonCoalesce.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesJsonCoalesce.java
@@ -39,6 +39,9 @@ public final class MdObjectPropertiesJsonCoalesce {
     if (incoming.tabularSections == null || incoming.tabularSections.isEmpty()) {
       incoming.tabularSections = copyNamedList(baseline.tabularSections);
     }
+    if (incoming.enumValues == null || incoming.enumValues.isEmpty()) {
+      incoming.enumValues = copyNamedList(baseline.enumValues);
+    }
     if (incoming.nestedSubsystems == null) {
       incoming.nestedSubsystems = baseline.nestedSubsystems == null
         ? new ArrayList<>()

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesJsonCoalesce.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesJsonCoalesce.java
@@ -76,6 +76,22 @@ public final class MdObjectPropertiesJsonCoalesce {
     if ("commonModule".equals(incoming.kind) && baseline.commonModule != null) {
       incoming.commonModule = coalesceFlat(incoming.commonModule, baseline.commonModule);
     }
+    if (isRegisterKind(incoming.kind) && baseline.register != null) {
+      incoming.register = coalesceFlat(incoming.register, baseline.register);
+      canonicalizeRegisterXmlBlobsFromBaselineIfLooseEqual(incoming.register, baseline.register);
+    }
+  }
+
+  static boolean isRegisterKind(String kind) {
+    return "informationRegister".equals(kind) || "accumulationRegister".equals(kind);
+  }
+
+  private static void canonicalizeRegisterXmlBlobsFromBaselineIfLooseEqual(
+    MdRegisterPropertiesDto d,
+    MdRegisterPropertiesDto b) {
+    if (MdObjectPropertiesDiff.looseXmlBlobEquals(d.standardAttributesXml, b.standardAttributesXml)) {
+      d.standardAttributesXml = b.standardAttributesXml;
+    }
   }
 
   private static <T> T coalesceFlat(T incoming, T baseline) {

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesJsonCoalesce.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesJsonCoalesce.java
@@ -42,6 +42,12 @@ public final class MdObjectPropertiesJsonCoalesce {
     if (incoming.enumValues == null || incoming.enumValues.isEmpty()) {
       incoming.enumValues = copyNamedList(baseline.enumValues);
     }
+    if (incoming.dimensions == null || incoming.dimensions.isEmpty()) {
+      incoming.dimensions = copyNamedList(baseline.dimensions);
+    }
+    if (incoming.resources == null || incoming.resources.isEmpty()) {
+      incoming.resources = copyNamedList(baseline.resources);
+    }
     if (incoming.nestedSubsystems == null) {
       incoming.nestedSubsystems = baseline.nestedSubsystems == null
         ? new ArrayList<>()

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesJsonCoalesce.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesJsonCoalesce.java
@@ -63,6 +63,39 @@ public final class MdObjectPropertiesJsonCoalesce {
         coalesceDocument(incoming.document, baseline.document);
       }
     }
+    if ("enum".equals(incoming.kind) && baseline.enumeration != null) {
+      incoming.enumeration = coalesceFlat(incoming.enumeration, baseline.enumeration);
+      canonicalizeEnumXmlBlobsFromBaselineIfLooseEqual(incoming.enumeration, baseline.enumeration);
+    }
+    if ("constant".equals(incoming.kind) && baseline.constant != null) {
+      incoming.constant = coalesceFlat(incoming.constant, baseline.constant);
+    }
+    if ("commonModule".equals(incoming.kind) && baseline.commonModule != null) {
+      incoming.commonModule = coalesceFlat(incoming.commonModule, baseline.commonModule);
+    }
+  }
+
+  private static <T> T coalesceFlat(T incoming, T baseline) {
+    if (incoming == null) {
+      return MdFlatDtoSupport.copy(baseline);
+    }
+    MdFlatDtoSupport.coalesce(incoming, baseline);
+    return incoming;
+  }
+
+  /**
+   * Блобы, отличающиеся только префиксами пространств имён, берём из базовой версии: иначе точечная
+   * запись сочла бы их изменёнными.
+   */
+  private static void canonicalizeEnumXmlBlobsFromBaselineIfLooseEqual(
+    MdEnumPropertiesDto d,
+    MdEnumPropertiesDto b) {
+    if (MdObjectPropertiesDiff.looseXmlBlobEquals(d.standardAttributesXml, b.standardAttributesXml)) {
+      d.standardAttributesXml = b.standardAttributesXml;
+    }
+    if (MdObjectPropertiesDiff.looseXmlBlobEquals(d.characteristicsXml, b.characteristicsXml)) {
+      d.characteristicsXml = b.characteristicsXml;
+    }
   }
 
   private static MdDocumentPropertiesDto copyDocumentFull(MdDocumentPropertiesDto s) {

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesLeafDiff.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesLeafDiff.java
@@ -84,6 +84,7 @@ public final class MdObjectPropertiesLeafDiff {
       case "enum" -> enumPropertyChanges(baseline, incoming);
       case "constant" -> constantPropertyChanges(baseline, incoming);
       case "commonModule" -> commonModulePropertyChanges(baseline, incoming);
+      case "informationRegister", "accumulationRegister" -> registerPropertyChanges(baseline, incoming);
       case "report", "dataProcessor", "task", "chartOfAccounts",
            "chartOfCharacteristicTypes", "chartOfCalculationTypes",
            "sessionParameter", "commonAttribute", "commonPicture", "documentNumerator",
@@ -124,6 +125,17 @@ public final class MdObjectPropertiesLeafDiff {
     List<GranularPatchChange> out = docLikePropertyChanges(baseline, incoming);
     MdSimplePropertiesGranularSerial.appendCommonModuleScalarChanges(
       baseline.commonModule, incoming.commonModule, out);
+    return out;
+  }
+
+  private static List<GranularPatchChange> registerPropertyChanges(
+    MdObjectPropertiesDto baseline,
+    MdObjectPropertiesDto incoming) {
+    if (baseline.register == null || incoming.register == null) {
+      return docLikePropertyChanges(baseline, incoming);
+    }
+    List<GranularPatchChange> out = docLikePropertyChanges(baseline, incoming);
+    MdSimplePropertiesGranularSerial.appendRegisterScalarChanges(baseline.register, incoming.register, out);
     return out;
   }
 

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesLeafDiff.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesLeafDiff.java
@@ -65,7 +65,8 @@ public final class MdObjectPropertiesLeafDiff {
       return List.of();
     }
     if (!namedListSameStructure(baseline.attributes, incoming.attributes)
-      || !namedListSameStructure(baseline.tabularSections, incoming.tabularSections)) {
+      || !namedListSameStructure(baseline.tabularSections, incoming.tabularSections)
+      || !namedListSameStructure(baseline.enumValues, incoming.enumValues)) {
       return List.of();
     }
     if (!MdObjectPropertiesDiff.listStringEquals(baseline.nestedSubsystems, incoming.nestedSubsystems)) {
@@ -99,6 +100,7 @@ public final class MdObjectPropertiesLeafDiff {
     }
     List<GranularPatchChange> out = docLikePropertyChanges(baseline, incoming);
     MdSimplePropertiesGranularSerial.appendEnumScalarChanges(baseline.enumeration, incoming.enumeration, out);
+    appendNamedChildSynonymComment("EnumValue", baseline.enumValues, incoming.enumValues, out);
     return out;
   }
 

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesLeafDiff.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesLeafDiff.java
@@ -66,7 +66,9 @@ public final class MdObjectPropertiesLeafDiff {
     }
     if (!namedListSameStructure(baseline.attributes, incoming.attributes)
       || !namedListSameStructure(baseline.tabularSections, incoming.tabularSections)
-      || !namedListSameStructure(baseline.enumValues, incoming.enumValues)) {
+      || !namedListSameStructure(baseline.enumValues, incoming.enumValues)
+      || !namedListSameStructure(baseline.dimensions, incoming.dimensions)
+      || !namedListSameStructure(baseline.resources, incoming.resources)) {
       return List.of();
     }
     if (!MdObjectPropertiesDiff.listStringEquals(baseline.nestedSubsystems, incoming.nestedSubsystems)) {
@@ -136,6 +138,8 @@ public final class MdObjectPropertiesLeafDiff {
     }
     List<GranularPatchChange> out = docLikePropertyChanges(baseline, incoming);
     MdSimplePropertiesGranularSerial.appendRegisterScalarChanges(baseline.register, incoming.register, out);
+    appendNamedChildSynonymComment("Dimension", baseline.dimensions, incoming.dimensions, out);
+    appendNamedChildSynonymComment("Resource", baseline.resources, incoming.resources, out);
     return out;
   }
 

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesLeafDiff.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesLeafDiff.java
@@ -80,12 +80,49 @@ public final class MdObjectPropertiesLeafDiff {
       case "catalog" -> catalogPropertyChanges(baseline, incoming);
       case "document" -> documentPropertyChanges(baseline, incoming);
       case "exchangePlan" -> docLikePropertyChanges(baseline, incoming);
-      case "constant", "enum", "report", "dataProcessor", "task", "chartOfAccounts",
-           "chartOfCharacteristicTypes", "chartOfCalculationTypes", "commonModule",
+      case "enum" -> enumPropertyChanges(baseline, incoming);
+      case "constant" -> constantPropertyChanges(baseline, incoming);
+      case "commonModule" -> commonModulePropertyChanges(baseline, incoming);
+      case "report", "dataProcessor", "task", "chartOfAccounts",
+           "chartOfCharacteristicTypes", "chartOfCalculationTypes",
            "sessionParameter", "commonAttribute", "commonPicture", "documentNumerator",
            "externalDataSource", "role" -> docLikePropertyChanges(baseline, incoming);
       default -> List.of();
     };
+  }
+
+  private static List<GranularPatchChange> enumPropertyChanges(
+    MdObjectPropertiesDto baseline,
+    MdObjectPropertiesDto incoming) {
+    if (baseline.enumeration == null || incoming.enumeration == null) {
+      return docLikePropertyChanges(baseline, incoming);
+    }
+    List<GranularPatchChange> out = docLikePropertyChanges(baseline, incoming);
+    MdSimplePropertiesGranularSerial.appendEnumScalarChanges(baseline.enumeration, incoming.enumeration, out);
+    return out;
+  }
+
+  private static List<GranularPatchChange> constantPropertyChanges(
+    MdObjectPropertiesDto baseline,
+    MdObjectPropertiesDto incoming) {
+    if (baseline.constant == null || incoming.constant == null) {
+      return docLikePropertyChanges(baseline, incoming);
+    }
+    List<GranularPatchChange> out = docLikePropertyChanges(baseline, incoming);
+    MdSimplePropertiesGranularSerial.appendConstantScalarChanges(baseline.constant, incoming.constant, out);
+    return out;
+  }
+
+  private static List<GranularPatchChange> commonModulePropertyChanges(
+    MdObjectPropertiesDto baseline,
+    MdObjectPropertiesDto incoming) {
+    if (baseline.commonModule == null || incoming.commonModule == null) {
+      return docLikePropertyChanges(baseline, incoming);
+    }
+    List<GranularPatchChange> out = docLikePropertyChanges(baseline, incoming);
+    MdSimplePropertiesGranularSerial.appendCommonModuleScalarChanges(
+      baseline.commonModule, incoming.commonModule, out);
+    return out;
   }
 
   /** Тот же состав имён и порядок; допускаются отличия synonym/comment. */

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesLeafDiff.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesLeafDiff.java
@@ -192,6 +192,13 @@ public final class MdObjectPropertiesLeafDiff {
           "Comment",
           MdCatalogPropertiesGranularSerial.commentElement(y.comment)));
       }
+      if (!MdFlatDtoSupport.equalsFlat(x.type, y.type, false)) {
+        out.add(GranularPatchChange.namedChild(
+          childContainerLocal,
+          y.name,
+          "Type",
+          MdTypeDescriptionSerial.typeElement("Type", y.type)));
+      }
     }
   }
 

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdPropertiesBridgeSupport.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdPropertiesBridgeSupport.java
@@ -1,0 +1,68 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+import io.github.yellowhammer.designerxml.SchemaVersion;
+import io.github.yellowhammer.designerxml.reflect.JaxbReflect;
+
+import jakarta.xml.bind.JAXBException;
+
+/**
+ * Общие приёмы чтения и записи {@code *Properties} через JAXB-рефлексию.
+ */
+final class MdPropertiesBridgeSupport {
+
+  private MdPropertiesBridgeSupport() {
+  }
+
+  /** Поддерево стандартных реквизитов как XML; пустая строка, если версия схемы его не знает. */
+  static String marshalStandardAttributesOrEmpty(SchemaVersion version, Object value) {
+    try {
+      return MdCfCatalogSubtreeXml.marshalStandardAttributes(version, value);
+    } catch (JAXBException e) {
+      return "";
+    }
+  }
+
+  /** Поддерево характеристик как XML; пустая строка, если версия схемы его не знает. */
+  static String marshalCharacteristicsOrEmpty(SchemaVersion version, Object value) {
+    try {
+      return MdCfCatalogSubtreeXml.marshalCharacteristics(version, value);
+    } catch (JAXBException e) {
+      return "";
+    }
+  }
+
+  /** Значение перечисления как имя Java-константы ({@code AUTO}); {@code null}, если элемента нет. */
+  static String enumName(Object properties, String getter) {
+    Object value = JaxbReflect.getOptional(properties, getter);
+    return value == null ? null : ((Enum<?>) value).name();
+  }
+
+  /** Создаёт локализованную строку, если её ещё нет, и кладёт русское содержимое. */
+  static void ensureAndSetRu(Object properties, String getter, String setter, String ru) {
+    Object localString = JaxbReflect.ensureOptional(properties, getter, setter);
+    LocalStringSync.setOrPutRu(localString, ru == null ? "" : ru);
+  }
+
+  static String nullIfBlank(String value) {
+    return value == null || value.isBlank() ? null : value;
+  }
+
+  /** Проверяет, что DTO относится к тому же объекту, и пишет общие для всех видов свойства. */
+  static void applyCommon(Object properties, MdObjectPropertiesDto dto) {
+    if (!dto.internalName.equals(JaxbReflect.getStringOptional(properties, "getName"))) {
+      throw new IllegalArgumentException("internalName mismatch with XML");
+    }
+    LocalStringSync.setOrPutRu(
+      JaxbReflect.getOptional(properties, "getSynonym"),
+      dto.synonymRu == null ? "" : dto.synonymRu);
+    JaxbReflect.setOptional(properties, "setComment", dto.comment == null ? "" : dto.comment);
+  }
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdPropertiesGranularChanges.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdPropertiesGranularChanges.java
@@ -1,0 +1,71 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Накопление точечных замен прямых дочерних элементов {@code Properties}: по строке на свойство.
+ * Замена добавляется, только если значение изменилось.
+ */
+final class MdPropertiesGranularChanges {
+
+  private final List<MdObjectPropertiesLeafDiff.GranularPatchChange> out;
+
+  MdPropertiesGranularChanges(List<MdObjectPropertiesLeafDiff.GranularPatchChange> out) {
+    this.out = out;
+  }
+
+  void text(String localName, String baseline, String incoming) {
+    if (!Objects.equals(baseline, incoming)) {
+      add(localName, MdCatalogPropertiesGranularSerial.textElement(
+        localName, MdCatalogPropertiesGranularSerial.nz(incoming)));
+    }
+  }
+
+  /** Значение — имя Java-константы ({@code AUTO}), в XML уходит как {@code Auto}. */
+  void enumText(String localName, String baseline, String incoming) {
+    if (!Objects.equals(baseline, incoming)) {
+      add(localName, MdCatalogPropertiesGranularSerial.enumTextElement(
+        localName, MdCatalogPropertiesGranularSerial.nz(incoming)));
+    }
+  }
+
+  void bool(String localName, boolean baseline, boolean incoming) {
+    if (baseline != incoming) {
+      add(localName, MdCatalogPropertiesGranularSerial.boolElement(localName, incoming));
+    }
+  }
+
+  void localStringRu(String localName, String baseline, String incoming) {
+    if (!Objects.equals(baseline, incoming)) {
+      add(localName, MdCatalogPropertiesGranularSerial.localStringRuElement(localName, incoming));
+    }
+  }
+
+  void refs(String localName, List<String> baseline, List<String> incoming) {
+    if (!MdObjectPropertiesDiff.listStringEquals(baseline, incoming)) {
+      add(localName, MdCatalogPropertiesGranularSerial.mdListTypeRefsElement(localName, incoming));
+    }
+  }
+
+  /** Поддерево, которое расширение не разбирает: пишем как есть либо пустым элементом. */
+  void xmlBlob(String localName, String baseline, String incoming) {
+    if (MdObjectPropertiesDiff.looseXmlBlobEquals(baseline, incoming)) {
+      return;
+    }
+    String xml = incoming == null ? "" : incoming.trim();
+    add(localName, xml.isEmpty() ? "<" + localName + "/>" : xml);
+  }
+
+  private void add(String localName, String elementXml) {
+    out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(localName, elementXml));
+  }
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdRegisterPropertiesBridge.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdRegisterPropertiesBridge.java
@@ -1,0 +1,128 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+import io.github.yellowhammer.designerxml.SchemaVersion;
+import io.github.yellowhammer.designerxml.reflect.JaxbReflect;
+
+import jakarta.xml.bind.JAXBException;
+
+import static io.github.yellowhammer.designerxml.cf.MdPropertiesBridgeSupport.enumName;
+import static io.github.yellowhammer.designerxml.cf.MdPropertiesBridgeSupport.ensureAndSetRu;
+import static io.github.yellowhammer.designerxml.cf.MdPropertiesBridgeSupport.nullIfBlank;
+
+/**
+ * Чтение и запись свойств регистров сведений и накопления через JAXB-рефлексию.
+ *
+ * <p>Поля, которых нет у вида регистра, {@code JaxbReflect} молча пропускает: у регистра
+ * накопления нет периодичности, у регистра сведений — вида регистра.
+ */
+public final class MdRegisterPropertiesBridge {
+
+  private MdRegisterPropertiesBridge() {
+  }
+
+  public static void read(SchemaVersion version, Object p, MdObjectPropertiesDto dto) {
+    MdRegisterPropertiesDto d = new MdRegisterPropertiesDto();
+    d.objectBelonging = enumName(p, "getObjectBelonging");
+    d.extendedConfigurationObject = nullIfBlank(JaxbReflect.getStringOptional(p, "getExtendedConfigurationObject"));
+    d.useStandardCommands = JaxbReflect.getBooleanOptional(p, "isUseStandardCommands");
+    d.standardAttributesXml = MdPropertiesBridgeSupport.marshalStandardAttributesOrEmpty(
+      version, JaxbReflect.getOptional(p, "getStandardAttributes"));
+    d.defaultListForm = JaxbReflect.getStringOptional(p, "getDefaultListForm");
+    d.auxiliaryListForm = JaxbReflect.getStringOptional(p, "getAuxiliaryListForm");
+    d.includeHelpInContents = JaxbReflect.getBooleanOptional(p, "isIncludeHelpInContents");
+    d.help = JaxbReflect.getStringOptional(p, "getHelp");
+    d.recordSetModule = JaxbReflect.getStringOptional(p, "getRecordSetModule");
+    d.managerModule = JaxbReflect.getStringOptional(p, "getManagerModule");
+    d.dataLockControlMode = enumName(p, "getDataLockControlMode");
+    d.fullTextSearch = enumName(p, "getFullTextSearch");
+    d.listPresentationRu = LocalStringSync.firstRu(JaxbReflect.getOptional(p, "getListPresentation"));
+    d.extendedListPresentationRu = LocalStringSync.firstRu(JaxbReflect.getOptional(p, "getExtendedListPresentation"));
+    d.explanationRu = LocalStringSync.firstRu(JaxbReflect.getOptional(p, "getExplanation"));
+    d.additionalIndexes = JaxbReflect.getStringOptional(p, "getAdditionalIndexes");
+
+    d.editType = enumName(p, "getEditType");
+    d.defaultRecordForm = JaxbReflect.getStringOptional(p, "getDefaultRecordForm");
+    d.auxiliaryRecordForm = JaxbReflect.getStringOptional(p, "getAuxiliaryRecordForm");
+    d.informationRegisterPeriodicity = enumName(p, "getInformationRegisterPeriodicity");
+    d.writeMode = enumName(p, "getWriteMode");
+    d.mainFilterOnPeriod = JaxbReflect.getBooleanOptional(p, "isMainFilterOnPeriod");
+    d.enableTotalsSliceFirst = JaxbReflect.getBooleanOptional(p, "isEnableTotalsSliceFirst");
+    d.enableTotalsSliceLast = JaxbReflect.getBooleanOptional(p, "isEnableTotalsSliceLast");
+    d.recordPresentationRu = LocalStringSync.firstRu(JaxbReflect.getOptional(p, "getRecordPresentation"));
+    d.extendedRecordPresentationRu =
+      LocalStringSync.firstRu(JaxbReflect.getOptional(p, "getExtendedRecordPresentation"));
+    d.dataHistory = enumName(p, "getDataHistory");
+    d.updateDataHistoryImmediatelyAfterWrite =
+      JaxbReflect.getBooleanOptional(p, "isUpdateDataHistoryImmediatelyAfterWrite");
+    d.executeAfterWriteDataHistoryVersionProcessing =
+      JaxbReflect.getBooleanOptional(p, "isExecuteAfterWriteDataHistoryVersionProcessing");
+
+    d.registerType = enumName(p, "getRegisterType");
+    d.enableTotalsSplitting = JaxbReflect.getBooleanOptional(p, "isEnableTotalsSplitting");
+    d.aggregates = JaxbReflect.getStringOptional(p, "getAggregates");
+    dto.register = d;
+  }
+
+  public static void apply(SchemaVersion version, Object p, MdObjectPropertiesDto dto) {
+    MdRegisterPropertiesDto d = dto.register;
+    if (d == null) {
+      throw new IllegalArgumentException("register required");
+    }
+    MdPropertiesBridgeSupport.applyCommon(p, dto);
+    JaxbReflect.setEnumOrKeep(p, "setObjectBelonging", d.objectBelonging);
+    JaxbReflect.setOptional(p, "setExtendedConfigurationObject", nullIfBlank(d.extendedConfigurationObject));
+    JaxbReflect.setOptional(p, "setUseStandardCommands", d.useStandardCommands);
+    applyStandardAttributes(version, p, d);
+    JaxbReflect.setOptional(p, "setDefaultListForm", d.defaultListForm);
+    JaxbReflect.setOptional(p, "setAuxiliaryListForm", d.auxiliaryListForm);
+    JaxbReflect.setOptional(p, "setIncludeHelpInContents", d.includeHelpInContents);
+    JaxbReflect.setOptional(p, "setHelp", d.help);
+    JaxbReflect.setOptional(p, "setRecordSetModule", d.recordSetModule);
+    JaxbReflect.setOptional(p, "setManagerModule", d.managerModule);
+    JaxbReflect.setEnumOrKeep(p, "setDataLockControlMode", d.dataLockControlMode);
+    JaxbReflect.setEnumOrKeep(p, "setFullTextSearch", d.fullTextSearch);
+    ensureAndSetRu(p, "getListPresentation", "setListPresentation", d.listPresentationRu);
+    ensureAndSetRu(p, "getExtendedListPresentation", "setExtendedListPresentation", d.extendedListPresentationRu);
+    ensureAndSetRu(p, "getExplanation", "setExplanation", d.explanationRu);
+    JaxbReflect.setOptional(p, "setAdditionalIndexes", d.additionalIndexes);
+
+    JaxbReflect.setEnumOrKeep(p, "setEditType", d.editType);
+    JaxbReflect.setOptional(p, "setDefaultRecordForm", d.defaultRecordForm);
+    JaxbReflect.setOptional(p, "setAuxiliaryRecordForm", d.auxiliaryRecordForm);
+    JaxbReflect.setEnumOrKeep(p, "setInformationRegisterPeriodicity", d.informationRegisterPeriodicity);
+    JaxbReflect.setEnumOrKeep(p, "setWriteMode", d.writeMode);
+    JaxbReflect.setOptional(p, "setMainFilterOnPeriod", d.mainFilterOnPeriod);
+    JaxbReflect.setOptional(p, "setEnableTotalsSliceFirst", d.enableTotalsSliceFirst);
+    JaxbReflect.setOptional(p, "setEnableTotalsSliceLast", d.enableTotalsSliceLast);
+    ensureAndSetRu(p, "getRecordPresentation", "setRecordPresentation", d.recordPresentationRu);
+    ensureAndSetRu(p, "getExtendedRecordPresentation", "setExtendedRecordPresentation", d.extendedRecordPresentationRu);
+    JaxbReflect.setEnumOrKeep(p, "setDataHistory", d.dataHistory);
+    JaxbReflect.setOptional(p, "setUpdateDataHistoryImmediatelyAfterWrite", d.updateDataHistoryImmediatelyAfterWrite);
+    JaxbReflect.setOptional(p, "setExecuteAfterWriteDataHistoryVersionProcessing",
+      d.executeAfterWriteDataHistoryVersionProcessing);
+
+    JaxbReflect.setEnumOrKeep(p, "setRegisterType", d.registerType);
+    JaxbReflect.setOptional(p, "setEnableTotalsSplitting", d.enableTotalsSplitting);
+    JaxbReflect.setOptional(p, "setAggregates", d.aggregates);
+  }
+
+  private static void applyStandardAttributes(SchemaVersion version, Object p, MdRegisterPropertiesDto d) {
+    if (d.standardAttributesXml == null || d.standardAttributesXml.isBlank()) {
+      return;
+    }
+    try {
+      JaxbReflect.setOptional(p, "setStandardAttributes",
+        MdCfCatalogSubtreeXml.unmarshalStandardAttributes(version, d.standardAttributesXml.trim()));
+    } catch (JAXBException e) {
+      throw new IllegalArgumentException("standardAttributesXml: " + e.getMessage(), e);
+    }
+  }
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdRegisterPropertiesDto.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdRegisterPropertiesDto.java
@@ -1,0 +1,60 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+/**
+ * Поля {@code InformationRegisterProperties} и {@code AccumulationRegisterProperties} для
+ * {@code cf-md-object-get/set} ({@code kind=informationRegister} и {@code kind=accumulationRegister}).
+ *
+ * <p>Виды регистров различаются лишь частью полей, поэтому DTO один: у регистра сведений пусты
+ * поля оборотного регистра и наоборот. Enum-значения — имена Java-констант ({@code NONPERIODICAL},
+ * {@code BALANCE}).
+ */
+public final class MdRegisterPropertiesDto {
+
+  public String objectBelonging;
+  public String extendedConfigurationObject;
+  public boolean useStandardCommands;
+  public String standardAttributesXml;
+  public String defaultListForm;
+  public String auxiliaryListForm;
+  public boolean includeHelpInContents;
+  public String help;
+  public String recordSetModule;
+  public String managerModule;
+  public String dataLockControlMode;
+  public String fullTextSearch;
+  public String listPresentationRu;
+  public String extendedListPresentationRu;
+  public String explanationRu;
+  public String additionalIndexes;
+
+  // Регистр сведений
+  /** Способ редактирования: в списке, в диалоге, обоими способами. */
+  public String editType;
+  public String defaultRecordForm;
+  public String auxiliaryRecordForm;
+  public String informationRegisterPeriodicity;
+  /** Режим записи: независимый либо подчинённый регистратору. */
+  public String writeMode;
+  public boolean mainFilterOnPeriod;
+  public boolean enableTotalsSliceFirst;
+  public boolean enableTotalsSliceLast;
+  public String recordPresentationRu;
+  public String extendedRecordPresentationRu;
+  public String dataHistory;
+  public boolean updateDataHistoryImmediatelyAfterWrite;
+  public boolean executeAfterWriteDataHistoryVersionProcessing;
+
+  // Регистр накопления
+  /** Вид регистра: остатки либо обороты. */
+  public String registerType;
+  public boolean enableTotalsSplitting;
+  public String aggregates;
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdSimplePropertiesGranularSerial.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdSimplePropertiesGranularSerial.java
@@ -46,6 +46,10 @@ final class MdSimplePropertiesGranularSerial {
     List<MdObjectPropertiesLeafDiff.GranularPatchChange> out) {
     MdPropertiesGranularChanges c = new MdPropertiesGranularChanges(out);
     c.enumText("ObjectBelonging", b.objectBelonging, i.objectBelonging);
+    if (!MdFlatDtoSupport.equalsFlat(b.type, i.type, false)) {
+      out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
+        "Type", MdTypeDescriptionSerial.typeElement("Type", i.type)));
+    }
     c.bool("UseStandardCommands", b.useStandardCommands, i.useStandardCommands);
     c.text("DefaultForm", b.defaultForm, i.defaultForm);
     c.localStringRu("ExtendedPresentation", b.extendedPresentationRu, i.extendedPresentationRu);

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdSimplePropertiesGranularSerial.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdSimplePropertiesGranularSerial.java
@@ -11,7 +11,8 @@ package io.github.yellowhammer.designerxml.cf;
 import java.util.List;
 
 /**
- * Точечные замены прямых дочерних элементов {@code Properties} перечисления, константы и общего модуля.
+ * Точечные замены прямых дочерних элементов {@code Properties} перечисления, константы, общего
+ * модуля и регистров.
  */
 final class MdSimplePropertiesGranularSerial {
 
@@ -75,6 +76,46 @@ final class MdSimplePropertiesGranularSerial {
       b.updateDataHistoryImmediatelyAfterWrite, i.updateDataHistoryImmediatelyAfterWrite);
     c.bool("ExecuteAfterWriteDataHistoryVersionProcessing",
       b.executeAfterWriteDataHistoryVersionProcessing, i.executeAfterWriteDataHistoryVersionProcessing);
+  }
+
+  static void appendRegisterScalarChanges(
+    MdRegisterPropertiesDto b,
+    MdRegisterPropertiesDto i,
+    List<MdObjectPropertiesLeafDiff.GranularPatchChange> out) {
+    MdPropertiesGranularChanges c = new MdPropertiesGranularChanges(out);
+    c.enumText("ObjectBelonging", b.objectBelonging, i.objectBelonging);
+    c.bool("UseStandardCommands", b.useStandardCommands, i.useStandardCommands);
+    c.enumText("EditType", b.editType, i.editType);
+    c.text("DefaultRecordForm", b.defaultRecordForm, i.defaultRecordForm);
+    c.text("DefaultListForm", b.defaultListForm, i.defaultListForm);
+    c.text("AuxiliaryRecordForm", b.auxiliaryRecordForm, i.auxiliaryRecordForm);
+    c.text("AuxiliaryListForm", b.auxiliaryListForm, i.auxiliaryListForm);
+    c.xmlBlob("StandardAttributes", b.standardAttributesXml, i.standardAttributesXml);
+    c.enumText("InformationRegisterPeriodicity", b.informationRegisterPeriodicity, i.informationRegisterPeriodicity);
+    c.enumText("WriteMode", b.writeMode, i.writeMode);
+    c.bool("MainFilterOnPeriod", b.mainFilterOnPeriod, i.mainFilterOnPeriod);
+    c.enumText("RegisterType", b.registerType, i.registerType);
+    c.bool("IncludeHelpInContents", b.includeHelpInContents, i.includeHelpInContents);
+    c.text("Help", b.help, i.help);
+    c.text("RecordSetModule", b.recordSetModule, i.recordSetModule);
+    c.text("ManagerModule", b.managerModule, i.managerModule);
+    c.enumText("DataLockControlMode", b.dataLockControlMode, i.dataLockControlMode);
+    c.enumText("FullTextSearch", b.fullTextSearch, i.fullTextSearch);
+    c.bool("EnableTotalsSliceFirst", b.enableTotalsSliceFirst, i.enableTotalsSliceFirst);
+    c.bool("EnableTotalsSliceLast", b.enableTotalsSliceLast, i.enableTotalsSliceLast);
+    c.bool("EnableTotalsSplitting", b.enableTotalsSplitting, i.enableTotalsSplitting);
+    c.text("Aggregates", b.aggregates, i.aggregates);
+    c.localStringRu("RecordPresentation", b.recordPresentationRu, i.recordPresentationRu);
+    c.localStringRu("ExtendedRecordPresentation", b.extendedRecordPresentationRu, i.extendedRecordPresentationRu);
+    c.localStringRu("ListPresentation", b.listPresentationRu, i.listPresentationRu);
+    c.localStringRu("ExtendedListPresentation", b.extendedListPresentationRu, i.extendedListPresentationRu);
+    c.localStringRu("Explanation", b.explanationRu, i.explanationRu);
+    c.enumText("DataHistory", b.dataHistory, i.dataHistory);
+    c.bool("UpdateDataHistoryImmediatelyAfterWrite",
+      b.updateDataHistoryImmediatelyAfterWrite, i.updateDataHistoryImmediatelyAfterWrite);
+    c.bool("ExecuteAfterWriteDataHistoryVersionProcessing",
+      b.executeAfterWriteDataHistoryVersionProcessing, i.executeAfterWriteDataHistoryVersionProcessing);
+    c.text("AdditionalIndexes", b.additionalIndexes, i.additionalIndexes);
   }
 
   static void appendCommonModuleScalarChanges(

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdSimplePropertiesGranularSerial.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdSimplePropertiesGranularSerial.java
@@ -1,0 +1,92 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+import java.util.List;
+
+/**
+ * Точечные замены прямых дочерних элементов {@code Properties} перечисления, константы и общего модуля.
+ */
+final class MdSimplePropertiesGranularSerial {
+
+  private MdSimplePropertiesGranularSerial() {
+  }
+
+  static void appendEnumScalarChanges(
+    MdEnumPropertiesDto b,
+    MdEnumPropertiesDto i,
+    List<MdObjectPropertiesLeafDiff.GranularPatchChange> out) {
+    MdPropertiesGranularChanges c = new MdPropertiesGranularChanges(out);
+    c.enumText("ObjectBelonging", b.objectBelonging, i.objectBelonging);
+    c.bool("UseStandardCommands", b.useStandardCommands, i.useStandardCommands);
+    c.xmlBlob("StandardAttributes", b.standardAttributesXml, i.standardAttributesXml);
+    c.xmlBlob("Characteristics", b.characteristicsXml, i.characteristicsXml);
+    c.bool("QuickChoice", b.quickChoice, i.quickChoice);
+    c.enumText("ChoiceMode", b.choiceMode, i.choiceMode);
+    c.text("DefaultListForm", b.defaultListForm, i.defaultListForm);
+    c.text("DefaultChoiceForm", b.defaultChoiceForm, i.defaultChoiceForm);
+    c.text("AuxiliaryListForm", b.auxiliaryListForm, i.auxiliaryListForm);
+    c.text("AuxiliaryChoiceForm", b.auxiliaryChoiceForm, i.auxiliaryChoiceForm);
+    c.text("ManagerModule", b.managerModule, i.managerModule);
+    c.localStringRu("ListPresentation", b.listPresentationRu, i.listPresentationRu);
+    c.localStringRu("ExtendedListPresentation", b.extendedListPresentationRu, i.extendedListPresentationRu);
+    c.localStringRu("Explanation", b.explanationRu, i.explanationRu);
+    c.enumText("ChoiceHistoryOnInput", b.choiceHistoryOnInput, i.choiceHistoryOnInput);
+  }
+
+  static void appendConstantScalarChanges(
+    MdConstantPropertiesDto b,
+    MdConstantPropertiesDto i,
+    List<MdObjectPropertiesLeafDiff.GranularPatchChange> out) {
+    MdPropertiesGranularChanges c = new MdPropertiesGranularChanges(out);
+    c.enumText("ObjectBelonging", b.objectBelonging, i.objectBelonging);
+    c.bool("UseStandardCommands", b.useStandardCommands, i.useStandardCommands);
+    c.text("DefaultForm", b.defaultForm, i.defaultForm);
+    c.localStringRu("ExtendedPresentation", b.extendedPresentationRu, i.extendedPresentationRu);
+    c.localStringRu("Explanation", b.explanationRu, i.explanationRu);
+    c.bool("PasswordMode", b.passwordMode, i.passwordMode);
+    c.localStringRu("Format", b.formatRu, i.formatRu);
+    c.localStringRu("EditFormat", b.editFormatRu, i.editFormatRu);
+    c.localStringRu("ToolTip", b.toolTipRu, i.toolTipRu);
+    c.bool("MarkNegatives", b.markNegatives, i.markNegatives);
+    c.text("Mask", b.mask, i.mask);
+    c.bool("MultiLine", b.multiLine, i.multiLine);
+    c.bool("ExtendedEdit", b.extendedEdit, i.extendedEdit);
+    c.enumText("FillChecking", b.fillChecking, i.fillChecking);
+    c.enumText("ChoiceFoldersAndItems", b.choiceFoldersAndItems, i.choiceFoldersAndItems);
+    c.enumText("QuickChoice", b.quickChoice, i.quickChoice);
+    c.text("ChoiceForm", b.choiceForm, i.choiceForm);
+    c.enumText("ChoiceHistoryOnInput", b.choiceHistoryOnInput, i.choiceHistoryOnInput);
+    c.text("ValueManagerModule", b.valueManagerModule, i.valueManagerModule);
+    c.text("ManagerModule", b.managerModule, i.managerModule);
+    c.enumText("DataLockControlMode", b.dataLockControlMode, i.dataLockControlMode);
+    c.enumText("DataHistory", b.dataHistory, i.dataHistory);
+    c.bool("UpdateDataHistoryImmediatelyAfterWrite",
+      b.updateDataHistoryImmediatelyAfterWrite, i.updateDataHistoryImmediatelyAfterWrite);
+    c.bool("ExecuteAfterWriteDataHistoryVersionProcessing",
+      b.executeAfterWriteDataHistoryVersionProcessing, i.executeAfterWriteDataHistoryVersionProcessing);
+  }
+
+  static void appendCommonModuleScalarChanges(
+    MdCommonModulePropertiesDto b,
+    MdCommonModulePropertiesDto i,
+    List<MdObjectPropertiesLeafDiff.GranularPatchChange> out) {
+    MdPropertiesGranularChanges c = new MdPropertiesGranularChanges(out);
+    c.enumText("ObjectBelonging", b.objectBelonging, i.objectBelonging);
+    c.bool("Global", b.global, i.global);
+    c.bool("ClientManagedApplication", b.clientManagedApplication, i.clientManagedApplication);
+    c.bool("Server", b.server, i.server);
+    c.bool("ExternalConnection", b.externalConnection, i.externalConnection);
+    c.bool("ClientOrdinaryApplication", b.clientOrdinaryApplication, i.clientOrdinaryApplication);
+    c.bool("Client", b.client, i.client);
+    c.bool("ServerCall", b.serverCall, i.serverCall);
+    c.bool("Privileged", b.privileged, i.privileged);
+    c.enumText("ReturnValuesReuse", b.returnValuesReuse, i.returnValuesReuse);
+  }
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdTypeDescriptionBridge.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdTypeDescriptionBridge.java
@@ -1,0 +1,203 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+import io.github.yellowhammer.designerxml.reflect.JaxbReflect;
+
+import javax.xml.namespace.QName;
+
+import java.math.BigDecimal;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Чтение и запись {@code v8:TypeDescription}: состав типов и квалификаторы.
+ *
+ * <p>В XML тип записан как имя с префиксом ({@code xs:string}, {@code cfg:CatalogRef.Номенклатура}),
+ * в модели JAXB — как {@link QName}. Префиксы фиксированы платформой, поэтому держим их таблицей:
+ * так строка типа одинаково читается и пишется независимо от объявлений в конкретном файле.
+ */
+public final class MdTypeDescriptionBridge {
+
+  /** Префикс → пространство имён, как их пишет конфигуратор. */
+  private static final Map<String, String> NS_BY_PREFIX = new LinkedHashMap<>();
+
+  static {
+    NS_BY_PREFIX.put("xs", "http://www.w3.org/2001/XMLSchema");
+    NS_BY_PREFIX.put("cfg", "http://v8.1c.ru/8.1/data/enterprise/current-config");
+    NS_BY_PREFIX.put("v8", "http://v8.1c.ru/8.1/data/core");
+    NS_BY_PREFIX.put("xen", "http://v8.1c.ru/8.3/xcf/enums");
+    NS_BY_PREFIX.put("app", "http://v8.1c.ru/8.2/managed-application/core");
+    NS_BY_PREFIX.put("style", "http://v8.1c.ru/8.1/data/ui/style");
+    NS_BY_PREFIX.put("sys", "http://v8.1c.ru/8.1/data/ui/fonts/system");
+    NS_BY_PREFIX.put("web", "http://v8.1c.ru/8.1/data/ui/colors/web");
+    NS_BY_PREFIX.put("win", "http://v8.1c.ru/8.1/data/ui/colors/windows");
+  }
+
+  private MdTypeDescriptionBridge() {
+  }
+
+  /**
+   * @param typeDescription узел {@code v8:TypeDescription} или {@code null}
+   * @return DTO либо {@code null}, если типа нет
+   */
+  public static MdTypeDescriptionDto read(Object typeDescription) {
+    if (typeDescription == null) {
+      return null;
+    }
+    MdTypeDescriptionDto dto = new MdTypeDescriptionDto();
+    for (QName type : JaxbReflect.<QName>list(typeDescription, "getType")) {
+      dto.types.add(typeText(type));
+    }
+    Object sq = JaxbReflect.getOptional(typeDescription, "getStringQualifiers");
+    if (sq != null) {
+      MdTypeDescriptionDto.MdStringQualifiersDto q = new MdTypeDescriptionDto.MdStringQualifiersDto();
+      q.length = decimalText(JaxbReflect.getOptional(sq, "getLength"));
+      q.allowedLength = enumName(JaxbReflect.getOptional(sq, "getAllowedLength"));
+      dto.stringQualifiers = q;
+    }
+    Object nq = JaxbReflect.getOptional(typeDescription, "getNumberQualifiers");
+    if (nq != null) {
+      MdTypeDescriptionDto.MdNumberQualifiersDto q = new MdTypeDescriptionDto.MdNumberQualifiersDto();
+      q.digits = decimalText(JaxbReflect.getOptional(nq, "getDigits"));
+      q.fractionDigits = decimalText(JaxbReflect.getOptional(nq, "getFractionDigits"));
+      q.allowedSign = enumName(JaxbReflect.getOptional(nq, "getAllowedSign"));
+      dto.numberQualifiers = q;
+    }
+    Object dq = JaxbReflect.getOptional(typeDescription, "getDateQualifiers");
+    if (dq != null) {
+      MdTypeDescriptionDto.MdDateQualifiersDto q = new MdTypeDescriptionDto.MdDateQualifiersDto();
+      q.dateFractions = enumName(JaxbReflect.getOptional(dq, "getDateFractions"));
+      dto.dateQualifiers = q;
+    }
+    Object bq = JaxbReflect.getOptional(typeDescription, "getBinaryDataQualifiers");
+    if (bq != null) {
+      MdTypeDescriptionDto.MdBinaryDataQualifiersDto q = new MdTypeDescriptionDto.MdBinaryDataQualifiersDto();
+      q.length = decimalText(JaxbReflect.getOptional(bq, "getLength"));
+      q.allowedLength = enumName(JaxbReflect.getOptional(bq, "getAllowedLength"));
+      dto.binaryDataQualifiers = q;
+    }
+    return dto;
+  }
+
+  /**
+   * Применяет DTO к узлу {@code v8:TypeDescription}.
+   */
+  public static void apply(Object typeDescription, MdTypeDescriptionDto dto) {
+    if (typeDescription == null || dto == null) {
+      return;
+    }
+    List<QName> types = JaxbReflect.list(typeDescription, "getType");
+    types.clear();
+    for (String text : dto.types) {
+      types.add(qname(text));
+    }
+    applyStringQualifiers(typeDescription, dto);
+    applyNumberQualifiers(typeDescription, dto);
+    applyDateQualifiers(typeDescription, dto);
+    applyBinaryDataQualifiers(typeDescription, dto);
+  }
+
+  private static void applyStringQualifiers(Object typeDescription, MdTypeDescriptionDto dto) {
+    if (dto.stringQualifiers == null) {
+      return;
+    }
+    Object sq = JaxbReflect.ensureOptional(typeDescription, "getStringQualifiers", "setStringQualifiers");
+    if (sq == null) {
+      return;
+    }
+    JaxbReflect.setOptional(sq, "setLength", decimalOrZero(dto.stringQualifiers.length));
+    JaxbReflect.setEnumOrKeep(sq, "setAllowedLength", dto.stringQualifiers.allowedLength);
+  }
+
+  private static void applyNumberQualifiers(Object typeDescription, MdTypeDescriptionDto dto) {
+    if (dto.numberQualifiers == null) {
+      return;
+    }
+    Object nq = JaxbReflect.ensureOptional(typeDescription, "getNumberQualifiers", "setNumberQualifiers");
+    if (nq == null) {
+      return;
+    }
+    JaxbReflect.setOptional(nq, "setDigits", decimalOrZero(dto.numberQualifiers.digits));
+    JaxbReflect.setOptional(nq, "setFractionDigits", decimalOrZero(dto.numberQualifiers.fractionDigits));
+    JaxbReflect.setEnumOrKeep(nq, "setAllowedSign", dto.numberQualifiers.allowedSign);
+  }
+
+  private static void applyDateQualifiers(Object typeDescription, MdTypeDescriptionDto dto) {
+    if (dto.dateQualifiers == null) {
+      return;
+    }
+    Object dq = JaxbReflect.ensureOptional(typeDescription, "getDateQualifiers", "setDateQualifiers");
+    if (dq == null) {
+      return;
+    }
+    JaxbReflect.setEnumOrKeep(dq, "setDateFractions", dto.dateQualifiers.dateFractions);
+  }
+
+  private static void applyBinaryDataQualifiers(Object typeDescription, MdTypeDescriptionDto dto) {
+    if (dto.binaryDataQualifiers == null) {
+      return;
+    }
+    Object bq = JaxbReflect.ensureOptional(typeDescription, "getBinaryDataQualifiers", "setBinaryDataQualifiers");
+    if (bq == null) {
+      return;
+    }
+    JaxbReflect.setOptional(bq, "setLength", decimalOrZero(dto.binaryDataQualifiers.length));
+    JaxbReflect.setEnumOrKeep(bq, "setAllowedLength", dto.binaryDataQualifiers.allowedLength);
+  }
+
+  /** {@code xs:string} из QName: префикс берём по пространству имён, как пишет конфигуратор. */
+  static String typeText(QName type) {
+    String prefix = prefixForNamespace(type.getNamespaceURI(), type.getPrefix());
+    return prefix.isEmpty() ? type.getLocalPart() : prefix + ":" + type.getLocalPart();
+  }
+
+  /** QName из {@code xs:string}: пространство имён берём по префиксу. */
+  static QName qname(String text) {
+    String value = text == null ? "" : text.trim();
+    int colon = value.indexOf(':');
+    if (colon < 0) {
+      return new QName(value);
+    }
+    String prefix = value.substring(0, colon);
+    String local = value.substring(colon + 1);
+    String ns = NS_BY_PREFIX.get(prefix);
+    if (ns == null) {
+      throw new IllegalArgumentException("неизвестный префикс типа: " + prefix);
+    }
+    return new QName(ns, local, prefix);
+  }
+
+  /** Пространство имён префикса; пусто, если префикс неизвестен. */
+  static String namespaceForPrefix(String prefix) {
+    return NS_BY_PREFIX.getOrDefault(prefix, "");
+  }
+
+  private static String prefixForNamespace(String namespace, String parsedPrefix) {
+    for (Map.Entry<String, String> e : NS_BY_PREFIX.entrySet()) {
+      if (e.getValue().equals(namespace)) {
+        return e.getKey();
+      }
+    }
+    return parsedPrefix == null ? "" : parsedPrefix;
+  }
+
+  private static String decimalText(Object value) {
+    return value == null ? "0" : ((BigDecimal) value).toPlainString();
+  }
+
+  private static BigDecimal decimalOrZero(String text) {
+    return new BigDecimal(text == null || text.isBlank() ? "0" : text.trim());
+  }
+
+  private static String enumName(Object value) {
+    return value == null ? null : ((Enum<?>) value).name();
+  }
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdTypeDescriptionDto.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdTypeDescriptionDto.java
@@ -1,0 +1,59 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Описание типа значения ({@code v8:TypeDescription}) для JSON: состав типов и квалификаторы.
+ *
+ * <p>Типы — как в XML, с префиксом пространства имён: {@code xs:string}, {@code xs:decimal},
+ * {@code xs:boolean}, {@code xs:dateTime}, {@code cfg:CatalogRef.Номенклатура}. Составной тип —
+ * несколько элементов списка.
+ *
+ * <p>Enum-значения квалификаторов — имена Java-констант ({@code VARIABLE}, {@code NONNEGATIVE},
+ * {@code DATE_TIME}).
+ */
+public final class MdTypeDescriptionDto {
+
+  public List<String> types;
+  public MdStringQualifiersDto stringQualifiers;
+  public MdNumberQualifiersDto numberQualifiers;
+  public MdDateQualifiersDto dateQualifiers;
+  public MdBinaryDataQualifiersDto binaryDataQualifiers;
+
+  public MdTypeDescriptionDto() {
+    this.types = new ArrayList<>();
+  }
+
+  /** Квалификаторы строки: длина и её изменяемость. */
+  public static final class MdStringQualifiersDto {
+    public String length;
+    public String allowedLength;
+  }
+
+  /** Квалификаторы числа: разрядность, дробная часть и допустимый знак. */
+  public static final class MdNumberQualifiersDto {
+    public String digits;
+    public String fractionDigits;
+    public String allowedSign;
+  }
+
+  /** Квалификаторы даты: состав даты. */
+  public static final class MdDateQualifiersDto {
+    public String dateFractions;
+  }
+
+  /** Квалификаторы двоичных данных: длина и её изменяемость. */
+  public static final class MdBinaryDataQualifiersDto {
+    public String length;
+    public String allowedLength;
+  }
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdTypeDescriptionSerial.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdTypeDescriptionSerial.java
@@ -1,0 +1,95 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+/**
+ * Сериализация {@code v8:TypeDescription} для точечной замены в XML.
+ *
+ * <p>Элемент собирается в одну строку: отступы расставит {@link MdObjectPropertiesGranularPatch}
+ * по месту замены. Пространство имён типа объявляем прямо на элементе {@code v8:Type} — так же
+ * пишет конфигуратор, и замена не зависит от объявлений в корне файла.
+ */
+final class MdTypeDescriptionSerial {
+
+  private MdTypeDescriptionSerial() {
+  }
+
+  /**
+   * @param localName имя элемента-обёртки ({@code Type})
+   */
+  static String typeElement(String localName, MdTypeDescriptionDto dto) {
+    if (dto == null || dto.types.isEmpty()) {
+      return "<" + localName + "/>";
+    }
+    StringBuilder sb = new StringBuilder();
+    sb.append('<').append(localName).append('>');
+    for (String type : dto.types) {
+      sb.append(typeTag(type));
+    }
+    if (dto.stringQualifiers != null) {
+      sb.append("<v8:StringQualifiers>")
+        .append(leaf("v8:Length", nz(dto.stringQualifiers.length)))
+        .append(enumLeaf("v8:AllowedLength", dto.stringQualifiers.allowedLength))
+        .append("</v8:StringQualifiers>");
+    }
+    if (dto.numberQualifiers != null) {
+      sb.append("<v8:NumberQualifiers>")
+        .append(leaf("v8:Digits", nz(dto.numberQualifiers.digits)))
+        .append(leaf("v8:FractionDigits", nz(dto.numberQualifiers.fractionDigits)))
+        .append(enumLeaf("v8:AllowedSign", dto.numberQualifiers.allowedSign))
+        .append("</v8:NumberQualifiers>");
+    }
+    if (dto.dateQualifiers != null) {
+      sb.append("<v8:DateQualifiers>")
+        .append(enumLeaf("v8:DateFractions", dto.dateQualifiers.dateFractions))
+        .append("</v8:DateQualifiers>");
+    }
+    if (dto.binaryDataQualifiers != null) {
+      sb.append("<v8:BinaryDataQualifiers>")
+        .append(leaf("v8:Length", nz(dto.binaryDataQualifiers.length)))
+        .append(enumLeaf("v8:AllowedLength", dto.binaryDataQualifiers.allowedLength))
+        .append("</v8:BinaryDataQualifiers>");
+    }
+    sb.append("</").append(localName).append('>');
+    return sb.toString();
+  }
+
+  private static String typeTag(String type) {
+    String value = type == null ? "" : type.trim();
+    int colon = value.indexOf(':');
+    if (colon < 0) {
+      return "<v8:Type>" + escape(value) + "</v8:Type>";
+    }
+    String prefix = value.substring(0, colon);
+    String namespace = MdTypeDescriptionBridge.namespaceForPrefix(prefix);
+    if (namespace.isEmpty()) {
+      throw new IllegalArgumentException("неизвестный префикс типа: " + prefix);
+    }
+    return "<v8:Type xmlns:" + prefix + "=\"" + namespace + "\">" + escape(value) + "</v8:Type>";
+  }
+
+  private static String leaf(String tag, String text) {
+    return "<" + tag + ">" + escape(text) + "</" + tag + ">";
+  }
+
+  private static String enumLeaf(String tag, String constantName) {
+    if (constantName == null || constantName.isBlank()) {
+      return "";
+    }
+    return leaf(tag, MdCatalogPropertiesGranularSerial.enumConstantToXmlText(constantName));
+  }
+
+  private static String nz(String value) {
+    return value == null || value.isBlank() ? "0" : value;
+  }
+
+  private static String escape(String s) {
+    return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
+  }
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/SubsystemTreeBuilder.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/SubsystemTreeBuilder.java
@@ -1,0 +1,92 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+import io.github.yellowhammer.designerxml.SchemaVersion;
+
+import jakarta.xml.bind.JAXBException;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Дерево подсистем конфигурации с их составом: одна операция вместо чтения каждой подсистемы
+ * по отдельности. Вложенность берётся из {@code ChildObjects/Subsystem} самой подсистемы.
+ */
+public final class SubsystemTreeBuilder {
+
+  private SubsystemTreeBuilder() {
+  }
+
+  /**
+   * Узел дерева подсистем.
+   */
+  public record SubsystemNodeDto(
+    String name,
+    /** Абсолютный нормализованный путь к XML подсистемы. */
+    String xmlPath,
+    /** Ссылки на объекты состава ({@code Catalog.Номенклатура}). */
+    List<String> contentRefs,
+    List<SubsystemNodeDto> children
+  ) {
+  }
+
+  /**
+   * @param configurationXml {@code Configuration.xml} конфигурации или расширения
+   * @return подсистемы верхнего уровня с вложенными
+   */
+  public static List<SubsystemNodeDto> build(Path configurationXml, SchemaVersion version)
+    throws JAXBException, IOException {
+    Path root = configurationXml.toAbsolutePath().normalize().getParent();
+    if (root == null) {
+      throw new IllegalArgumentException("Configuration.xml without parent directory");
+    }
+    List<SubsystemNodeDto> out = new ArrayList<>();
+    Set<Path> visited = new HashSet<>();
+    for (String name : ConfigurationChildObjectLister.listNames(configurationXml, version, "Subsystem")) {
+      SubsystemNodeDto node = readNode(root.resolve("Subsystems").resolve(name + ".xml"), version, visited);
+      if (node != null) {
+        out.add(node);
+      }
+    }
+    return out;
+  }
+
+  private static SubsystemNodeDto readNode(Path xml, SchemaVersion version, Set<Path> visited)
+    throws JAXBException, IOException {
+    Path normalized = xml.toAbsolutePath().normalize();
+    if (!Files.isRegularFile(normalized) || !visited.add(normalized)) {
+      return null;
+    }
+    MdObjectPropertiesDto dto = MdObjectPropertiesEdit.readDto(normalized, version);
+    List<SubsystemNodeDto> children = new ArrayList<>();
+    for (String nested : dto.nestedSubsystems) {
+      // Вложенные подсистемы лежат в каталоге владельца: Subsystems/<Имя>/Subsystems/<Вложенная>.xml
+      Path nestedXml = normalized
+        .getParent()
+        .resolve(dto.internalName)
+        .resolve("Subsystems")
+        .resolve(nested + ".xml");
+      SubsystemNodeDto child = readNode(nestedXml, version, visited);
+      if (child != null) {
+        children.add(child);
+      }
+    }
+    return new SubsystemNodeDto(
+      dto.internalName,
+      normalized.toString(),
+      new ArrayList<>(dto.contentRefs),
+      children);
+  }
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cli/ApplyMutationCmd.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cli/ApplyMutationCmd.java
@@ -140,6 +140,25 @@ final class ApplyMutationCmd implements Callable<Integer> {
           p.reqPath(p.objectXml, "objectXml"), p.version(), p.req(p.sourceName, "sourceName"), p.req(p.newName, "newName"));
         return "OK";
 
+      case "cf-md-enum-value-add":
+        MdObjectChildMutations.addEnumValue(p.reqPath(p.objectXml, "objectXml"), p.version(), p.req(p.name, "name"));
+        return "OK";
+      case "cf-md-enum-value-rename":
+        MdObjectChildMutations.renameEnumValue(
+          p.reqPath(p.objectXml, "objectXml"), p.version(), p.req(p.oldName, "oldName"), p.req(p.newName, "newName"));
+        return "OK";
+      case "cf-md-enum-value-delete":
+        MdObjectChildMutations.deleteEnumValue(p.reqPath(p.objectXml, "objectXml"), p.version(), p.req(p.name, "name"));
+        return "OK";
+      case "cf-md-enum-value-duplicate":
+        MdObjectChildMutations.duplicateEnumValue(
+          p.reqPath(p.objectXml, "objectXml"), p.version(), p.req(p.sourceName, "sourceName"), p.req(p.newName, "newName"));
+        return "OK";
+      case "cf-md-enum-value-reorder":
+        MdObjectChildMutations.reorderEnumValues(
+          p.reqPath(p.objectXml, "objectXml"), p.version(), parseNameList(p));
+        return "OK";
+
       case "cf-md-tabular-section-add":
         MdObjectChildMutations.addTabularSection(p.reqPath(p.objectXml, "objectXml"), p.version(), p.req(p.name, "name"));
         return "OK";

--- a/src/main/java/io/github/yellowhammer/designerxml/cli/ApplyMutationCmd.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cli/ApplyMutationCmd.java
@@ -140,6 +140,44 @@ final class ApplyMutationCmd implements Callable<Integer> {
           p.reqPath(p.objectXml, "objectXml"), p.version(), p.req(p.sourceName, "sourceName"), p.req(p.newName, "newName"));
         return "OK";
 
+      case "cf-md-dimension-add":
+        MdObjectChildMutations.addDimension(p.reqPath(p.objectXml, "objectXml"), p.version(), p.req(p.name, "name"));
+        return "OK";
+      case "cf-md-dimension-rename":
+        MdObjectChildMutations.renameDimension(
+          p.reqPath(p.objectXml, "objectXml"), p.version(), p.req(p.oldName, "oldName"), p.req(p.newName, "newName"));
+        return "OK";
+      case "cf-md-dimension-delete":
+        MdObjectChildMutations.deleteDimension(p.reqPath(p.objectXml, "objectXml"), p.version(), p.req(p.name, "name"));
+        return "OK";
+      case "cf-md-dimension-duplicate":
+        MdObjectChildMutations.duplicateDimension(
+          p.reqPath(p.objectXml, "objectXml"), p.version(), p.req(p.sourceName, "sourceName"), p.req(p.newName, "newName"));
+        return "OK";
+      case "cf-md-dimension-reorder":
+        MdObjectChildMutations.reorderDimensions(
+          p.reqPath(p.objectXml, "objectXml"), p.version(), parseNameList(p));
+        return "OK";
+
+      case "cf-md-resource-add":
+        MdObjectChildMutations.addResource(p.reqPath(p.objectXml, "objectXml"), p.version(), p.req(p.name, "name"));
+        return "OK";
+      case "cf-md-resource-rename":
+        MdObjectChildMutations.renameResource(
+          p.reqPath(p.objectXml, "objectXml"), p.version(), p.req(p.oldName, "oldName"), p.req(p.newName, "newName"));
+        return "OK";
+      case "cf-md-resource-delete":
+        MdObjectChildMutations.deleteResource(p.reqPath(p.objectXml, "objectXml"), p.version(), p.req(p.name, "name"));
+        return "OK";
+      case "cf-md-resource-duplicate":
+        MdObjectChildMutations.duplicateResource(
+          p.reqPath(p.objectXml, "objectXml"), p.version(), p.req(p.sourceName, "sourceName"), p.req(p.newName, "newName"));
+        return "OK";
+      case "cf-md-resource-reorder":
+        MdObjectChildMutations.reorderResources(
+          p.reqPath(p.objectXml, "objectXml"), p.version(), parseNameList(p));
+        return "OK";
+
       case "cf-md-enum-value-add":
         MdObjectChildMutations.addEnumValue(p.reqPath(p.objectXml, "objectXml"), p.version(), p.req(p.name, "name"));
         return "OK";

--- a/src/main/java/io/github/yellowhammer/designerxml/cli/ReadJsonCmd.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cli/ReadJsonCmd.java
@@ -41,6 +41,7 @@ import io.github.yellowhammer.designerxml.cf.ProjectMetadataGraphDto;
 import io.github.yellowhammer.designerxml.cf.ProjectMetadataTreeBuilder;
 import io.github.yellowhammer.designerxml.cf.ProjectMetadataTreeDto;
 import io.github.yellowhammer.designerxml.cf.ProjectSourceDirs;
+import io.github.yellowhammer.designerxml.cf.SubsystemTreeBuilder;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
@@ -131,6 +132,11 @@ final class ReadJsonCmd implements Callable<Integer> {
         var names = ConfigurationCatalogLister.listCatalogNames(
           p.reqPath(p.configurationXml, "configurationXml"), p.version());
         return ConfigurationCatalogLister.toJsonArray(names);
+      }
+      case "cf-md-subsystem-tree": {
+        var nodes = SubsystemTreeBuilder.build(
+          p.reqPath(p.configurationXml, "configurationXml"), p.version());
+        return gson.toJson(nodes);
       }
       case "project-metadata-tree": {
         ProjectMetadataTreeDto dto = ProjectMetadataTreeBuilder.build(

--- a/src/test/java/io/github/yellowhammer/designerxml/DesignerXmlRoundTripTest.java
+++ b/src/test/java/io/github/yellowhammer/designerxml/DesignerXmlRoundTripTest.java
@@ -40,8 +40,9 @@ class DesignerXmlRoundTripTest {
   @TempDir
   Path tempDir;
 
+  /** Выгрузка ssl_3_1 сделана в формате 2.20: моделью следующей версии она тоже должна читаться. */
   @Test
-  void roundTripSsl31ConfigurationV2_21() throws Exception {
+  void roundTripSsl31ConfigurationByNewerModel() throws Exception {
     Path input = Ssl31SubmodulePaths.configurationXml();
     Path out = tempDir.resolve("out.xml");
 
@@ -55,8 +56,9 @@ class DesignerXmlRoundTripTest {
     assertThat(((JAXBElement<?>) again).getDeclaredType()).isEqualTo(((JAXBElement<?>) root).getDeclaredType());
   }
 
+  /** Родной формат выгрузки ssl_3_1. */
   @Test
-  void roundTripSsl31ConfigurationV2_20() throws Exception {
+  void roundTripSsl31ConfigurationInNativeFormat() throws Exception {
     Path input = Ssl31SubmodulePaths.configurationXml();
     Path out = tempDir.resolve("out-v2_20.xml");
 

--- a/src/test/java/io/github/yellowhammer/designerxml/cf/AddCatalogFromEmptyCfTest.java
+++ b/src/test/java/io/github/yellowhammer/designerxml/cf/AddCatalogFromEmptyCfTest.java
@@ -8,52 +8,40 @@ package io.github.yellowhammer.designerxml.cf;
 import io.github.yellowhammer.designerxml.DesignerXml;
 import io.github.yellowhammer.designerxml.SchemaVersion;
 
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/** Первый справочник после {@link EmptyCfScaffold#writeEmptyTree} — без готового {@code Catalogs/*.xml}. */
+/**
+ * Первый справочник после {@link EmptyCfScaffold#writeEmptyTree} — без готового {@code Catalogs/*.xml}.
+ * Проверяем в каждом поддерживаемом формате, а не в паре выбранных.
+ */
 class AddCatalogFromEmptyCfTest {
 
   @TempDir
   Path workspace;
 
-  @Test
-  void firstCatalogV220WithoutExistingCatalogsXml() throws Exception {
-    Path cf = workspace.resolve("cf");
-    EmptyCfScaffold.writeEmptyTree(
-      cf, CfLayout.DEFAULT_CONFIGURATION_NAME, null, null, null, SchemaVersion.V2_20);
+  @ParameterizedTest
+  @EnumSource(SchemaVersion.class)
+  void firstCatalogWithoutExistingCatalogsXml(SchemaVersion version) throws Exception {
+    Path cf = workspace.resolve("cf-" + version.name());
+    EmptyCfScaffold.writeEmptyTree(cf, CfLayout.DEFAULT_CONFIGURATION_NAME, null, null, null, version);
     Path cfg = cf.resolve(CfLayout.CONFIGURATION_XML);
     assertThat(cf.resolve(CfLayout.CATALOGS_DIR)).doesNotExist();
-    assertThat(Files.readString(cfg)).contains("version=\"2.20\"");
+    assertThat(Files.readString(cfg)).contains("version=\"" + version.metadataObjectVersionAttribute() + "\"");
 
     String name = "_ПервыйИзПустой";
-    MdObjectAdd.add(cfg, name, SchemaVersion.V2_20, MdObjectAddType.CATALOG, "Первый", false);
+    MdObjectAdd.add(cfg, name, version, MdObjectAddType.CATALOG, "Первый", false);
 
     Path catXml = CfLayout.catalogObjectXml(cf, name);
     assertThat(catXml).exists();
-    DesignerXml.read(catXml, SchemaVersion.V2_20);
-    String text = Files.readString(catXml, java.nio.charset.StandardCharsets.UTF_8);
-    assertThat(text).contains("<Name>" + name + "</Name>");
-  }
-
-  @Test
-  void firstCatalogV221WithoutExistingCatalogsXml() throws Exception {
-    Path cf = workspace.resolve("cf221");
-    EmptyCfScaffold.writeEmptyTree(
-      cf, CfLayout.DEFAULT_CONFIGURATION_NAME, null, null, null, SchemaVersion.V2_21);
-    Path cfg = cf.resolve(CfLayout.CONFIGURATION_XML);
-    assertThat(Files.readString(cfg)).contains("version=\"2.21\"");
-
-    String name = "_Первый221";
-    MdObjectAdd.add(cfg, name, SchemaVersion.V2_21, MdObjectAddType.CATALOG, "Первый", false);
-
-    Path catXml = CfLayout.catalogObjectXml(cf, name);
-    assertThat(catXml).exists();
-    DesignerXml.read(catXml, SchemaVersion.V2_21);
+    DesignerXml.read(catXml, version);
+    assertThat(Files.readString(catXml, StandardCharsets.UTF_8)).contains("<Name>" + name + "</Name>");
   }
 }

--- a/src/test/java/io/github/yellowhammer/designerxml/cf/ExternalArtifactAddGoldenTest.java
+++ b/src/test/java/io/github/yellowhammer/designerxml/cf/ExternalArtifactAddGoldenTest.java
@@ -10,8 +10,9 @@ package io.github.yellowhammer.designerxml.cf;
 
 import io.github.yellowhammer.designerxml.DesignerXml;
 import io.github.yellowhammer.designerxml.SchemaVersion;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -19,52 +20,55 @@ import java.nio.file.Path;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * Создание внешнего отчёта и обработки на диске: результат детерминирован, нормализован и читается
+ * моделью своей версии. Проверяем в каждом поддерживаемом формате, а не в паре выбранных.
+ */
 class ExternalArtifactAddGoldenTest {
   private static final String CONTAINED_OBJECT_TAG = "<xr:ContainedObject>";
+  private static final String REPORT_CLASS_ID = "e41aff26-25cf-4bb6-b6c1-3f478a75f374";
+  private static final String DATA_PROCESSOR_CLASS_ID = "c3831ec8-d8d5-4f93-8a22-f9bfae07327f";
 
   @TempDir
   Path workspace;
 
-  @Test
-  void createReportDeterministicAndNormalizedV220() throws Exception {
-    Path rootA = workspace.resolve("erfA");
-    Path rootB = workspace.resolve("erfB");
-    String name = "_ВнешнийОтчетТест";
-    Path xmlA = NewExternalArtifactXml.create(rootA, name, ExternalArtifactKind.REPORT, SchemaVersion.V2_20);
-    Path xmlB = NewExternalArtifactXml.create(rootB, name, ExternalArtifactKind.REPORT, SchemaVersion.V2_20);
+  @ParameterizedTest
+  @EnumSource(SchemaVersion.class)
+  void createReportDeterministicAndNormalized(SchemaVersion version) throws Exception {
+    String text = createTwiceAndAssertSame(version, ExternalArtifactKind.REPORT, "_ВнешнийОтчетТест", "erf");
+    assertThat(text).contains("xmlns:cfg=");
+    assertThat(text).contains("<xr:ClassId>" + REPORT_CLASS_ID + "</xr:ClassId>");
+  }
+
+  @ParameterizedTest
+  @EnumSource(SchemaVersion.class)
+  void createDataProcessorDeterministicAndReadable(SchemaVersion version) throws Exception {
+    String text = createTwiceAndAssertSame(version, ExternalArtifactKind.DATA_PROCESSOR, "_ВнешняяОбработкаТест", "epf");
+    assertThat(text).contains("<ExternalDataProcessor");
+    assertThat(text).contains("<xr:ClassId>" + DATA_PROCESSOR_CLASS_ID + "</xr:ClassId>");
+  }
+
+  /**
+   * @return текст первого созданного файла (второй обязан совпасть с ним)
+   */
+  private String createTwiceAndAssertSame(
+    SchemaVersion version,
+    ExternalArtifactKind kind,
+    String name,
+    String dirPrefix
+  ) throws Exception {
+    Path xmlA = NewExternalArtifactXml.create(workspace.resolve(dirPrefix + "A-" + version.name()), name, kind, version);
+    Path xmlB = NewExternalArtifactXml.create(workspace.resolve(dirPrefix + "B-" + version.name()), name, kind, version);
     String textA = Files.readString(xmlA, StandardCharsets.UTF_8);
-    String textB = Files.readString(xmlB, StandardCharsets.UTF_8);
-    assertThat(textA).isEqualTo(textB);
-    assertThat(textA).contains("version=\"2.20\"");
-    assertThat(textA).contains("xmlns:cfg=");
+    assertThat(textA).isEqualTo(Files.readString(xmlB, StandardCharsets.UTF_8));
+    assertThat(textA).contains("version=\"" + version.metadataObjectVersionAttribute() + "\"");
     assertThat(textA).contains("\n\t<");
     assertThat(textA).doesNotContain("standalone=\"yes\"");
     assertThat(textA).contains(CONTAINED_OBJECT_TAG);
-    assertThat(textA).contains("<xr:ClassId>e41aff26-25cf-4bb6-b6c1-3f478a75f374</xr:ClassId>");
     assertThat(textA).contains("<Synonym/>");
-    assertThat(textA.indexOf(CONTAINED_OBJECT_TAG))
-      .isLessThan(textA.indexOf("<xr:GeneratedType"));
-    DesignerXml.read(xmlA, SchemaVersion.V2_20);
-  }
-
-  @Test
-  void createDataProcessorDeterministicAndReadableV221() throws Exception {
-    Path rootA = workspace.resolve("epfA");
-    Path rootB = workspace.resolve("epfB");
-    String name = "_ВнешняяОбработкаТест";
-    Path xmlA = NewExternalArtifactXml.create(rootA, name, ExternalArtifactKind.DATA_PROCESSOR, SchemaVersion.V2_21);
-    Path xmlB = NewExternalArtifactXml.create(rootB, name, ExternalArtifactKind.DATA_PROCESSOR, SchemaVersion.V2_21);
-    String textA = Files.readString(xmlA, StandardCharsets.UTF_8);
-    String textB = Files.readString(xmlB, StandardCharsets.UTF_8);
-    assertThat(textA).isEqualTo(textB);
-    assertThat(textA).contains("version=\"2.21\"");
-    assertThat(textA).contains("<ExternalDataProcessor");
-    assertThat(textA).doesNotContain("standalone=\"yes\"");
-    assertThat(textA).contains(CONTAINED_OBJECT_TAG);
-    assertThat(textA).contains("<xr:ClassId>c3831ec8-d8d5-4f93-8a22-f9bfae07327f</xr:ClassId>");
-    assertThat(textA).contains("<Synonym/>");
-    assertThat(textA.indexOf(CONTAINED_OBJECT_TAG))
-      .isLessThan(textA.indexOf("<xr:GeneratedType"));
-    DesignerXml.read(xmlA, SchemaVersion.V2_21);
+    // Порядок InternalInfo — как у конфигуратора.
+    assertThat(textA.indexOf(CONTAINED_OBJECT_TAG)).isLessThan(textA.indexOf("<xr:GeneratedType"));
+    DesignerXml.read(xmlA, version);
+    return textA;
   }
 }

--- a/src/test/java/io/github/yellowhammer/designerxml/cf/GoldenWriterCreateDeterminismTest.java
+++ b/src/test/java/io/github/yellowhammer/designerxml/cf/GoldenWriterCreateDeterminismTest.java
@@ -12,28 +12,46 @@ import io.github.yellowhammer.designerxml.DesignerXml;
 import io.github.yellowhammer.designerxml.SchemaVersion;
 import io.github.yellowhammer.designerxml.XmlValidator;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.EnumSet;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * Пустая выгрузка одинакова от запуска к запуску, переписывается идемпотентно и читается моделью
+ * своей версии — в каждом поддерживаемом формате.
+ */
 class GoldenWriterCreateDeterminismTest {
+
+  /**
+   * Форматы, где XSD из {@code namespace-forest} расходятся с выводом самой платформы, поэтому
+   * эталон не проходит проверку по схеме (#6):
+   * <ul>
+   *   <li>2.10 — {@code app:permission} платформа пишет без {@code app:description};</li>
+   *   <li>2.21 — {@code ConfigurationExtensionCompatibilityMode} имеет значение {@code Version8_5_1},
+   *       которого нет в перечислении схемы.</li>
+   * </ul>
+   */
+  private static final Set<SchemaVersion> XSD_MISMATCH_WITH_PLATFORM =
+    EnumSet.of(SchemaVersion.V2_10, SchemaVersion.V2_21);
 
   @TempDir
   Path workspace;
 
-  @Test
-  void initEmptyCfIsDeterministicAndIdempotentV220() throws Exception {
-    Path cfA = workspace.resolve("cfA");
-    Path cfB = workspace.resolve("cfB");
+  @ParameterizedTest
+  @EnumSource(SchemaVersion.class)
+  void initEmptyCfIsDeterministicAndIdempotent(SchemaVersion version) throws Exception {
+    Path cfA = workspace.resolve("cfA-" + version.name());
+    Path cfB = workspace.resolve("cfB-" + version.name());
 
-    EmptyCfScaffold.writeEmptyTree(
-      cfA, CfLayout.DEFAULT_CONFIGURATION_NAME, null, null, null, SchemaVersion.V2_20);
-    EmptyCfScaffold.writeEmptyTree(
-      cfB, CfLayout.DEFAULT_CONFIGURATION_NAME, null, null, null, SchemaVersion.V2_20);
+    EmptyCfScaffold.writeEmptyTree(cfA, CfLayout.DEFAULT_CONFIGURATION_NAME, null, null, null, version);
+    EmptyCfScaffold.writeEmptyTree(cfB, CfLayout.DEFAULT_CONFIGURATION_NAME, null, null, null, version);
 
     Path cfgA = cfA.resolve(CfLayout.CONFIGURATION_XML);
     Path cfgB = cfB.resolve(CfLayout.CONFIGURATION_XML);
@@ -41,13 +59,13 @@ class GoldenWriterCreateDeterminismTest {
     String second = Files.readString(cfgB);
     assertThat(first).isEqualTo(second);
 
-    EmptyCfScaffold.writeEmptyTree(
-      cfA, CfLayout.DEFAULT_CONFIGURATION_NAME, null, null, null, SchemaVersion.V2_20);
+    EmptyCfScaffold.writeEmptyTree(cfA, CfLayout.DEFAULT_CONFIGURATION_NAME, null, null, null, version);
     String third = Files.readString(cfgA);
     assertThat(third).isEqualTo(first);
 
-    DesignerXml.read(cfgA, SchemaVersion.V2_20);
-    Path xsdRoot = Path.of(System.getProperty("xsd.root"));
-    XmlValidator.validate(cfgA, SchemaVersion.V2_20, xsdRoot);
+    DesignerXml.read(cfgA, version);
+    if (!XSD_MISMATCH_WITH_PLATFORM.contains(version)) {
+      XmlValidator.validate(cfgA, version, Path.of(System.getProperty("xsd.root")));
+    }
   }
 }

--- a/src/test/java/io/github/yellowhammer/designerxml/cf/MdBoilerplateAddTest.java
+++ b/src/test/java/io/github/yellowhammer/designerxml/cf/MdBoilerplateAddTest.java
@@ -8,8 +8,9 @@ package io.github.yellowhammer.designerxml.cf;
 import io.github.yellowhammer.designerxml.DesignerXml;
 import io.github.yellowhammer.designerxml.SchemaVersion;
 
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -17,36 +18,48 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * Добавление объектов в пустую выгрузку: файл появляется, регистрируется в {@code Configuration.xml},
+ * читается моделью своей версии и не зависит от запуска. Проверяем в каждом поддерживаемом формате.
+ *
+ * <p>Профиль объекта (набор элементов «как у конфигуратора») сверяется с эталоном той же версии,
+ * поэтому такие проверки тоже параметризованы.
+ */
 class MdObjectAddTest {
 
   @TempDir
   Path workspace;
 
-  @Test
-  void addEnumAfterEmptyCfV220() throws Exception {
-    Path cf = workspace.resolve("cf");
-    EmptyCfScaffold.writeEmptyTree(
-      cf, CfLayout.DEFAULT_CONFIGURATION_NAME, null, null, null, SchemaVersion.V2_20);
-    Path cfg = cf.resolve(CfLayout.CONFIGURATION_XML);
-    String name = "_ПеречислениеТест";
-    MdObjectAdd.add(cfg, name, SchemaVersion.V2_20, MdObjectAddType.ENUM);
-    Path out = CfLayout.objectXmlInSubdir(cf, "Enums", name);
+  private Path emptyCfg(SchemaVersion version, String dirName) throws Exception {
+    Path cf = workspace.resolve(dirName + "-" + version.name());
+    EmptyCfScaffold.writeEmptyTree(cf, CfLayout.DEFAULT_CONFIGURATION_NAME, null, null, null, version);
+    return cf.resolve(CfLayout.CONFIGURATION_XML);
+  }
+
+  private static Path addAndRead(Path cfg, String subdir, String name, SchemaVersion version, MdObjectAddType type)
+    throws Exception {
+    MdObjectAdd.add(cfg, name, version, type);
+    Path out = CfLayout.objectXmlInSubdir(cfg.getParent(), subdir, name);
     assertThat(out).exists();
-    DesignerXml.read(out, SchemaVersion.V2_20);
+    DesignerXml.read(out, version);
+    return out;
+  }
+
+  @ParameterizedTest
+  @EnumSource(SchemaVersion.class)
+  void addEnumAfterEmptyCf(SchemaVersion version) throws Exception {
+    Path cfg = emptyCfg(version, "cf");
+    String name = "_ПеречислениеТест";
+    addAndRead(cfg, "Enums", name, version, MdObjectAddType.ENUM);
     assertThat(Files.readString(cfg)).contains("<Enum>" + name + "</Enum>");
   }
 
-  @Test
-  void addConstantAfterEmptyCfV221() throws Exception {
-    Path cf = workspace.resolve("cf221");
-    EmptyCfScaffold.writeEmptyTree(
-      cf, CfLayout.DEFAULT_CONFIGURATION_NAME, null, null, null, SchemaVersion.V2_21);
-    Path cfg = cf.resolve(CfLayout.CONFIGURATION_XML);
+  @ParameterizedTest
+  @EnumSource(SchemaVersion.class)
+  void addConstantAfterEmptyCf(SchemaVersion version) throws Exception {
+    Path cfg = emptyCfg(version, "cfConstant");
     String name = "_КонстантаТест";
-    MdObjectAdd.add(cfg, name, SchemaVersion.V2_21, MdObjectAddType.CONSTANT);
-    Path out = CfLayout.objectXmlInSubdir(cf, "Constants", name);
-    assertThat(out).exists();
-    DesignerXml.read(out, SchemaVersion.V2_21);
+    Path out = addAndRead(cfg, "Constants", name, version, MdObjectAddType.CONSTANT);
     assertThat(Files.readString(cfg)).contains("<Constant>" + name + "</Constant>");
     String xml = Files.readString(out);
     assertThat(xml).contains("<xr:GeneratedType name=\"ConstantValueManager." + name + "\" category=\"ValueManager\">");
@@ -56,72 +69,41 @@ class MdObjectAddTest {
     assertThat(xml).contains("<QuickChoice>Auto</QuickChoice>");
   }
 
-  @Test
-  void addObjectIsDeterministicForSameInputV220() throws Exception {
-    Path cfA = workspace.resolve("cfA");
-    Path cfB = workspace.resolve("cfB");
-    EmptyCfScaffold.writeEmptyTree(
-      cfA, CfLayout.DEFAULT_CONFIGURATION_NAME, null, null, null, SchemaVersion.V2_20);
-    EmptyCfScaffold.writeEmptyTree(
-      cfB, CfLayout.DEFAULT_CONFIGURATION_NAME, null, null, null, SchemaVersion.V2_20);
-
-    Path cfgA = cfA.resolve(CfLayout.CONFIGURATION_XML);
-    Path cfgB = cfB.resolve(CfLayout.CONFIGURATION_XML);
-    String name = "_ОтчетДетерминизм";
-
-    MdObjectAdd.add(cfgA, name, SchemaVersion.V2_20, MdObjectAddType.REPORT);
-    MdObjectAdd.add(cfgB, name, SchemaVersion.V2_20, MdObjectAddType.REPORT);
-
-    Path outA = CfLayout.objectXmlInSubdir(cfA, "Reports", name);
-    Path outB = CfLayout.objectXmlInSubdir(cfB, "Reports", name);
-    assertThat(outA).exists();
-    assertThat(outB).exists();
-    assertThat(Files.readString(outA)).isEqualTo(Files.readString(outB));
-    assertThat(Files.readString(cfgA)).isEqualTo(Files.readString(cfgB));
-  }
-
-  @Test
-  void addObjectAllTypesReadableV220() throws Exception {
-    Path cf = workspace.resolve("cfAllKinds");
-    EmptyCfScaffold.writeEmptyTree(
-      cf, CfLayout.DEFAULT_CONFIGURATION_NAME, null, null, null, SchemaVersion.V2_20);
-    Path cfg = cf.resolve(CfLayout.CONFIGURATION_XML);
-
+  @ParameterizedTest
+  @EnumSource(SchemaVersion.class)
+  void addObjectAllTypesReadableAndDeterministic(SchemaVersion version) throws Exception {
+    Path cfgA = emptyCfg(version, "cfA");
+    Path cfgB = emptyCfg(version, "cfB");
     List<MdObjectAddType> types = List.of(MdObjectAddType.values());
     int idx = 1000;
     for (MdObjectAddType type : types) {
       String name = type.namePrefix() + idx++;
-      MdObjectAdd.add(cfg, name, SchemaVersion.V2_20, type);
-      Path out = CfObjectPathResolver.objectXml(cf, type.configurationXmlTag(), name).orElseThrow();
-      assertThat(out).exists();
-      DesignerXml.read(out, SchemaVersion.V2_20);
+      MdObjectAdd.add(cfgA, name, version, type);
+      MdObjectAdd.add(cfgB, name, version, type);
+      Path outA = CfObjectPathResolver.objectXml(cfgA.getParent(), type.configurationXmlTag(), name).orElseThrow();
+      Path outB = CfObjectPathResolver.objectXml(cfgB.getParent(), type.configurationXmlTag(), name).orElseThrow();
+      assertThat(Files.readString(outA)).as("детерминированный вывод %s", type).isEqualTo(Files.readString(outB));
+      DesignerXml.read(outA, version);
     }
+    assertThat(Files.readString(cfgA)).isEqualTo(Files.readString(cfgB));
   }
 
-  @Test
-  void addWithNextAvailableNamePicksDocument1OnEmptyCfV220() throws Exception {
-    Path cf = workspace.resolve("cfAutoDocument");
-    EmptyCfScaffold.writeEmptyTree(
-      cf, CfLayout.DEFAULT_CONFIGURATION_NAME, null, null, null, SchemaVersion.V2_20);
-    Path cfg = cf.resolve(CfLayout.CONFIGURATION_XML);
-    String name = MdObjectAdd.addWithNextAvailableName(
-      cfg, SchemaVersion.V2_20, MdObjectAddType.DOCUMENT, null, false);
+  @ParameterizedTest
+  @EnumSource(SchemaVersion.class)
+  void addWithNextAvailableNamePicksDocument1OnEmptyCf(SchemaVersion version) throws Exception {
+    Path cfg = emptyCfg(version, "cfAutoDocument");
+    String name = MdObjectAdd.addWithNextAvailableName(cfg, version, MdObjectAddType.DOCUMENT, null, false);
     assertThat(name).isEqualTo("Документ1");
-    Path out = CfLayout.objectXmlInSubdir(cf, "Documents", name);
-    assertThat(out).exists();
+    assertThat(CfLayout.objectXmlInSubdir(cfg.getParent(), "Documents", name)).exists();
     assertThat(Files.readString(cfg)).contains("<Document>" + name + "</Document>");
   }
 
-  @Test
-  void addDocumentProfileIsSnapshotLikeV220() throws Exception {
-    Path cf = workspace.resolve("cfDocument");
-    EmptyCfScaffold.writeEmptyTree(
-      cf, CfLayout.DEFAULT_CONFIGURATION_NAME, null, null, null, SchemaVersion.V2_20);
-    Path cfg = cf.resolve(CfLayout.CONFIGURATION_XML);
+  @ParameterizedTest
+  @EnumSource(SchemaVersion.class)
+  void addDocumentProfileIsSnapshotLike(SchemaVersion version) throws Exception {
+    Path cfg = emptyCfg(version, "cfDocument");
     String name = "Документ1";
-    MdObjectAdd.add(cfg, name, SchemaVersion.V2_20, MdObjectAddType.DOCUMENT);
-    Path out = CfLayout.objectXmlInSubdir(cf, "Documents", name);
-    String xml = Files.readString(out);
+    String xml = Files.readString(addAndRead(cfg, "Documents", name, version, MdObjectAddType.DOCUMENT));
     assertThat(xml).contains("<InputByString>");
     assertThat(xml).contains("<xr:Field>Document." + name + ".StandardAttribute.Number</xr:Field>");
     assertThat(xml).contains("<Posting>Allow</Posting>");
@@ -130,105 +112,60 @@ class MdObjectAddTest {
     assertThat(xml).contains("<SequenceFilling>AutoFill</SequenceFilling>");
   }
 
-  @Test
-  void addReportProfileIsSnapshotLikeV220() throws Exception {
-    Path cf = workspace.resolve("cfReport");
-    EmptyCfScaffold.writeEmptyTree(
-      cf, CfLayout.DEFAULT_CONFIGURATION_NAME, null, null, null, SchemaVersion.V2_20);
-    Path cfg = cf.resolve(CfLayout.CONFIGURATION_XML);
-    String name = "Отчет1";
-    MdObjectAdd.add(cfg, name, SchemaVersion.V2_20, MdObjectAddType.REPORT);
-    String xml = Files.readString(CfLayout.objectXmlInSubdir(cf, "Reports", name));
+  @ParameterizedTest
+  @EnumSource(SchemaVersion.class)
+  void addReportProfileIsSnapshotLike(SchemaVersion version) throws Exception {
+    Path cfg = emptyCfg(version, "cfReport");
+    String xml = Files.readString(addAndRead(cfg, "Reports", "Отчет1", version, MdObjectAddType.REPORT));
     assertThat(xml).contains("<DefaultForm/>");
     assertThat(xml).contains("<MainDataCompositionSchema/>");
     assertThat(xml).contains("<IncludeHelpInContents>false</IncludeHelpInContents>");
     assertThat(xml).contains("<ExtendedPresentation/>");
   }
 
-  @Test
-  void addDataProcessorProfileIsSnapshotLikeV220() throws Exception {
-    Path cf = workspace.resolve("cfDataProcessor");
-    EmptyCfScaffold.writeEmptyTree(
-      cf, CfLayout.DEFAULT_CONFIGURATION_NAME, null, null, null, SchemaVersion.V2_20);
-    Path cfg = cf.resolve(CfLayout.CONFIGURATION_XML);
-    String name = "Обработка1";
-    MdObjectAdd.add(cfg, name, SchemaVersion.V2_20, MdObjectAddType.DATA_PROCESSOR);
-    String xml = Files.readString(CfLayout.objectXmlInSubdir(cf, "DataProcessors", name));
+  @ParameterizedTest
+  @EnumSource(SchemaVersion.class)
+  void addDataProcessorProfileIsSnapshotLike(SchemaVersion version) throws Exception {
+    Path cfg = emptyCfg(version, "cfDataProcessor");
+    String xml = Files.readString(addAndRead(cfg, "DataProcessors", "Обработка1", version, MdObjectAddType.DATA_PROCESSOR));
     assertThat(xml).contains("<DefaultForm/>");
     assertThat(xml).contains("<AuxiliaryForm/>");
     assertThat(xml).contains("<ExtendedPresentation/>");
     assertThat(xml).contains("<Explanation/>");
   }
 
-  @Test
-  void addEnumProfileIsSnapshotLikeV220() throws Exception {
-    Path cf = workspace.resolve("cfEnum");
-    EmptyCfScaffold.writeEmptyTree(
-      cf, CfLayout.DEFAULT_CONFIGURATION_NAME, null, null, null, SchemaVersion.V2_20);
-    Path cfg = cf.resolve(CfLayout.CONFIGURATION_XML);
-    String name = "Перечисление1";
-    MdObjectAdd.add(cfg, name, SchemaVersion.V2_20, MdObjectAddType.ENUM);
-    String xml = Files.readString(CfLayout.objectXmlInSubdir(cf, "Enums", name));
+  @ParameterizedTest
+  @EnumSource(SchemaVersion.class)
+  void addEnumProfileIsSnapshotLike(SchemaVersion version) throws Exception {
+    Path cfg = emptyCfg(version, "cfEnumProfile");
+    String xml = Files.readString(addAndRead(cfg, "Enums", "Перечисление1", version, MdObjectAddType.ENUM));
     assertThat(xml).contains("<UseStandardCommands>false</UseStandardCommands>");
     assertThat(xml).contains("<QuickChoice>true</QuickChoice>");
     assertThat(xml).contains("<ChoiceMode>BothWays</ChoiceMode>");
     assertThat(xml).contains("<ChoiceHistoryOnInput>Auto</ChoiceHistoryOnInput>");
   }
 
-  @Test
-  void addExternalDataSourceProfileIsSnapshotLikeV220() throws Exception {
-    Path cf = workspace.resolve("cfExternalDataSource");
-    EmptyCfScaffold.writeEmptyTree(
-      cf, CfLayout.DEFAULT_CONFIGURATION_NAME, null, null, null, SchemaVersion.V2_20);
-    Path cfg = cf.resolve(CfLayout.CONFIGURATION_XML);
+  @ParameterizedTest
+  @EnumSource(SchemaVersion.class)
+  void addExternalDataSourceProfileIsSnapshotLike(SchemaVersion version) throws Exception {
+    Path cfg = emptyCfg(version, "cfExternalDataSource");
     String name = "ВнешнийИсточникДанных1";
-    MdObjectAdd.add(cfg, name, SchemaVersion.V2_20, MdObjectAddType.EXTERNAL_DATA_SOURCE);
-    String xml = Files.readString(CfLayout.objectXmlInSubdir(cf, "ExternalDataSources", name));
+    String xml = Files.readString(addAndRead(cfg, "ExternalDataSources", name, version, MdObjectAddType.EXTERNAL_DATA_SOURCE));
     assertThat(xml).contains("ExternalDataSourceTablesManager." + name);
     assertThat(xml).contains("ExternalDataSourceCubesManager." + name);
     assertThat(xml).contains("<DataLockControlMode>Automatic</DataLockControlMode>");
   }
 
-  @Test
-  void addTaskProfileIsSnapshotLikeV220() throws Exception {
-    Path cf = workspace.resolve("cfTask");
-    EmptyCfScaffold.writeEmptyTree(
-      cf, CfLayout.DEFAULT_CONFIGURATION_NAME, null, null, null, SchemaVersion.V2_20);
-    Path cfg = cf.resolve(CfLayout.CONFIGURATION_XML);
+  @ParameterizedTest
+  @EnumSource(SchemaVersion.class)
+  void addTaskProfileIsSnapshotLike(SchemaVersion version) throws Exception {
+    Path cfg = emptyCfg(version, "cfTask");
     String name = "Задача1";
-    MdObjectAdd.add(cfg, name, SchemaVersion.V2_20, MdObjectAddType.TASK);
-    String xml = Files.readString(CfLayout.objectXmlInSubdir(cf, "Tasks", name));
+    String xml = Files.readString(addAndRead(cfg, "Tasks", name, version, MdObjectAddType.TASK));
     assertThat(xml).contains("<TaskNumberAutoPrefix>DontUse</TaskNumberAutoPrefix>");
     assertThat(xml).contains("<DescriptionLength>25</DescriptionLength>");
     assertThat(xml).contains("<DefaultPresentation>AsDescription</DefaultPresentation>");
     assertThat(xml).contains("<xr:Field>Task." + name + ".StandardAttribute.Description</xr:Field>");
     assertThat(xml).contains("<FullTextSearch>Use</FullTextSearch>");
   }
-
-  @Test
-  void addObjectAllTypesDeterministicV221() throws Exception {
-    Path cfA = workspace.resolve("cfA221");
-    Path cfB = workspace.resolve("cfB221");
-    EmptyCfScaffold.writeEmptyTree(
-      cfA, CfLayout.DEFAULT_CONFIGURATION_NAME, null, null, null, SchemaVersion.V2_21);
-    EmptyCfScaffold.writeEmptyTree(
-      cfB, CfLayout.DEFAULT_CONFIGURATION_NAME, null, null, null, SchemaVersion.V2_21);
-    Path cfgA = cfA.resolve(CfLayout.CONFIGURATION_XML);
-    Path cfgB = cfB.resolve(CfLayout.CONFIGURATION_XML);
-
-    List<MdObjectAddType> types = List.of(MdObjectAddType.values());
-    int idx = 2000;
-    for (MdObjectAddType type : types) {
-      String name = type.namePrefix() + idx++;
-      MdObjectAdd.add(cfgA, name, SchemaVersion.V2_21, type);
-      MdObjectAdd.add(cfgB, name, SchemaVersion.V2_21, type);
-      Path outA = CfObjectPathResolver.objectXml(cfA, type.configurationXmlTag(), name).orElseThrow();
-      Path outB = CfObjectPathResolver.objectXml(cfB, type.configurationXmlTag(), name).orElseThrow();
-      assertThat(Files.readString(outA))
-        .as("детерминированный вывод %s", type)
-        .isEqualTo(Files.readString(outB));
-      DesignerXml.read(outA, SchemaVersion.V2_21);
-    }
-  }
-
 }

--- a/src/test/java/io/github/yellowhammer/designerxml/cf/SubsystemTreeBuilderTest.java
+++ b/src/test/java/io/github/yellowhammer/designerxml/cf/SubsystemTreeBuilderTest.java
@@ -1,0 +1,69 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+import io.github.yellowhammer.designerxml.SchemaVersion;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Дерево подсистем: вложенность и состав читаются из XML, а не угадываются по каталогам.
+ */
+class SubsystemTreeBuilderTest {
+
+  @Test
+  void build_readsNestedSubsystemsAndContent() throws Exception {
+    List<SubsystemTreeBuilder.SubsystemNodeDto> roots =
+      SubsystemTreeBuilder.build(configurationXml(), SchemaVersion.V2_20);
+
+    assertThat(roots).as("подсистемы верхнего уровня").isNotEmpty();
+    assertThat(roots).allSatisfy(node -> {
+      assertThat(node.name()).isNotBlank();
+      assertThat(node.xmlPath()).endsWith(node.name() + ".xml");
+    });
+
+    SubsystemTreeBuilder.SubsystemNodeDto withChildren = roots.stream()
+      .filter(node -> !node.children().isEmpty())
+      .findFirst()
+      .orElseThrow(() -> new AssertionError("ожидалась подсистема с вложенными"));
+    assertThat(withChildren.children()).allSatisfy(child ->
+      assertThat(child.xmlPath()).contains(withChildren.name()));
+
+    assertThat(roots.stream().anyMatch(node -> !node.contentRefs().isEmpty()))
+      .as("состав подсистем должен читаться")
+      .isTrue();
+  }
+
+  @Test
+  void build_returnsEachSubsystemOnce() throws Exception {
+    List<SubsystemTreeBuilder.SubsystemNodeDto> roots =
+      SubsystemTreeBuilder.build(configurationXml(), SchemaVersion.V2_20);
+
+    long total = count(roots);
+    long unique = roots.stream().mapToLong(SubsystemTreeBuilderTest::countUniquePaths).sum();
+    assertThat(total).isEqualTo(unique);
+  }
+
+  private static long count(List<SubsystemTreeBuilder.SubsystemNodeDto> nodes) {
+    return nodes.stream().mapToLong(node -> 1 + count(node.children())).sum();
+  }
+
+  private static long countUniquePaths(SubsystemTreeBuilder.SubsystemNodeDto node) {
+    return 1 + node.children().stream().mapToLong(SubsystemTreeBuilderTest::countUniquePaths).sum();
+  }
+
+  private static Path configurationXml() {
+    return Path.of(System.getProperty("fixtures.ssl31.root")).resolve("src").resolve("cf").resolve("Configuration.xml");
+  }
+}

--- a/src/test/java/io/github/yellowhammer/designerxml/cli/ApplyMutationCmdTest.java
+++ b/src/test/java/io/github/yellowhammer/designerxml/cli/ApplyMutationCmdTest.java
@@ -535,6 +535,45 @@ class ApplyMutationCmdTest {
     assertThat(exit).as("операция %s", op).isZero();
   }
 
+  /**
+   * Платформа требует тип у реквизита, измерения и ресурса: без него объект не загрузится.
+   * Схема этого не ловит — {@code Type} в XSD объявлен как {@code minOccurs="0"} (#6), поэтому
+   * проверяем наличие типа явно.
+   */
+  @Test
+  void addedChildren_haveDefaultType() throws Exception {
+    Path register = copyToTemp(sampleInformationRegisterXml());
+    run("cf-md-dimension-add", register, "\"name\":\"Склад\"");
+    run("cf-md-resource-add", register, "\"name\":\"Количество\"");
+    run("cf-md-attribute-add", register, "\"name\":\"Примечание\"");
+    String registerXml = Files.readString(register, StandardCharsets.UTF_8);
+    for (String childName : java.util.List.of("Склад", "Количество", "Примечание")) {
+      assertThat(typeBlockAfterName(registerXml, childName))
+        .as("тип у %s", childName)
+        .contains("xs:string")
+        .contains("<v8:Length>10</v8:Length>")
+        .contains("<v8:AllowedLength>Variable</v8:AllowedLength>");
+    }
+
+    Path catalog = copyToTemp(sampleCatalogXml());
+    run("cf-md-attribute-add", catalog, "\"name\":\"НовыйРеквизит\"");
+    assertThat(typeBlockAfterName(Files.readString(catalog, StandardCharsets.UTF_8), "НовыйРеквизит"))
+      .contains("xs:string");
+
+    Path enumXml = copyToTemp(sampleEnumXml());
+    run("cf-md-enum-value-add", enumXml, "\"name\":\"НовоеЗначение\"");
+    assertThat(typeBlockAfterName(Files.readString(enumXml, StandardCharsets.UTF_8), "НовоеЗначение"))
+      .as("у значения перечисления типа нет")
+      .doesNotContain("<Type>");
+  }
+
+  /** Кусок XML после элемента Name с заданным значением: там платформа и держит тип. */
+  private static String typeBlockAfterName(String xml, String name) {
+    int at = xml.indexOf("<Name>" + name + "</Name>");
+    assertThat(at).as("объект %s должен быть в XML", name).isGreaterThan(0);
+    return xml.substring(at, Math.min(xml.length(), at + 400));
+  }
+
   @Test
   void unknownOp_returnsError() throws Exception {
     Path params = writeParams("{\"op\":\"no-such-op\"}");

--- a/src/test/java/io/github/yellowhammer/designerxml/cli/ApplyMutationCmdTest.java
+++ b/src/test/java/io/github/yellowhammer/designerxml/cli/ApplyMutationCmdTest.java
@@ -331,6 +331,50 @@ class ApplyMutationCmdTest {
   }
 
   @Test
+  void objectSet_constantType_writesTypeWithQualifiersGranularly() throws Exception {
+    Path objectXml = copyToTemp(sampleConstantXml());
+    String before = Files.readString(objectXml, StandardCharsets.UTF_8);
+    io.github.yellowhammer.designerxml.cf.MdObjectPropertiesDto dto =
+      io.github.yellowhammer.designerxml.cf.MdObjectPropertiesEdit.readDto(
+        objectXml, io.github.yellowhammer.designerxml.SchemaVersion.V2_20);
+    assertThat(dto.constant.type).as("тип значения должен читаться").isNotNull();
+    assertThat(dto.constant.type.types).containsExactly("xs:boolean");
+
+    // Булево -> строка длиной 25, как это делает конфигуратор.
+    dto.constant.type.types = new java.util.ArrayList<>(java.util.List.of("xs:string"));
+    io.github.yellowhammer.designerxml.cf.MdTypeDescriptionDto.MdStringQualifiersDto q =
+      new io.github.yellowhammer.designerxml.cf.MdTypeDescriptionDto.MdStringQualifiersDto();
+    q.length = "25";
+    q.allowedLength = "VARIABLE";
+    dto.constant.type.stringQualifiers = q;
+    Path params = writeParams(
+      "{"
+        + "\"op\":\"cf-md-object-set\","
+        + "\"objectXml\":" + json(objectXml.toString()) + ","
+        + "\"schemaVersion\":\"V2_20\","
+        + "\"payloadJson\":" + json(new com.google.gson.Gson().toJson(dto))
+        + "}");
+
+    int exit = new CommandLine(new DesignerXmlCli()).execute("apply-mutation", "--params", params.toString());
+
+    assertThat(exit).isZero();
+    String after = Files.readString(objectXml, StandardCharsets.UTF_8);
+    assertThat(after).contains("<v8:Type xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">xs:string</v8:Type>");
+    assertThat(after).contains("<v8:Length>25</v8:Length>");
+    assertThat(after).contains("<v8:AllowedLength>Variable</v8:AllowedLength>");
+    assertThat(after).doesNotContain("xs:boolean");
+    // Гранулярность: тип раскрылся в квалификаторы, остальное не переформатировано.
+    assertThat(countLines(after) - countLines(before)).isBetween(0L, 5L);
+    // Тип читается обратно.
+    io.github.yellowhammer.designerxml.cf.MdObjectPropertiesDto reread =
+      io.github.yellowhammer.designerxml.cf.MdObjectPropertiesEdit.readDto(
+        objectXml, io.github.yellowhammer.designerxml.SchemaVersion.V2_20);
+    assertThat(reread.constant.type.types).containsExactly("xs:string");
+    assertThat(reread.constant.type.stringQualifiers.length).isEqualTo("25");
+    assertThat(reread.constant.type.stringQualifiers.allowedLength).isEqualTo("VARIABLE");
+  }
+
+  @Test
   void objectSet_commonModuleFlags_writeGranularly() throws Exception {
     Path objectXml = copyToTemp(sampleCommonModuleXml());
     String before = Files.readString(objectXml, StandardCharsets.UTF_8);

--- a/src/test/java/io/github/yellowhammer/designerxml/cli/ApplyMutationCmdTest.java
+++ b/src/test/java/io/github/yellowhammer/designerxml/cli/ApplyMutationCmdTest.java
@@ -575,6 +575,45 @@ class ApplyMutationCmdTest {
   }
 
   @Test
+  void objectSet_attributeType_writesGranularly() throws Exception {
+    Path objectXml = copyToTemp(sampleCatalogXml());
+    String before = Files.readString(objectXml, StandardCharsets.UTF_8);
+    io.github.yellowhammer.designerxml.cf.MdObjectPropertiesDto dto =
+      io.github.yellowhammer.designerxml.cf.MdObjectPropertiesEdit.readDto(
+        objectXml, io.github.yellowhammer.designerxml.SchemaVersion.V2_20);
+    io.github.yellowhammer.designerxml.cf.MdNamedPropertyDto attribute = dto.attributes.stream()
+      .filter(a -> a.type != null && a.type.types.contains("xs:string"))
+      .findFirst()
+      .orElseThrow(() -> new AssertionError("нужен строковый реквизит"));
+    assertThat(attribute.type.stringQualifiers).as("квалификаторы строки читаются").isNotNull();
+
+    attribute.type.stringQualifiers.length = "77";
+    Path params = writeParams(
+      "{"
+        + "\"op\":\"cf-md-object-set\","
+        + "\"objectXml\":" + json(objectXml.toString()) + ","
+        + "\"schemaVersion\":\"V2_20\","
+        + "\"payloadJson\":" + json(new com.google.gson.Gson().toJson(dto))
+        + "}");
+
+    int exit = new CommandLine(new DesignerXmlCli()).execute("apply-mutation", "--params", params.toString());
+
+    assertThat(exit).isZero();
+    String after = Files.readString(objectXml, StandardCharsets.UTF_8);
+    assertThat(after).contains("<v8:Length>77</v8:Length>");
+    assertThat(countLines(after)).isEqualTo(countLines(before));
+
+    io.github.yellowhammer.designerxml.cf.MdObjectPropertiesDto reread =
+      io.github.yellowhammer.designerxml.cf.MdObjectPropertiesEdit.readDto(
+        objectXml, io.github.yellowhammer.designerxml.SchemaVersion.V2_20);
+    io.github.yellowhammer.designerxml.cf.MdNamedPropertyDto rereadAttribute = reread.attributes.stream()
+      .filter(a -> a.name.equals(attribute.name))
+      .findFirst()
+      .orElseThrow();
+    assertThat(rereadAttribute.type.stringQualifiers.length).isEqualTo("77");
+  }
+
+  @Test
   void unknownOp_returnsError() throws Exception {
     Path params = writeParams("{\"op\":\"no-such-op\"}");
     int exit = new CommandLine(new DesignerXmlCli()).execute("apply-mutation", "--params", params.toString());

--- a/src/test/java/io/github/yellowhammer/designerxml/cli/ApplyMutationCmdTest.java
+++ b/src/test/java/io/github/yellowhammer/designerxml/cli/ApplyMutationCmdTest.java
@@ -402,6 +402,71 @@ class ApplyMutationCmdTest {
   }
 
   @Test
+  void objectSet_informationRegisterScalars_writeGranularly() throws Exception {
+    Path objectXml = copyToTemp(sampleInformationRegisterXml());
+    String before = Files.readString(objectXml, StandardCharsets.UTF_8);
+    io.github.yellowhammer.designerxml.cf.MdObjectPropertiesDto dto =
+      io.github.yellowhammer.designerxml.cf.MdObjectPropertiesEdit.readDto(
+        objectXml, io.github.yellowhammer.designerxml.SchemaVersion.V2_20);
+    assertThat(dto.kind).isEqualTo("informationRegister");
+    assertThat(dto.register).as("регистр сведений должен читаться гранулярно").isNotNull();
+    assertThat(dto.register.writeMode).isEqualTo("INDEPENDENT");
+    dto.synonymRu = "Демо: Графики работы 222";
+    dto.register.informationRegisterPeriodicity = "DAY";
+    dto.register.editType = "BOTH_WAYS";
+    dto.register.enableTotalsSliceLast = !dto.register.enableTotalsSliceLast;
+    Path params = writeParams(
+      "{"
+        + "\"op\":\"cf-md-object-set\","
+        + "\"objectXml\":" + json(objectXml.toString()) + ","
+        + "\"schemaVersion\":\"V2_20\","
+        + "\"payloadJson\":" + json(new com.google.gson.Gson().toJson(dto))
+        + "}");
+
+    int exit = new CommandLine(new DesignerXmlCli()).execute("apply-mutation", "--params", params.toString());
+
+    assertThat(exit).isZero();
+    String after = Files.readString(objectXml, StandardCharsets.UTF_8);
+    assertThat(after).contains("Демо: Графики работы 222");
+    assertThat(after).contains("<InformationRegisterPeriodicity>Day</InformationRegisterPeriodicity>");
+    assertThat(after).contains("<EditType>BothWays</EditType>");
+    assertThat(countLines(after)).isEqualTo(countLines(before));
+  }
+
+  @Test
+  void objectSet_accumulationRegisterScalars_writeGranularly() throws Exception {
+    Path objectXml = copyToTemp(sampleAccumulationRegisterXml());
+    String before = Files.readString(objectXml, StandardCharsets.UTF_8);
+    io.github.yellowhammer.designerxml.cf.MdObjectPropertiesDto dto =
+      io.github.yellowhammer.designerxml.cf.MdObjectPropertiesEdit.readDto(
+        objectXml, io.github.yellowhammer.designerxml.SchemaVersion.V2_20);
+    assertThat(dto.kind).isEqualTo("accumulationRegister");
+    assertThat(dto.register).as("регистр накопления должен читаться гранулярно").isNotNull();
+    assertThat(dto.register.registerType).isIn("BALANCE", "TURNOVERS");
+    // Поля регистра сведений у регистра накопления пусты: у вида объекта их просто нет.
+    assertThat(dto.register.informationRegisterPeriodicity).isNull();
+    dto.register.enableTotalsSplitting = !dto.register.enableTotalsSplitting;
+    dto.register.explanationRu = "Пояснение из теста";
+    Path params = writeParams(
+      "{"
+        + "\"op\":\"cf-md-object-set\","
+        + "\"objectXml\":" + json(objectXml.toString()) + ","
+        + "\"schemaVersion\":\"V2_20\","
+        + "\"payloadJson\":" + json(new com.google.gson.Gson().toJson(dto))
+        + "}");
+
+    int exit = new CommandLine(new DesignerXmlCli()).execute("apply-mutation", "--params", params.toString());
+
+    assertThat(exit).isZero();
+    String after = Files.readString(objectXml, StandardCharsets.UTF_8);
+    assertThat(after).contains("<EnableTotalsSplitting>" + dto.register.enableTotalsSplitting
+      + "</EnableTotalsSplitting>");
+    assertThat(after).contains("Пояснение из теста");
+    // Гранулярность: пустое пояснение раскрылось в локализованную строку.
+    assertThat(countLines(after) - countLines(before)).isBetween(0L, 6L);
+  }
+
+  @Test
   void unknownOp_returnsError() throws Exception {
     Path params = writeParams("{\"op\":\"no-such-op\"}");
     int exit = new CommandLine(new DesignerXmlCli()).execute("apply-mutation", "--params", params.toString());
@@ -477,6 +542,14 @@ class ApplyMutationCmdTest {
 
   private static Path sampleCommonModuleXml() {
     return cfDir().resolve("CommonModules").resolve("_ДемоЗаметки.xml");
+  }
+
+  private static Path sampleInformationRegisterXml() {
+    return cfDir().resolve("InformationRegisters").resolve("_ДемоГрафикиРаботы.xml");
+  }
+
+  private static Path sampleAccumulationRegisterXml() {
+    return cfDir().resolve("AccumulationRegisters").resolve("_ДемоОборотыПоСчетамНаОплату.xml");
   }
 
   private static Path cfDir() {

--- a/src/test/java/io/github/yellowhammer/designerxml/cli/ApplyMutationCmdTest.java
+++ b/src/test/java/io/github/yellowhammer/designerxml/cli/ApplyMutationCmdTest.java
@@ -467,6 +467,75 @@ class ApplyMutationCmdTest {
   }
 
   @Test
+  void registerChildren_addRenameAndReorderDimensions() throws Exception {
+    Path objectXml = copyToTemp(sampleInformationRegisterXml());
+    io.github.yellowhammer.designerxml.cf.MdObjectPropertiesDto before =
+      io.github.yellowhammer.designerxml.cf.MdObjectPropertiesEdit.readDto(
+        objectXml, io.github.yellowhammer.designerxml.SchemaVersion.V2_20);
+    assertThat(before.dimensions).as("измерения должны читаться").isNotEmpty();
+    assertThat(before.resources).as("ресурсы должны читаться").isNotEmpty();
+    String firstDimension = before.dimensions.get(0).name;
+
+    run("cf-md-dimension-add", objectXml, "\"name\":\"НовоеИзмерение\"");
+    run("cf-md-resource-add", objectXml, "\"name\":\"НовыйРесурс\"");
+    run("cf-md-dimension-rename", objectXml, "\"oldName\":\"НовоеИзмерение\",\"newName\":\"Склад\"");
+    run("cf-md-dimension-reorder", objectXml,
+      "\"payloadJson\":" + json("[\"Склад\",\"" + firstDimension + "\"]"));
+
+    io.github.yellowhammer.designerxml.cf.MdObjectPropertiesDto after =
+      io.github.yellowhammer.designerxml.cf.MdObjectPropertiesEdit.readDto(
+        objectXml, io.github.yellowhammer.designerxml.SchemaVersion.V2_20);
+    assertThat(after.dimensions.stream().map(d -> d.name))
+      .as("порядок измерений задан списком")
+      .startsWith("Склад", firstDimension);
+    assertThat(after.resources.stream().map(r -> r.name)).contains("НовыйРесурс");
+
+    run("cf-md-dimension-delete", objectXml, "\"name\":\"Склад\"");
+    io.github.yellowhammer.designerxml.cf.MdObjectPropertiesDto afterDelete =
+      io.github.yellowhammer.designerxml.cf.MdObjectPropertiesEdit.readDto(
+        objectXml, io.github.yellowhammer.designerxml.SchemaVersion.V2_20);
+    assertThat(afterDelete.dimensions.stream().map(d -> d.name)).doesNotContain("Склад");
+  }
+
+  @Test
+  void objectSet_registerDimensionSynonym_writesGranularly() throws Exception {
+    Path objectXml = copyToTemp(sampleInformationRegisterXml());
+    String before = Files.readString(objectXml, StandardCharsets.UTF_8);
+    io.github.yellowhammer.designerxml.cf.MdObjectPropertiesDto dto =
+      io.github.yellowhammer.designerxml.cf.MdObjectPropertiesEdit.readDto(
+        objectXml, io.github.yellowhammer.designerxml.SchemaVersion.V2_20);
+    dto.dimensions.get(0).synonymRu = "Дата графика";
+    dto.resources.get(0).synonymRu = "Значение графика";
+    Path params = writeParams(
+      "{"
+        + "\"op\":\"cf-md-object-set\","
+        + "\"objectXml\":" + json(objectXml.toString()) + ","
+        + "\"schemaVersion\":\"V2_20\","
+        + "\"payloadJson\":" + json(new com.google.gson.Gson().toJson(dto))
+        + "}");
+
+    int exit = new CommandLine(new DesignerXmlCli()).execute("apply-mutation", "--params", params.toString());
+
+    assertThat(exit).isZero();
+    String after = Files.readString(objectXml, StandardCharsets.UTF_8);
+    assertThat(after).contains("Дата графика").contains("Значение графика");
+    assertThat(countLines(after)).isEqualTo(countLines(before));
+  }
+
+  /** Запускает apply-mutation с полями операции; objectXml и schemaVersion добавляются сами. */
+  private static void run(String op, Path objectXml, String fieldsJson) throws Exception {
+    Path params = writeParams(
+      "{"
+        + "\"op\":" + json(op) + ","
+        + "\"objectXml\":" + json(objectXml.toString()) + ","
+        + "\"schemaVersion\":\"V2_20\","
+        + fieldsJson
+        + "}");
+    int exit = new CommandLine(new DesignerXmlCli()).execute("apply-mutation", "--params", params.toString());
+    assertThat(exit).as("операция %s", op).isZero();
+  }
+
+  @Test
   void unknownOp_returnsError() throws Exception {
     Path params = writeParams("{\"op\":\"no-such-op\"}");
     int exit = new CommandLine(new DesignerXmlCli()).execute("apply-mutation", "--params", params.toString());

--- a/src/test/java/io/github/yellowhammer/designerxml/cli/ApplyMutationCmdTest.java
+++ b/src/test/java/io/github/yellowhammer/designerxml/cli/ApplyMutationCmdTest.java
@@ -269,6 +269,95 @@ class ApplyMutationCmdTest {
   }
 
   @Test
+  void objectSet_enumScalars_writeGranularly() throws Exception {
+    Path objectXml = copyToTemp(sampleEnumXml());
+    String before = Files.readString(objectXml, StandardCharsets.UTF_8);
+    io.github.yellowhammer.designerxml.cf.MdObjectPropertiesDto dto =
+      io.github.yellowhammer.designerxml.cf.MdObjectPropertiesEdit.readDto(
+        objectXml, io.github.yellowhammer.designerxml.SchemaVersion.V2_20);
+    assertThat(dto.enumeration).as("перечисление должно читаться гранулярно").isNotNull();
+    dto.synonymRu = "Демо: Статусы заказов 222";
+    dto.enumeration.quickChoice = !dto.enumeration.quickChoice;
+    dto.enumeration.choiceMode = "QUICK_CHOICE";
+    dto.enumeration.explanationRu = "Пояснение из теста";
+    Path params = writeParams(
+      "{"
+        + "\"op\":\"cf-md-object-set\","
+        + "\"objectXml\":" + json(objectXml.toString()) + ","
+        + "\"schemaVersion\":\"V2_20\","
+        + "\"payloadJson\":" + json(new com.google.gson.Gson().toJson(dto))
+        + "}");
+
+    int exit = new CommandLine(new DesignerXmlCli()).execute("apply-mutation", "--params", params.toString());
+
+    assertThat(exit).isZero();
+    String after = Files.readString(objectXml, StandardCharsets.UTF_8);
+    assertThat(after).contains("Демо: Статусы заказов 222");
+    assertThat(after).contains("<ChoiceMode>QuickChoice</ChoiceMode>");
+    assertThat(after).contains("Пояснение из теста");
+    // Гранулярность: пустое пояснение раскрылось в локализованную строку, остальное не переформатировано.
+    assertThat(countLines(after) - countLines(before)).isBetween(0L, 6L);
+  }
+
+  @Test
+  void objectSet_constantScalars_writeGranularly() throws Exception {
+    Path objectXml = copyToTemp(sampleConstantXml());
+    String before = Files.readString(objectXml, StandardCharsets.UTF_8);
+    io.github.yellowhammer.designerxml.cf.MdObjectPropertiesDto dto =
+      io.github.yellowhammer.designerxml.cf.MdObjectPropertiesEdit.readDto(
+        objectXml, io.github.yellowhammer.designerxml.SchemaVersion.V2_20);
+    assertThat(dto.constant).as("константа должна читаться гранулярно").isNotNull();
+    dto.constant.passwordMode = !dto.constant.passwordMode;
+    dto.constant.fillChecking = "SHOW_ERROR";
+    dto.constant.toolTipRu = "Подсказка из теста";
+    Path params = writeParams(
+      "{"
+        + "\"op\":\"cf-md-object-set\","
+        + "\"objectXml\":" + json(objectXml.toString()) + ","
+        + "\"schemaVersion\":\"V2_20\","
+        + "\"payloadJson\":" + json(new com.google.gson.Gson().toJson(dto))
+        + "}");
+
+    int exit = new CommandLine(new DesignerXmlCli()).execute("apply-mutation", "--params", params.toString());
+
+    assertThat(exit).isZero();
+    String after = Files.readString(objectXml, StandardCharsets.UTF_8);
+    assertThat(after).contains("<FillChecking>ShowError</FillChecking>");
+    assertThat(after).contains("Подсказка из теста");
+    // Тип значения не трогали — остаётся как был.
+    assertThat(after).contains("<Type>");
+    // Гранулярность: пустая подсказка раскрылась в локализованную строку, остальное не переформатировано.
+    assertThat(countLines(after) - countLines(before)).isBetween(0L, 6L);
+  }
+
+  @Test
+  void objectSet_commonModuleFlags_writeGranularly() throws Exception {
+    Path objectXml = copyToTemp(sampleCommonModuleXml());
+    String before = Files.readString(objectXml, StandardCharsets.UTF_8);
+    io.github.yellowhammer.designerxml.cf.MdObjectPropertiesDto dto =
+      io.github.yellowhammer.designerxml.cf.MdObjectPropertiesEdit.readDto(
+        objectXml, io.github.yellowhammer.designerxml.SchemaVersion.V2_20);
+    assertThat(dto.commonModule).as("общий модуль должен читаться гранулярно").isNotNull();
+    dto.commonModule.serverCall = !dto.commonModule.serverCall;
+    dto.commonModule.privileged = !dto.commonModule.privileged;
+    Path params = writeParams(
+      "{"
+        + "\"op\":\"cf-md-object-set\","
+        + "\"objectXml\":" + json(objectXml.toString()) + ","
+        + "\"schemaVersion\":\"V2_20\","
+        + "\"payloadJson\":" + json(new com.google.gson.Gson().toJson(dto))
+        + "}");
+
+    int exit = new CommandLine(new DesignerXmlCli()).execute("apply-mutation", "--params", params.toString());
+
+    assertThat(exit).isZero();
+    String after = Files.readString(objectXml, StandardCharsets.UTF_8);
+    assertThat(after).contains("<Privileged>" + dto.commonModule.privileged + "</Privileged>");
+    assertThat(after).contains("<ServerCall>" + dto.commonModule.serverCall + "</ServerCall>");
+    assertThat(countLines(after)).isEqualTo(countLines(before));
+  }
+
+  @Test
   void unknownOp_returnsError() throws Exception {
     Path params = writeParams("{\"op\":\"no-such-op\"}");
     int exit = new CommandLine(new DesignerXmlCli()).execute("apply-mutation", "--params", params.toString());
@@ -332,6 +421,22 @@ class ApplyMutationCmdTest {
       .resolve("cf")
       .resolve("Documents")
       .resolve("_ДемоЗаказПокупателя.xml");
+  }
+
+  private static Path sampleEnumXml() {
+    return cfDir().resolve("Enums").resolve("_ДемоСтатусыЗаказовПокупателей.xml");
+  }
+
+  private static Path sampleConstantXml() {
+    return cfDir().resolve("Constants").resolve("_ДемоИспользоватьНесколькоОрганизаций.xml");
+  }
+
+  private static Path sampleCommonModuleXml() {
+    return cfDir().resolve("CommonModules").resolve("_ДемоЗаметки.xml");
+  }
+
+  private static Path cfDir() {
+    return Path.of(System.getProperty("fixtures.ssl31.root")).resolve("src").resolve("cf");
   }
 
   private static Path sampleCatalogXml() {


### PR DESCRIPTION
Технический PR: #5 слился в `feature/document-properties` вместо main, потому что база не переадресовалась после слияния #4 (удаление веток при слиянии в репозитории выключено). Здесь тот же набор коммитов доезжает до main.

Содержимое — как в #5: гранулярные DTO перечисления, константы, общего модуля и регистров, операции над значениями перечисления и над измерениями/ресурсами, DTO описания типа с квалификаторами, чтение дерева подсистем одной операцией, тесты скаффолда на всех поддерживаемых схемах, версия 0.4.0.