### PR TITLE
ci: убрали бампы зависимостей из changelog

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -42,6 +42,8 @@ commit_parsers = [
     { message = "^test", group = "<!-- 6 -->Тестирование" },
     { message = "^chore\\(release\\)", skip = true },
     { message = "^chore\\(deps.*\\)", skip = true },
+    { message = "^build\\(deps.*\\)", skip = true },
+    { message = "^ci\\(deps.*\\)", skip = true },
     { message = "^chore\\(pr\\)", skip = true },
     { message = "^chore\\(pull\\)", skip = true },
     { message = "^chore|^ci", group = "<!-- 7 -->Обслуживание" },


### PR DESCRIPTION
В `cliff.toml` бампы Dependabot скрывались только по префиксу `chore(deps)`, а Dependabot коммитит их ещё и как `build(deps)` (Gradle) и `ci(deps)` (github-actions). Из-за этого они всплывали в changelog: в md-sparrow строкой `deps: Bump org.assertj:assertj-core` в «Прочем».

Намерение в конфиге было, правило просто не покрывало все префиксы. Теперь скрыты все три.

## Проверка
Локальный `git-cliff --unreleased` до правки давал разделы «Новые возможности», «Исправления», «Тестирование» и «Прочее» с бампом assertj; после правки «Прочее» пропало, остальные не изменились.

Такая же правка для расширения — в его репозитории отдельным PR: там в 0.8.0 в «Обслуживание» попадало восемь строк `ci(deps): bump ...`.