### PR TITLE
chore: вернули версию, которую ставит релизный workflow

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ repositories {
 }
 
 group = "io.github.yellowhammer"
-version = "0.4.0"
+version = "0.3.2"
 
 // Корень XSD: каталог submodule `resources/namespace-forest/` (см. .gitmodules, gradle.properties `xsd.root`).
 val xsdRootPath = (findProperty("xsd.root") as String?) ?: "resources/namespace-forest"


### PR DESCRIPTION
Убирает ручной бамп версии до 0.4.0: `version` в `build.gradle.kts` снова `0.3.2`, как её оставил последний релиз.

Версия принадлежит релизному workflow: он ставит её из тега или из введённого номера (`sed -i` по строке `version = "..."`) и коммитит в main как `chore(release): version X`. Ручной бамп занимал номер заранее и не давал выбрать версию в момент выпуска. Кроме этой строки версия нигде не зашита.