### PR TITLE
feat(cf-md-object): свойства объектов метаданных всех поддержанных видов

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,8 +9,8 @@
 ```bash
 ./gradlew build
 ./gradlew test
-./gradlew shadowJar   # fat JAR → build/libs/md-sparrow-*-all.jar (VS Code / скрипты)
-./gradlew javadoc   # HTML → build/docs/javadoc/index.html (в VS Code: задача «javadoc»)
+./gradlew shadowJar   # fat JAR → build/libs/md-sparrow-*-all.jar
+./gradlew javadoc     # HTML → build/docs/javadoc/index.html
 ```
 
 Проверка лицензионных заголовков входит в `./gradlew check` (задача `license`).
@@ -31,6 +31,12 @@
 `bindings.xjb`/`catalog.xml` для XJC и карта import'ов валидатора строятся автоматически
 (см. `build.gradle.kts` и `XmlValidator`) — править их вручную не нужно.
 
-## Интеграция в IDE (отдельная задача)
+## Проверка своей сборки
 
-Имеет смысл вызывать библиотеку из расширения **1C: Platform Tools** ([vscode-1c-platform-tools](https://github.com/yellow-hammer/vscode-1c-platform-tools)): JDK 21, артефакт `./gradlew shadowJar` → `build/libs/md-sparrow-*-all.jar`, подпроцесс `java -jar …` с подкомандами CLI (`add-md-object --type CATALOG` и др.). Дублировать отдельное мини-расширение под это не обязательно — достаточно настроек путей и команды в существующем дереве инструментов.
+`./gradlew shadowJar` собирает fat JAR в `build/libs/`. Если поведение CLI расходится с исходниками, а тесты зелёные — пересоберите с `--rerun-tasks`: причина обычно в протухшем build cache.
+
+Программы, вызывающие библиотеку подпроцессом, обычно берут выпущенный JAR из GitHub Releases, поэтому для проверки своей сборки в такой программе нужно указать ей путь к локальному файлу и отключить автообновление, если оно есть.
+
+## Новые операции CLI
+
+Изменения и чтение вызывающие программы делают не отдельными подкомандами, а двумя каналами: `apply-mutation` и `read-json` с `--params` — путём к UTF-8 JSON. Причина в `CliParams`: на Windows лаунчер `java.exe` декодирует `argv` через ANSI-кодовую страницу ОС, и кириллические имена и пути превращаются в `?`. Поэтому новая операция заводится полем `op` в этом канале, а одиночная подкоманда остаётся для скриптов и ручного запуска.

--- a/README.md
+++ b/README.md
@@ -4,55 +4,40 @@
 [![telegram chat](resources/badges/telegram-chat.png)](https://t.me/wonder_yellow)
 [![Ask Devin](resources/badges/deepwiki-badge.png)](https://deepwiki.com/yellow-hammer/md-sparrow)
 
-Java-библиотека для чтения/записи XML метаданных 1С (`MetaDataObject`) по XSD из [namespace-forest](https://github.com/yellow-hammer/namespace-forest).
+Чтение и запись XML метаданных 1С (`MetaDataObject`) по XSD из [namespace-forest](https://github.com/yellow-hammer/namespace-forest). Поддержаны все версии формата выгрузки от 2.10 до 2.21.
 
-## Что важно перед стартом
+Работает и как Java-библиотека, и как CLI: подходит и для встраивания в инструменты разработки, и для скриптов сборки.
 
-- Нужен JDK 21.
-- Нужны submodule: `resources/namespace-forest/` (XSD), `fixtures/ssl31/` (типовая конфигурация для тестов чтения) и `fixtures/samples-1c-platform/` (эталоны для scaffold). Команда: `git submodule update --init --recursive`.
+## Что умеет
 
-## API
+- Читать и писать свойства объектов метаданных, их реквизиты и табличные части, не трогая остальной файл: правка идёт точечно, форматирование и порядок элементов сохраняются.
+- Создавать объекты, расширения и пустую выгрузку из эталонов, снятых с платформы, в формате нужной версии.
+- Проверять выгрузку: валидация по XSD, целостность состава и ссылок, round-trip JAXB, перекодировка между версиями формата.
+- Отдавать дерево и граф метаданных проекта в JSON для внешних инструментов.
 
-- **`io.github.yellowhammer.designerxml.DesignerXml`** — чтение/запись JAXB `MetaDataObject` по [`SchemaVersion`](src/main/java/io/github/yellowhammer/designerxml/SchemaVersion.java).
-- **`io.github.yellowhammer.designerxml.XmlValidator`** — валидация XML по XSD из submodule `resources/namespace-forest`.
-- **`io.github.yellowhammer.designerxml.cf.MdObjectAdd`** — создание новых объектов метаданных в `src/cf` из golden-эталонов нужной версии (см. [docs/scaffold-golden.md](docs/scaffold-golden.md)).
-- **`io.github.yellowhammer.designerxml.cf.CatalogFormEdit`** — чтение/запись полей формы справочника (имя, синоним ru, комментарий) через JAXB.
-- **`io.github.yellowhammer.designerxml.cf.MdObjectChildMutations`** — CRUD мутации дочерних узлов объекта (реквизиты, ТЧ, реквизиты ТЧ).
+## Начало работы
 
-## CLI (`DesignerXmlCli`)
+Нужен JDK 21 и submodule со схемами и эталонами:
 
-Основные команды CLI:
+```bash
+git submodule update --init --recursive
+./gradlew build
+./gradlew shadowJar
+```
 
-- `validate` — проверка XML по XSD (`-v V2_10`…`V2_21`, путь к XSD root).
-- `round-trip` — проверка JAXB: прочитать и записать файл.
-- `transcode` — перекодировать XML метаданных между версиями формата (понижение/повышение).
-- `init-empty-cf` — инициализация пустой выгрузки в `src/cf`.
-- `init-empty-cfe` — каркас пустого расширения конфигурации (`--from-configuration` берёт режимы совместимости из основной конфигурации).
-- `validate-dump` — проверка целостности выгрузки (состав, ссылки, версии формата) с JSON-списком находок.
-- `project-metadata-tree` — JSON-дерево метаданных по корню проекта (узлы с синонимами и родительскими подсистемами).
-- `cf-md-graph` — граф метаданных проекта (узлы + типизированные связи) в JSON; используется расширением VS Code для ER-диаграмм.
-- `add-md-object` — создание объекта метаданных (`--type`: `CATALOG`, `DOCUMENT`, `ENUM`, … — 19 видов; для каталога доступны `--synonym-ru` / `--synonym-empty`).
-- `external-artifact-add` / `external-artifact-properties-get` / `…-set` / `…-rename` / `…-delete` / `…-duplicate` — отдельные внешние отчёты и обработки (`src/erf`, `src/epf`).
-- `cf-list-catalogs` — JSON-массив имён справочников из `ChildObjects`.
-- `cf-list-child-objects` — список имён дочерних объектов по `--tag`.
-- `cf-catalog-form-get` / `cf-catalog-form-set` — чтение/запись формы справочника.
-- `cf-md-object-get` / `cf-md-object-set` — чтение/запись DTO свойств объекта метаданных (имя, синоним, комментарий и т. д.).
-- `cf-md-object-structure-get` — чтение структуры объекта (секции, ТЧ, вложенные узлы).
-- `cf-md-object-rename` / `cf-md-object-delete` / `cf-md-object-duplicate` — переименование/удаление/копирование объекта метаданных.
-- `cf-md-attribute-*`, `cf-md-tabular-section-*`, `cf-md-tabular-attribute-*` — CRUD реквизитов и табличных частей (`add`/`rename`/`delete`/`duplicate`, см. `MdObjectChildMutations`).
-- `cf-configuration-properties-get` / `cf-configuration-properties-set` — чтение/запись свойств конфигурации (`Configuration.xml`).
+Собранный `build/libs/md-sparrow-*-all.jar` запускается напрямую; список команд и их параметры выдаёт сама программа:
 
-Интеграция добавления справочника: `io.github.yellowhammer.designerxml.cf.AddCatalogIntegrationTest` (`MdObjectAddType.CATALOG`; `Configuration.xml` + один `Catalogs/*.xml` из submodule `fixtures/ssl31`, временный `src/cf`).
+```bash
+java -jar build/libs/md-sparrow-0.4.1-all.jar --help
+```
 
-## Для разработчиков
+## Документация
 
-- [CONTRIBUTING.md](CONTRIBUTING.md) — как внести вклад (сборка, тесты, схемы, выпуск JAR).
+- [CONTRIBUTING.md](CONTRIBUTING.md) — сборка, тесты, схемы, выпуск JAR.
 - [docs/cf-layout.md](docs/cf-layout.md) — раскладка `src/cf` и порядок `ChildObjects`.
-- [docs/cf-md-object.md](docs/cf-md-object.md) — контракт свойств объектов метаданных (CLI cf-md-object, DTO, матрица типов).
-- [docs/scaffold-golden.md](docs/scaffold-golden.md) — архитектура scaffold по golden-эталонам.
+- [docs/cf-md-object.md](docs/cf-md-object.md) — контракт свойств объектов: DTO и матрица поддержки по видам.
+- [docs/scaffold-golden.md](docs/scaffold-golden.md) — создание объектов по эталонам.
 - [docs/validate-dump.md](docs/validate-dump.md) — проверка целостности выгрузки и виды находок.
-- **`.cursor/rules/`** — правила Cursor для агента (контекст JAXB, submodules, стиль).
-- `.github/workflows/release.yml` — выкладывает `md-sparrow-*-all.jar` в GitHub Releases при push тега `v*` или ручном запуске (workflow_dispatch с вводом версии).
 
 ## Лицензия
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -220,6 +220,8 @@ tasks.jar {
     manifest {
         attributes["Main-Class"] = application.mainClass.get()
         attributes["Implementation-Title"] = "md-sparrow"
+        // версию CLI берёт отсюда: иначе её пришлось бы дублировать в коде и она бы отставала
+        attributes["Implementation-Version"] = project.version
     }
 }
 
@@ -230,6 +232,7 @@ tasks.shadowJar {
     manifest {
         attributes["Main-Class"] = application.mainClass.get()
         attributes["Implementation-Title"] = "md-sparrow"
+        attributes["Implementation-Version"] = project.version
     }
 }
 

--- a/docs/cf-md-object.md
+++ b/docs/cf-md-object.md
@@ -1,6 +1,6 @@
 # Свойства объектов метаданных (cf-md-object)
 
-Контракт CLI-команд чтения и записи свойств объектов метаданных. Потребитель — расширение [vscode-1c-platform-tools](https://github.com/yellow-hammer/vscode-1c-platform-tools) (форма «Свойства объекта»); данные читаются и записываются только через JAXB, без правки XML на стороне клиента.
+Контракт CLI-команд чтения и записи свойств объектов метаданных. Данные читаются и записываются только через JAXB: вызывающая программа получает и отдаёт DTO, XML на её стороне не правится.
 
 ## Команды CLI
 
@@ -8,48 +8,65 @@
 |----------------------------------------------|----------------------|
 | `cf-md-object-get <путь.xml> -v V2_10…V2_21` | stdout: один JSON    |
 | `cf-md-object-set <путь.xml> <json> -v …`    | запись из файла JSON |
+| `cf-md-object-enums -v V2_10…V2_21`          | stdout: JSON допустимых значений перечислимых свойств |
 
 ### CRUD дочерних узлов объекта
 
 | Команда                                               | Назначение                |
 |-------------------------------------------------------|---------------------------|
 | `cf-md-attribute-add/rename/delete/duplicate`         | Реквизиты объекта         |
+| `cf-md-command-add/rename/delete`                     | Команды объекта           |
 | `cf-md-tabular-section-add/rename/delete/duplicate`   | Табличные части объекта   |
 | `cf-md-tabular-attribute-add/rename/delete/duplicate` | Реквизиты табличной части |
 
 Структура объекта (секции, ТЧ, вложенные узлы) — `cf-md-object-structure-get`.
 
+### Допустимые значения перечислимых свойств
+
+`cf-md-object-enums` отдаёт словарь `блок.свойство` → константы модели, например `{"chartOfCharacteristicTypes.codeSeries":["WHOLE_CHARACTERISTIC_KIND","WITHIN_SUBORDINATION"]}`. Набор снимается с модели запрошенной версии формата, поэтому вызывающей программе не нужна своя копия списка: при записи значение вне этого набора отклоняется с перечислением допустимых.
+
 ## Поля JSON (`MdObjectPropertiesDto`)
 
 Общие поля:
 
-- `kind`: `"catalog"` \| `"constant"` \| `"enum"` \| `"document"` \| `"report"` \| `"dataProcessor"` \| `"task"` \| `"chartOfAccounts"` \| `"chartOfCharacteristicTypes"` \| `"chartOfCalculationTypes"` \| `"commonModule"` \| `"subsystem"` \| `"sessionParameter"` \| `"exchangePlan"` \| `"commonAttribute"` \| `"commonPicture"` \| `"documentNumerator"` \| `"externalDataSource"` \| `"role"`
+- `kind`: `"catalog"` \| `"constant"` \| `"enum"` \| `"document"` \| `"report"` \| `"dataProcessor"` \| `"task"` \| `"chartOfAccounts"` \| `"chartOfCharacteristicTypes"` \| `"chartOfCalculationTypes"` \| `"commonModule"` \| `"subsystem"` \| `"sessionParameter"` \| `"exchangePlan"` \| `"commonAttribute"` \| `"commonPicture"` \| `"documentNumerator"` \| `"eventSubscription"` \| `"scheduledJob"` \| `"commonCommand"` \| `"externalDataSource"` \| `"role"` \| `"documentJournal"` \| `"businessProcess"`
 - `internalName`: имя объекта (как в XML; при сохранении должно совпадать с именем файла без `.xml`)
 - `synonymRu`, `comment`: строки; для `catalog` / `document` / `exchangePlan` синоним ru синхронизируется с представлениями так же, как в `cf-catalog-form-get/set`
 
 ## Матрица поддерживаемых типов
 
-| kind (DTO)                   | containerLocal (XML)         | Поддержка полей                                                                  |
-|------------------------------|------------------------------|----------------------------------------------------------------------------------|
-| `catalog`                    | `Catalog`                    | расширенная (`catalog`, `attributes`, `tabularSections`, `synonymRu`, `comment`) |
-| `document`                   | `Document`                   | расширенная (`attributes`, `tabularSections`, `synonymRu`, `comment`)            |
-| `subsystem`                  | `Subsystem`                  | расширенная (`nestedSubsystems`, `contentRefs` чтение, `synonymRu`, `comment`)   |
-| `exchangePlan`               | `ExchangePlan`               | расширенная (`attributes`, `tabularSections`, `synonymRu`, `comment`)            |
-| `constant`                   | `Constant`                   | базовая (`synonymRu`, `comment`)                                                 |
-| `enum`                       | `Enum`                       | базовая (`synonymRu`, `comment`)                                                 |
-| `report`                     | `Report`                     | базовая (`synonymRu`, `comment`)                                                 |
-| `dataProcessor`              | `DataProcessor`              | базовая (`synonymRu`, `comment`)                                                 |
-| `task`                       | `Task`                       | базовая (`synonymRu`, `comment`)                                                 |
-| `chartOfAccounts`            | `ChartOfAccounts`            | базовая (`synonymRu`, `comment`)                                                 |
-| `chartOfCharacteristicTypes` | `ChartOfCharacteristicTypes` | базовая (`synonymRu`, `comment`)                                                 |
-| `chartOfCalculationTypes`    | `ChartOfCalculationTypes`    | базовая (`synonymRu`, `comment`)                                                 |
-| `commonModule`               | `CommonModule`               | базовая (`synonymRu`, `comment`)                                                 |
-| `sessionParameter`           | `SessionParameter`           | базовая (`synonymRu`, `comment`)                                                 |
-| `commonAttribute`            | `CommonAttribute`            | базовая (`synonymRu`, `comment`)                                                 |
-| `commonPicture`              | `CommonPicture`              | базовая (`synonymRu`, `comment`)                                                 |
-| `documentNumerator`          | `DocumentNumerator`          | базовая (`synonymRu`, `comment`)                                                 |
-| `externalDataSource`         | `ExternalDataSource`         | базовая (`synonymRu`, `comment`)                                                 |
-| `role`                       | `Role`                       | базовая (`synonymRu`, `comment`)                                                 |
+| kind (DTO)                   | containerLocal (XML)         | Поддержка полей                                                                     |
+|------------------------------|------------------------------|-------------------------------------------------------------------------------------|
+| `catalog`                    | `Catalog`                    | полная (`catalog`, `attributes`, `tabularSections`)                                  |
+| `document`                   | `Document`                   | полная (`document`, `attributes`, `tabularSections`)                                 |
+| `enum`                       | `Enum`                       | полная (`enumeration`, `enumValues`)                                                 |
+| `constant`                   | `Constant`                   | полная (`constant`)                                                                  |
+| `commonModule`               | `CommonModule`               | полная (`commonModule`)                                                              |
+| `informationRegister`        | `InformationRegister`        | полная (`register`, `dimensions`, `resources`, `attributes`)                         |
+| `accumulationRegister`       | `AccumulationRegister`       | полная (`register`, `dimensions`, `resources`, `attributes`)                         |
+| `report`                     | `Report`                     | полная (`report`)                                                                    |
+| `dataProcessor`              | `DataProcessor`              | полная (`report`, поля отчёта пусты)                                                 |
+| `documentJournal`            | `DocumentJournal`            | полная (`documentJournal`, регистрируемые документы)                                 |
+| `chartOfCharacteristicTypes` | `ChartOfCharacteristicTypes` | полная (`chartOfCharacteristicTypes`, `attributes`, `tabularSections`)               |
+| `exchangePlan`               | `ExchangePlan`               | полная (`exchangePlan`, `attributes`, `tabularSections`; состав плана не трогаем)    |
+| `task`                       | `Task`                       | полная (`task`, `attributes`, `tabularSections`)                                     |
+| `businessProcess`            | `BusinessProcess`            | полная (`businessProcess`, `attributes`, `tabularSections`)                          |
+| `chartOfAccounts`            | `ChartOfAccounts`            | полная (`chartOfAccounts`, `attributes`, `tabularSections`)                          |
+| `chartOfCalculationTypes`    | `ChartOfCalculationTypes`    | полная (`chartOfCalculationTypes`, `attributes`, `tabularSections`)                  |
+| `subsystem`                  | `Subsystem`                  | расширенная (`nestedSubsystems`, `contentRefs` чтение)                               |
+
+| `sessionParameter`            | `SessionParameter`            | полная (`sessionParameter`: тип значения) |
+| `commonAttribute` | `CommonAttribute` | полная (`commonAttribute`: разделение данных, поле ввода) |
+| `commonPicture` | `CommonPicture` | полная (`commonPicture`: доступность картинки) |
+| `documentNumerator`           | `DocumentNumerator`           | полная (`documentNumerator`: нумерация) |
+| `eventSubscription`           | `EventSubscription`           | полная (`eventSubscription`: источник, событие, обработчик) |
+| `scheduledJob`                | `ScheduledJob`                | полная (`scheduledJob`: метод, ключ, расписание, перезапуски) |
+| `commonCommand`               | `CommonCommand`               | полная (`commonCommand`: группа, параметр, представление) |
+| `externalDataSource` | `ExternalDataSource` | полная (`externalDataSource`: режим блокировки) |
+| `role` | `Role` | полная (`role`: общие поля; состав прав - отдельный файл) |
+
+Базовая поддержка — `internalName`, `synonymRu`, `comment`; полная — плюс типизированный блок свойств вида,
+который читается и пишется целиком, гранулярно по изменённым элементам.
 
 Для `catalog`, `document`, `exchangePlan`:
 
@@ -67,5 +84,5 @@ Round-trip и регрессии — на выгрузках вроде submodul
 ## Ограничения текущего этапа
 
 - Для всех перечисленных `kind` поддержаны базовые поля `internalName/synonymRu/comment` с гранулярной записью.
-- Расширенные поля `catalog` и список `attributes/tabularSections` остаются полными только для типов, где это уже реализовано (`catalog`, `document`, `exchangePlan`).
+- Типизированный блок свойств есть у видов из строк «полная»; остальным доступны только базовые поля.
 - Для `subsystem` дополнительно поддержаны `nestedSubsystems` и чтение `contentRefs`.

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/CommandFiles.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/CommandFiles.java
@@ -1,0 +1,76 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.stream.Stream;
+
+/**
+ * Файлы команд объекта: модуль команды лежит рядом с XML объекта в
+ * {@code <Объект>/Commands/<Имя>/Ext/CommandModule.bsl}.
+ *
+ * <p>Узел команды живёт в самом XML объекта, а модуль - отдельным файлом, поэтому переименование и
+ * удаление команды затрагивают оба места: осиротевший каталог модуля конфигуратор считает мусором.
+ */
+public final class CommandFiles {
+
+  private CommandFiles() {
+  }
+
+  /**
+   * Переименовывает каталог модуля команды, если он есть.
+   *
+   * @param objectXml путь к XML объекта
+   * @param oldName текущее имя команды
+   * @param newName новое имя команды
+   * @throws IOException если каталог не удалось переименовать
+   */
+  public static void renameCommandDirectory(Path objectXml, String oldName, String newName) throws IOException {
+    Path from = commandDirectory(objectXml, oldName);
+    if (from == null || !Files.isDirectory(from)) {
+      return;
+    }
+    Path to = from.resolveSibling(newName);
+    Files.move(from, to);
+  }
+
+  /**
+   * Удаляет каталог модуля команды вместе с содержимым, если он есть.
+   *
+   * @param objectXml путь к XML объекта
+   * @param name имя команды
+   * @throws IOException если каталог не удалось удалить
+   */
+  public static void deleteCommandDirectory(Path objectXml, String name) throws IOException {
+    Path dir = commandDirectory(objectXml, name);
+    if (dir == null || !Files.isDirectory(dir)) {
+      return;
+    }
+    try (Stream<Path> walk = Files.walk(dir)) {
+      for (Path path : walk.sorted(Comparator.reverseOrder()).toList()) {
+        Files.delete(path);
+      }
+    }
+  }
+
+  private static Path commandDirectory(Path objectXml, String name) {
+    if (name == null || name.isBlank()) {
+      return null;
+    }
+    String fileName = objectXml.getFileName().toString();
+    if (!fileName.endsWith(".xml")) {
+      return null;
+    }
+    Path objectDir = objectXml.resolveSibling(fileName.substring(0, fileName.length() - 4));
+    return objectDir.resolve("Commands").resolve(name);
+  }
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/ConfigurationChildObjectLister.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/ConfigurationChildObjectLister.java
@@ -17,7 +17,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 
 /**
  * Имена объектов из {@code Configuration/ChildObjects} по локальному имени тега (как в XSD).
@@ -28,22 +27,17 @@ public final class ConfigurationChildObjectLister {
   private ConfigurationChildObjectLister() {
   }
 
-  private static final Set<String> SUPPORTED_TAGS = Set.of(
-    "Catalog", "Document", "Enum", "Constant", "Report", "DataProcessor", "Task",
-    "ChartOfAccounts", "ChartOfCharacteristicTypes", "ChartOfCalculationTypes", "CommonModule",
-    "Subsystem", "SessionParameter", "ExchangePlan", "CommonAttribute", "CommonPicture",
-    "DocumentNumerator", "ExternalDataSource", "Role",
-    "InformationRegister", "AccumulationRegister", "AccountingRegister", "CalculationRegister");
-
   /**
-   * @param childTag например {@code Catalog}, {@code Document}, {@code Enum}, {@code Constant}
+   * Имена объектов конфигурации по тегу состава.
+   *
+   * <p>Список тегов не перечисляем: он берётся из самой модели формата, иначе новый вид
+   * пришлось бы дописывать здесь руками, а его отсутствие выглядело бы как ошибка вызова.
+   *
+   * @param childTag локальное имя тега, например {@code Catalog}, {@code SettingsStorage}
    */
   public static List<String> listNames(Path configurationXml, SchemaVersion version, String childTag)
     throws JAXBException, IOException {
     Objects.requireNonNull(childTag, "childTag");
-    if (!SUPPORTED_TAGS.contains(childTag)) {
-      throw new IllegalArgumentException("unsupported ChildObjects tag: " + childTag);
-    }
     Object mdo = JaxbReflect.value(DesignerXml.read(configurationXml, version));
     Object cfg = JaxbReflect.get(mdo, "getConfiguration");
     if (cfg == null) {
@@ -53,7 +47,19 @@ public final class ConfigurationChildObjectLister {
     if (child == null) {
       return new ArrayList<>();
     }
-    List<String> raw = new ArrayList<>(JaxbReflect.<String>list(child, "get" + childTag));
+    Object names = JaxbReflect.getOptional(child, "get" + childTag);
+    if (names == null) {
+      throw new IllegalArgumentException(
+        "в составе конфигурации формата " + version.metadataObjectVersionAttribute()
+          + " нет тега " + childTag);
+    }
+    if (!(names instanceof List<?> list)) {
+      throw new IllegalArgumentException(childTag + ": тег состава не является списком имён");
+    }
+    List<String> raw = new ArrayList<>();
+    for (Object name : list) {
+      raw.add(String.valueOf(name));
+    }
     return sortedCopy(raw);
   }
 

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/ConfigurationPropertiesEdit.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/ConfigurationPropertiesEdit.java
@@ -224,8 +224,12 @@ public final class ConfigurationPropertiesEdit {
     for (String v : safeTrimmedList(values)) {
       try {
         vals.add(Enum.valueOf(enumClass.asSubclass(Enum.class), v));
-      } catch (IllegalArgumentException ignored) {
-        // неизвестное значение пропускаем, чтобы не ломать сохранение
+      } catch (IllegalArgumentException e) {
+        // Пропустить значение молча нельзя: правка исчезла бы без следа, а на диск легла бы
+        // конфигурация с другим назначением использования.
+        throw new IllegalArgumentException(
+          "UsePurposes: недопустимое значение " + v
+            + "; допустимы " + java.util.Arrays.toString(enumClass.getEnumConstants()), e);
       }
     }
   }

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdBusinessProcessPropertiesBridge.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdBusinessProcessPropertiesBridge.java
@@ -1,0 +1,131 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+import io.github.yellowhammer.designerxml.SchemaVersion;
+import io.github.yellowhammer.designerxml.reflect.JaxbReflect;
+
+import static io.github.yellowhammer.designerxml.cf.MdPropertiesBridgeSupport.enumName;
+import static io.github.yellowhammer.designerxml.cf.MdPropertiesBridgeSupport.ensureAndSetRu;
+import static io.github.yellowhammer.designerxml.cf.MdPropertiesBridgeSupport.nullIfBlank;
+
+/**
+ * Чтение и запись {@code BusinessProcessProperties} через JAXB-рефлексию.
+ */
+public final class MdBusinessProcessPropertiesBridge {
+
+  private MdBusinessProcessPropertiesBridge() {
+  }
+
+  public static void read(SchemaVersion version, Object p, MdObjectPropertiesDto dto) {
+    MdBusinessProcessPropertiesDto d = new MdBusinessProcessPropertiesDto();
+    d.objectBelonging = enumName(p, "getObjectBelonging");
+    d.extendedConfigurationObject = nullIfBlank(JaxbReflect.getStringOptional(p, "getExtendedConfigurationObject"));
+    d.useStandardCommands = JaxbReflect.getBooleanOptional(p, "isUseStandardCommands");
+    d.objectModule = JaxbReflect.getStringOptional(p, "getObjectModule");
+    d.managerModule = JaxbReflect.getStringOptional(p, "getManagerModule");
+    d.flowchart = JaxbReflect.getStringOptional(p, "getFlowchart");
+    d.editType = enumName(p, "getEditType");
+    MdPropertiesBridgeSupport.addFields(d.inputByString, JaxbReflect.getOptional(p, "getInputByString"));
+    d.createOnInput = enumName(p, "getCreateOnInput");
+    d.searchStringModeOnInputByString = enumName(p, "getSearchStringModeOnInputByString");
+    d.choiceDataGetModeOnInputByString = enumName(p, "getChoiceDataGetModeOnInputByString");
+    d.fullTextSearchOnInputByString = enumName(p, "getFullTextSearchOnInputByString");
+    d.defaultObjectForm = JaxbReflect.getStringOptional(p, "getDefaultObjectForm");
+    d.defaultListForm = JaxbReflect.getStringOptional(p, "getDefaultListForm");
+    d.defaultChoiceForm = JaxbReflect.getStringOptional(p, "getDefaultChoiceForm");
+    d.auxiliaryObjectForm = JaxbReflect.getStringOptional(p, "getAuxiliaryObjectForm");
+    d.auxiliaryListForm = JaxbReflect.getStringOptional(p, "getAuxiliaryListForm");
+    d.auxiliaryChoiceForm = JaxbReflect.getStringOptional(p, "getAuxiliaryChoiceForm");
+    d.choiceHistoryOnInput = enumName(p, "getChoiceHistoryOnInput");
+    d.numberType = enumName(p, "getNumberType");
+    d.numberLength = MdPropertiesBridgeSupport.decimalOrZero(p, "getNumberLength");
+    d.numberAllowedLength = enumName(p, "getNumberAllowedLength");
+    d.checkUnique = JaxbReflect.getBooleanOptional(p, "isCheckUnique");
+    d.standardAttributesXml = MdPropertiesBridgeSupport.marshalStandardAttributesOrEmpty(
+      version, JaxbReflect.getOptional(p, "getStandardAttributes"));
+    d.characteristicsXml = MdPropertiesBridgeSupport.marshalCharacteristicsOrEmpty(
+      version, JaxbReflect.getOptional(p, "getCharacteristics"));
+    d.autonumbering = JaxbReflect.getBooleanOptional(p, "isAutonumbering");
+    MdPropertiesBridgeSupport.addItems(d.basedOn, JaxbReflect.getOptional(p, "getBasedOn"));
+    d.numberPeriodicity = enumName(p, "getNumberPeriodicity");
+    d.task = JaxbReflect.getStringOptional(p, "getTask");
+    d.createTaskInPrivilegedMode = JaxbReflect.getBooleanOptional(p, "isCreateTaskInPrivilegedMode");
+    MdPropertiesBridgeSupport.addFields(d.dataLockFields, JaxbReflect.getOptional(p, "getDataLockFields"));
+    d.dataLockControlMode = enumName(p, "getDataLockControlMode");
+    d.includeHelpInContents = JaxbReflect.getBooleanOptional(p, "isIncludeHelpInContents");
+    d.fullTextSearch = enumName(p, "getFullTextSearch");
+    d.objectPresentationRu = LocalStringSync.firstRu(JaxbReflect.getOptional(p, "getObjectPresentation"));
+    d.extendedObjectPresentationRu =
+      LocalStringSync.firstRu(JaxbReflect.getOptional(p, "getExtendedObjectPresentation"));
+    d.listPresentationRu = LocalStringSync.firstRu(JaxbReflect.getOptional(p, "getListPresentation"));
+    d.extendedListPresentationRu = LocalStringSync.firstRu(JaxbReflect.getOptional(p, "getExtendedListPresentation"));
+    d.explanationRu = LocalStringSync.firstRu(JaxbReflect.getOptional(p, "getExplanation"));
+    d.dataHistory = enumName(p, "getDataHistory");
+    d.updateDataHistoryImmediatelyAfterWrite =
+      JaxbReflect.getBooleanOptional(p, "isUpdateDataHistoryImmediatelyAfterWrite");
+    d.executeAfterWriteDataHistoryVersionProcessing =
+      JaxbReflect.getBooleanOptional(p, "isExecuteAfterWriteDataHistoryVersionProcessing");
+    d.additionalIndexes = JaxbReflect.getStringOptional(p, "getAdditionalIndexes");
+    dto.businessProcess = d;
+  }
+
+  public static void apply(SchemaVersion version, Object p, MdObjectPropertiesDto dto) {
+    MdBusinessProcessPropertiesDto d = dto.businessProcess;
+    if (d == null) {
+      throw new IllegalArgumentException("businessProcess required");
+    }
+    MdPropertiesBridgeSupport.applyCommon(p, dto);
+    JaxbReflect.setEnumOrKeep(p, "setObjectBelonging", d.objectBelonging);
+    JaxbReflect.setOptional(p, "setExtendedConfigurationObject", nullIfBlank(d.extendedConfigurationObject));
+    JaxbReflect.setOptional(p, "setUseStandardCommands", d.useStandardCommands);
+    JaxbReflect.setOptional(p, "setObjectModule", d.objectModule);
+    JaxbReflect.setOptional(p, "setManagerModule", d.managerModule);
+    JaxbReflect.setOptional(p, "setFlowchart", d.flowchart);
+    JaxbReflect.setEnumOrKeep(p, "setEditType", d.editType);
+    MdPropertiesBridgeSupport.setFields(JaxbReflect.getOptional(p, "getInputByString"), d.inputByString);
+    JaxbReflect.setEnumOrKeep(p, "setCreateOnInput", d.createOnInput);
+    JaxbReflect.setEnumOrKeep(p, "setSearchStringModeOnInputByString", d.searchStringModeOnInputByString);
+    JaxbReflect.setEnumOrKeep(p, "setChoiceDataGetModeOnInputByString", d.choiceDataGetModeOnInputByString);
+    JaxbReflect.setEnumOrKeep(p, "setFullTextSearchOnInputByString", d.fullTextSearchOnInputByString);
+    JaxbReflect.setOptional(p, "setDefaultObjectForm", d.defaultObjectForm);
+    JaxbReflect.setOptional(p, "setDefaultListForm", d.defaultListForm);
+    JaxbReflect.setOptional(p, "setDefaultChoiceForm", d.defaultChoiceForm);
+    JaxbReflect.setOptional(p, "setAuxiliaryObjectForm", d.auxiliaryObjectForm);
+    JaxbReflect.setOptional(p, "setAuxiliaryListForm", d.auxiliaryListForm);
+    JaxbReflect.setOptional(p, "setAuxiliaryChoiceForm", d.auxiliaryChoiceForm);
+    JaxbReflect.setEnumOrKeep(p, "setChoiceHistoryOnInput", d.choiceHistoryOnInput);
+    JaxbReflect.setEnumOrKeep(p, "setNumberType", d.numberType);
+    MdPropertiesBridgeSupport.setDecimal(p, "setNumberLength", d.numberLength);
+    JaxbReflect.setEnumOrKeep(p, "setNumberAllowedLength", d.numberAllowedLength);
+    JaxbReflect.setOptional(p, "setCheckUnique", d.checkUnique);
+    MdPropertiesBridgeSupport.applyStandardAttributes(version, p, d.standardAttributesXml);
+    MdPropertiesBridgeSupport.applyCharacteristics(version, p, d.characteristicsXml);
+    JaxbReflect.setOptional(p, "setAutonumbering", d.autonumbering);
+    MdListTypeRefs.replaceItems(JaxbReflect.getOptional(p, "getBasedOn"), d.basedOn);
+    JaxbReflect.setEnumOrKeep(p, "setNumberPeriodicity", d.numberPeriodicity);
+    JaxbReflect.setOptional(p, "setTask", d.task);
+    JaxbReflect.setOptional(p, "setCreateTaskInPrivilegedMode", d.createTaskInPrivilegedMode);
+    MdPropertiesBridgeSupport.setFields(JaxbReflect.getOptional(p, "getDataLockFields"), d.dataLockFields);
+    JaxbReflect.setEnumOrKeep(p, "setDataLockControlMode", d.dataLockControlMode);
+    JaxbReflect.setOptional(p, "setIncludeHelpInContents", d.includeHelpInContents);
+    JaxbReflect.setEnumOrKeep(p, "setFullTextSearch", d.fullTextSearch);
+    ensureAndSetRu(p, "getObjectPresentation", "setObjectPresentation", d.objectPresentationRu);
+    ensureAndSetRu(p, "getExtendedObjectPresentation", "setExtendedObjectPresentation",
+      d.extendedObjectPresentationRu);
+    ensureAndSetRu(p, "getListPresentation", "setListPresentation", d.listPresentationRu);
+    ensureAndSetRu(p, "getExtendedListPresentation", "setExtendedListPresentation", d.extendedListPresentationRu);
+    ensureAndSetRu(p, "getExplanation", "setExplanation", d.explanationRu);
+    JaxbReflect.setEnumOrKeep(p, "setDataHistory", d.dataHistory);
+    JaxbReflect.setOptional(p, "setUpdateDataHistoryImmediatelyAfterWrite", d.updateDataHistoryImmediatelyAfterWrite);
+    JaxbReflect.setOptional(p, "setExecuteAfterWriteDataHistoryVersionProcessing",
+      d.executeAfterWriteDataHistoryVersionProcessing);
+    JaxbReflect.setOptional(p, "setAdditionalIndexes", d.additionalIndexes);
+  }
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdBusinessProcessPropertiesDto.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdBusinessProcessPropertiesDto.java
@@ -1,0 +1,72 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Поля {@code BusinessProcessProperties} для {@code cf-md-object-get/set}
+ * ({@code kind=businessProcess}).
+ * Enum-значения — имена Java-констант ({@code NUMBER}, {@code BOTH_WAYS}).
+ */
+public final class MdBusinessProcessPropertiesDto {
+
+  public String objectBelonging;
+  public String extendedConfigurationObject;
+  public boolean useStandardCommands;
+  public String objectModule;
+  public String managerModule;
+  /** Карта маршрута бизнес-процесса. */
+  public String flowchart;
+  public String editType;
+  public List<String> inputByString;
+  public String createOnInput;
+  public String searchStringModeOnInputByString;
+  public String choiceDataGetModeOnInputByString;
+  public String fullTextSearchOnInputByString;
+  public String defaultObjectForm;
+  public String defaultListForm;
+  public String defaultChoiceForm;
+  public String auxiliaryObjectForm;
+  public String auxiliaryListForm;
+  public String auxiliaryChoiceForm;
+  public String choiceHistoryOnInput;
+  public String numberType;
+  public String numberLength;
+  public String numberAllowedLength;
+  public boolean checkUnique;
+  public String standardAttributesXml;
+  public String characteristicsXml;
+  public boolean autonumbering;
+  public List<String> basedOn;
+  public String numberPeriodicity;
+  /** Задача бизнес-процесса ({@code Task.Имя}). */
+  public String task;
+  public boolean createTaskInPrivilegedMode;
+  public List<String> dataLockFields;
+  public String dataLockControlMode;
+  public boolean includeHelpInContents;
+  public String fullTextSearch;
+  public String objectPresentationRu;
+  public String extendedObjectPresentationRu;
+  public String listPresentationRu;
+  public String extendedListPresentationRu;
+  public String explanationRu;
+  public String dataHistory;
+  public boolean updateDataHistoryImmediatelyAfterWrite;
+  public boolean executeAfterWriteDataHistoryVersionProcessing;
+  public String additionalIndexes;
+
+  public MdBusinessProcessPropertiesDto() {
+    this.inputByString = new ArrayList<>();
+    this.basedOn = new ArrayList<>();
+    this.dataLockFields = new ArrayList<>();
+  }
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdCatalogPropertiesGranularSerial.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdCatalogPropertiesGranularSerial.java
@@ -375,21 +375,16 @@ public final class MdCatalogPropertiesGranularSerial {
   }
 
   static String inputByStringElement(List<String> fields) {
-    StringBuilder sb = new StringBuilder("<InputByString>");
-    if (fields != null) {
-      for (String f : fields) {
-        if (f == null || f.isBlank()) {
-          continue;
-        }
-        sb.append("<xr:Field>").append(escapeXml(f.trim())).append("</xr:Field>");
-      }
-    }
-    sb.append("</InputByString>");
-    return sb.toString();
+    return fieldListElement("InputByString", fields);
   }
 
   static String dataLockFieldsElement(List<String> fields) {
-    StringBuilder sb = new StringBuilder("<DataLockFields>");
+    return fieldListElement("DataLockFields", fields);
+  }
+
+  /** Список полей объекта: {@code <Имя><xr:Field>…</xr:Field></Имя>}. */
+  static String fieldListElement(String localName, List<String> fields) {
+    StringBuilder sb = new StringBuilder("<").append(localName).append(">");
     if (fields != null) {
       for (String f : fields) {
         if (f == null || f.isBlank()) {
@@ -398,7 +393,7 @@ public final class MdCatalogPropertiesGranularSerial {
         sb.append("<xr:Field>").append(escapeXml(f.trim())).append("</xr:Field>");
       }
     }
-    sb.append("</DataLockFields>");
+    sb.append("</").append(localName).append(">");
     return sb.toString();
   }
 

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdChartOfAccountsPropertiesBridge.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdChartOfAccountsPropertiesBridge.java
@@ -1,0 +1,137 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+import io.github.yellowhammer.designerxml.SchemaVersion;
+import io.github.yellowhammer.designerxml.reflect.JaxbReflect;
+
+import static io.github.yellowhammer.designerxml.cf.MdPropertiesBridgeSupport.enumName;
+import static io.github.yellowhammer.designerxml.cf.MdPropertiesBridgeSupport.ensureAndSetRu;
+import static io.github.yellowhammer.designerxml.cf.MdPropertiesBridgeSupport.nullIfBlank;
+
+/**
+ * Чтение и запись {@code ChartOfAccountsProperties} через JAXB-рефлексию.
+ *
+ * <p>Признаки учёта и стандартные табличные части не трогаем: они правятся своими операциями.
+ */
+public final class MdChartOfAccountsPropertiesBridge {
+
+  private MdChartOfAccountsPropertiesBridge() {
+  }
+
+  public static void read(SchemaVersion version, Object p, MdObjectPropertiesDto dto) {
+    MdChartOfAccountsPropertiesDto d = new MdChartOfAccountsPropertiesDto();
+    d.objectBelonging = enumName(p, "getObjectBelonging");
+    d.extendedConfigurationObject = nullIfBlank(JaxbReflect.getStringOptional(p, "getExtendedConfigurationObject"));
+    d.useStandardCommands = JaxbReflect.getBooleanOptional(p, "isUseStandardCommands");
+    d.includeHelpInContents = JaxbReflect.getBooleanOptional(p, "isIncludeHelpInContents");
+    MdPropertiesBridgeSupport.addItems(d.basedOn, JaxbReflect.getOptional(p, "getBasedOn"));
+    d.extDimensionTypes = JaxbReflect.getStringOptional(p, "getExtDimensionTypes");
+    d.maxExtDimensionCount = MdPropertiesBridgeSupport.decimalOrZero(p, "getMaxExtDimensionCount");
+    d.codeMask = JaxbReflect.getStringOptional(p, "getCodeMask");
+    d.codeLength = MdPropertiesBridgeSupport.decimalOrZero(p, "getCodeLength");
+    d.descriptionLength = MdPropertiesBridgeSupport.decimalOrZero(p, "getDescriptionLength");
+    d.codeSeries = enumName(p, "getCodeSeries");
+    d.checkUnique = JaxbReflect.getBooleanOptional(p, "isCheckUnique");
+    d.defaultPresentation = enumName(p, "getDefaultPresentation");
+    d.standardAttributesXml = MdPropertiesBridgeSupport.marshalStandardAttributesOrEmpty(
+      version, JaxbReflect.getOptional(p, "getStandardAttributes"));
+    d.characteristicsXml = MdPropertiesBridgeSupport.marshalCharacteristicsOrEmpty(
+      version, JaxbReflect.getOptional(p, "getCharacteristics"));
+    d.predefinedDataUpdate = enumName(p, "getPredefinedDataUpdate");
+    d.editType = enumName(p, "getEditType");
+    d.quickChoice = JaxbReflect.getBooleanOptional(p, "isQuickChoice");
+    d.choiceMode = enumName(p, "getChoiceMode");
+    MdPropertiesBridgeSupport.addFields(d.inputByString, JaxbReflect.getOptional(p, "getInputByString"));
+    d.searchStringModeOnInputByString = enumName(p, "getSearchStringModeOnInputByString");
+    d.fullTextSearchOnInputByString = enumName(p, "getFullTextSearchOnInputByString");
+    d.choiceDataGetModeOnInputByString = enumName(p, "getChoiceDataGetModeOnInputByString");
+    d.createOnInput = enumName(p, "getCreateOnInput");
+    d.choiceHistoryOnInput = enumName(p, "getChoiceHistoryOnInput");
+    d.defaultObjectForm = JaxbReflect.getStringOptional(p, "getDefaultObjectForm");
+    d.defaultListForm = JaxbReflect.getStringOptional(p, "getDefaultListForm");
+    d.defaultChoiceForm = JaxbReflect.getStringOptional(p, "getDefaultChoiceForm");
+    d.auxiliaryObjectForm = JaxbReflect.getStringOptional(p, "getAuxiliaryObjectForm");
+    d.auxiliaryListForm = JaxbReflect.getStringOptional(p, "getAuxiliaryListForm");
+    d.auxiliaryChoiceForm = JaxbReflect.getStringOptional(p, "getAuxiliaryChoiceForm");
+    d.objectModule = JaxbReflect.getStringOptional(p, "getObjectModule");
+    d.managerModule = JaxbReflect.getStringOptional(p, "getManagerModule");
+    MdPropertiesBridgeSupport.addFields(d.dataLockFields, JaxbReflect.getOptional(p, "getDataLockFields"));
+    d.dataLockControlMode = enumName(p, "getDataLockControlMode");
+    d.fullTextSearch = enumName(p, "getFullTextSearch");
+    d.objectPresentationRu = LocalStringSync.firstRu(JaxbReflect.getOptional(p, "getObjectPresentation"));
+    d.extendedObjectPresentationRu =
+      LocalStringSync.firstRu(JaxbReflect.getOptional(p, "getExtendedObjectPresentation"));
+    d.listPresentationRu = LocalStringSync.firstRu(JaxbReflect.getOptional(p, "getListPresentation"));
+    d.extendedListPresentationRu = LocalStringSync.firstRu(JaxbReflect.getOptional(p, "getExtendedListPresentation"));
+    d.explanationRu = LocalStringSync.firstRu(JaxbReflect.getOptional(p, "getExplanation"));
+    d.dataHistory = enumName(p, "getDataHistory");
+    d.updateDataHistoryImmediatelyAfterWrite =
+      JaxbReflect.getBooleanOptional(p, "isUpdateDataHistoryImmediatelyAfterWrite");
+    d.executeAfterWriteDataHistoryVersionProcessing =
+      JaxbReflect.getBooleanOptional(p, "isExecuteAfterWriteDataHistoryVersionProcessing");
+    d.additionalIndexes = JaxbReflect.getStringOptional(p, "getAdditionalIndexes");
+    dto.chartOfAccounts = d;
+  }
+
+  public static void apply(SchemaVersion version, Object p, MdObjectPropertiesDto dto) {
+    MdChartOfAccountsPropertiesDto d = dto.chartOfAccounts;
+    if (d == null) {
+      throw new IllegalArgumentException("chartOfAccounts required");
+    }
+    MdPropertiesBridgeSupport.applyCommon(p, dto);
+    JaxbReflect.setEnumOrKeep(p, "setObjectBelonging", d.objectBelonging);
+    JaxbReflect.setOptional(p, "setExtendedConfigurationObject", nullIfBlank(d.extendedConfigurationObject));
+    JaxbReflect.setOptional(p, "setUseStandardCommands", d.useStandardCommands);
+    JaxbReflect.setOptional(p, "setIncludeHelpInContents", d.includeHelpInContents);
+    MdListTypeRefs.replaceItems(JaxbReflect.getOptional(p, "getBasedOn"), d.basedOn);
+    JaxbReflect.setOptional(p, "setExtDimensionTypes", d.extDimensionTypes);
+    MdPropertiesBridgeSupport.setDecimal(p, "setMaxExtDimensionCount", d.maxExtDimensionCount);
+    JaxbReflect.setOptional(p, "setCodeMask", d.codeMask);
+    MdPropertiesBridgeSupport.setDecimal(p, "setCodeLength", d.codeLength);
+    MdPropertiesBridgeSupport.setDecimal(p, "setDescriptionLength", d.descriptionLength);
+    JaxbReflect.setEnumOrKeep(p, "setCodeSeries", d.codeSeries);
+    JaxbReflect.setOptional(p, "setCheckUnique", d.checkUnique);
+    JaxbReflect.setEnumOrKeep(p, "setDefaultPresentation", d.defaultPresentation);
+    MdPropertiesBridgeSupport.applyStandardAttributes(version, p, d.standardAttributesXml);
+    MdPropertiesBridgeSupport.applyCharacteristics(version, p, d.characteristicsXml);
+    JaxbReflect.setEnumOrKeep(p, "setPredefinedDataUpdate", d.predefinedDataUpdate);
+    JaxbReflect.setEnumOrKeep(p, "setEditType", d.editType);
+    JaxbReflect.setOptional(p, "setQuickChoice", d.quickChoice);
+    JaxbReflect.setEnumOrKeep(p, "setChoiceMode", d.choiceMode);
+    MdPropertiesBridgeSupport.setFields(JaxbReflect.getOptional(p, "getInputByString"), d.inputByString);
+    JaxbReflect.setEnumOrKeep(p, "setSearchStringModeOnInputByString", d.searchStringModeOnInputByString);
+    JaxbReflect.setEnumOrKeep(p, "setFullTextSearchOnInputByString", d.fullTextSearchOnInputByString);
+    JaxbReflect.setEnumOrKeep(p, "setChoiceDataGetModeOnInputByString", d.choiceDataGetModeOnInputByString);
+    JaxbReflect.setEnumOrKeep(p, "setCreateOnInput", d.createOnInput);
+    JaxbReflect.setEnumOrKeep(p, "setChoiceHistoryOnInput", d.choiceHistoryOnInput);
+    JaxbReflect.setOptional(p, "setDefaultObjectForm", d.defaultObjectForm);
+    JaxbReflect.setOptional(p, "setDefaultListForm", d.defaultListForm);
+    JaxbReflect.setOptional(p, "setDefaultChoiceForm", d.defaultChoiceForm);
+    JaxbReflect.setOptional(p, "setAuxiliaryObjectForm", d.auxiliaryObjectForm);
+    JaxbReflect.setOptional(p, "setAuxiliaryListForm", d.auxiliaryListForm);
+    JaxbReflect.setOptional(p, "setAuxiliaryChoiceForm", d.auxiliaryChoiceForm);
+    JaxbReflect.setOptional(p, "setObjectModule", d.objectModule);
+    JaxbReflect.setOptional(p, "setManagerModule", d.managerModule);
+    MdPropertiesBridgeSupport.setFields(JaxbReflect.getOptional(p, "getDataLockFields"), d.dataLockFields);
+    JaxbReflect.setEnumOrKeep(p, "setDataLockControlMode", d.dataLockControlMode);
+    JaxbReflect.setEnumOrKeep(p, "setFullTextSearch", d.fullTextSearch);
+    ensureAndSetRu(p, "getObjectPresentation", "setObjectPresentation", d.objectPresentationRu);
+    ensureAndSetRu(p, "getExtendedObjectPresentation", "setExtendedObjectPresentation",
+      d.extendedObjectPresentationRu);
+    ensureAndSetRu(p, "getListPresentation", "setListPresentation", d.listPresentationRu);
+    ensureAndSetRu(p, "getExtendedListPresentation", "setExtendedListPresentation", d.extendedListPresentationRu);
+    ensureAndSetRu(p, "getExplanation", "setExplanation", d.explanationRu);
+    JaxbReflect.setEnumOrKeep(p, "setDataHistory", d.dataHistory);
+    JaxbReflect.setOptional(p, "setUpdateDataHistoryImmediatelyAfterWrite", d.updateDataHistoryImmediatelyAfterWrite);
+    JaxbReflect.setOptional(p, "setExecuteAfterWriteDataHistoryVersionProcessing",
+      d.executeAfterWriteDataHistoryVersionProcessing);
+    JaxbReflect.setOptional(p, "setAdditionalIndexes", d.additionalIndexes);
+  }
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdChartOfAccountsPropertiesDto.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdChartOfAccountsPropertiesDto.java
@@ -1,0 +1,75 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Поля {@code ChartOfAccountsProperties} для {@code cf-md-object-get/set}
+ * ({@code kind=chartOfAccounts}).
+ * Enum-значения — имена Java-констант ({@code AS_CODE}, {@code BOTH_WAYS}).
+ */
+public final class MdChartOfAccountsPropertiesDto {
+
+  public String objectBelonging;
+  public String extendedConfigurationObject;
+  public boolean useStandardCommands;
+  public boolean includeHelpInContents;
+  public List<String> basedOn;
+  /** Виды субконто: план видов характеристик либо пусто. */
+  public String extDimensionTypes;
+  /** Максимальное количество субконто. */
+  public String maxExtDimensionCount;
+  public String codeMask;
+  public String codeLength;
+  public String descriptionLength;
+  /** Серии кодов: во всём плане счетов либо в пределах подчинения. */
+  public String codeSeries;
+  public boolean checkUnique;
+  public String defaultPresentation;
+  public String standardAttributesXml;
+  public String characteristicsXml;
+  public String predefinedDataUpdate;
+  public String editType;
+  public boolean quickChoice;
+  public String choiceMode;
+  public List<String> inputByString;
+  public String searchStringModeOnInputByString;
+  public String fullTextSearchOnInputByString;
+  public String choiceDataGetModeOnInputByString;
+  public String createOnInput;
+  public String choiceHistoryOnInput;
+  public String defaultObjectForm;
+  public String defaultListForm;
+  public String defaultChoiceForm;
+  public String auxiliaryObjectForm;
+  public String auxiliaryListForm;
+  public String auxiliaryChoiceForm;
+  public String objectModule;
+  public String managerModule;
+  public List<String> dataLockFields;
+  public String dataLockControlMode;
+  public String fullTextSearch;
+  public String objectPresentationRu;
+  public String extendedObjectPresentationRu;
+  public String listPresentationRu;
+  public String extendedListPresentationRu;
+  public String explanationRu;
+  public String dataHistory;
+  public boolean updateDataHistoryImmediatelyAfterWrite;
+  public boolean executeAfterWriteDataHistoryVersionProcessing;
+  public String additionalIndexes;
+
+  public MdChartOfAccountsPropertiesDto() {
+    this.basedOn = new ArrayList<>();
+    this.inputByString = new ArrayList<>();
+    this.dataLockFields = new ArrayList<>();
+  }
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdChartOfCalculationTypesPropertiesBridge.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdChartOfCalculationTypesPropertiesBridge.java
@@ -1,0 +1,131 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+import io.github.yellowhammer.designerxml.SchemaVersion;
+import io.github.yellowhammer.designerxml.reflect.JaxbReflect;
+
+import static io.github.yellowhammer.designerxml.cf.MdPropertiesBridgeSupport.enumName;
+import static io.github.yellowhammer.designerxml.cf.MdPropertiesBridgeSupport.ensureAndSetRu;
+import static io.github.yellowhammer.designerxml.cf.MdPropertiesBridgeSupport.nullIfBlank;
+
+/**
+ * Чтение и запись {@code ChartOfCalculationTypesProperties} через JAXB-рефлексию.
+ *
+ * <p>Вытесняющие и ведущие виды расчёта живут в составе объекта, а не в свойствах: здесь их нет.
+ */
+public final class MdChartOfCalculationTypesPropertiesBridge {
+
+  private MdChartOfCalculationTypesPropertiesBridge() {
+  }
+
+  public static void read(SchemaVersion version, Object p, MdObjectPropertiesDto dto) {
+    MdChartOfCalculationTypesPropertiesDto d = new MdChartOfCalculationTypesPropertiesDto();
+    d.objectBelonging = enumName(p, "getObjectBelonging");
+    d.extendedConfigurationObject = nullIfBlank(JaxbReflect.getStringOptional(p, "getExtendedConfigurationObject"));
+    d.useStandardCommands = JaxbReflect.getBooleanOptional(p, "isUseStandardCommands");
+    d.codeLength = MdPropertiesBridgeSupport.decimalOrZero(p, "getCodeLength");
+    d.descriptionLength = MdPropertiesBridgeSupport.decimalOrZero(p, "getDescriptionLength");
+    d.codeType = enumName(p, "getCodeType");
+    d.codeAllowedLength = enumName(p, "getCodeAllowedLength");
+    d.editType = enumName(p, "getEditType");
+    MdPropertiesBridgeSupport.addFields(d.inputByString, JaxbReflect.getOptional(p, "getInputByString"));
+    d.createOnInput = enumName(p, "getCreateOnInput");
+    d.searchStringModeOnInputByString = enumName(p, "getSearchStringModeOnInputByString");
+    d.choiceDataGetModeOnInputByString = enumName(p, "getChoiceDataGetModeOnInputByString");
+    d.fullTextSearchOnInputByString = enumName(p, "getFullTextSearchOnInputByString");
+    d.choiceHistoryOnInput = enumName(p, "getChoiceHistoryOnInput");
+    d.defaultObjectForm = JaxbReflect.getStringOptional(p, "getDefaultObjectForm");
+    d.defaultListForm = JaxbReflect.getStringOptional(p, "getDefaultListForm");
+    d.defaultChoiceForm = JaxbReflect.getStringOptional(p, "getDefaultChoiceForm");
+    d.auxiliaryObjectForm = JaxbReflect.getStringOptional(p, "getAuxiliaryObjectForm");
+    d.auxiliaryListForm = JaxbReflect.getStringOptional(p, "getAuxiliaryListForm");
+    d.auxiliaryChoiceForm = JaxbReflect.getStringOptional(p, "getAuxiliaryChoiceForm");
+    d.objectModule = JaxbReflect.getStringOptional(p, "getObjectModule");
+    d.managerModule = JaxbReflect.getStringOptional(p, "getManagerModule");
+    MdPropertiesBridgeSupport.addItems(d.basedOn, JaxbReflect.getOptional(p, "getBasedOn"));
+    d.dependenceOnCalculationTypes = enumName(p, "getDependenceOnCalculationTypes");
+    MdPropertiesBridgeSupport.addItems(d.baseCalculationTypes, JaxbReflect.getOptional(p, "getBaseCalculationTypes"));
+    d.actionPeriodUse = JaxbReflect.getBooleanOptional(p, "isActionPeriodUse");
+    d.standardAttributesXml = MdPropertiesBridgeSupport.marshalStandardAttributesOrEmpty(
+      version, JaxbReflect.getOptional(p, "getStandardAttributes"));
+    d.characteristicsXml = MdPropertiesBridgeSupport.marshalCharacteristicsOrEmpty(
+      version, JaxbReflect.getOptional(p, "getCharacteristics"));
+    d.predefinedDataUpdate = enumName(p, "getPredefinedDataUpdate");
+    d.includeHelpInContents = JaxbReflect.getBooleanOptional(p, "isIncludeHelpInContents");
+    MdPropertiesBridgeSupport.addFields(d.dataLockFields, JaxbReflect.getOptional(p, "getDataLockFields"));
+    d.dataLockControlMode = enumName(p, "getDataLockControlMode");
+    d.fullTextSearch = enumName(p, "getFullTextSearch");
+    d.objectPresentationRu = LocalStringSync.firstRu(JaxbReflect.getOptional(p, "getObjectPresentation"));
+    d.extendedObjectPresentationRu =
+      LocalStringSync.firstRu(JaxbReflect.getOptional(p, "getExtendedObjectPresentation"));
+    d.listPresentationRu = LocalStringSync.firstRu(JaxbReflect.getOptional(p, "getListPresentation"));
+    d.extendedListPresentationRu = LocalStringSync.firstRu(JaxbReflect.getOptional(p, "getExtendedListPresentation"));
+    d.explanationRu = LocalStringSync.firstRu(JaxbReflect.getOptional(p, "getExplanation"));
+    d.dataHistory = enumName(p, "getDataHistory");
+    d.updateDataHistoryImmediatelyAfterWrite =
+      JaxbReflect.getBooleanOptional(p, "isUpdateDataHistoryImmediatelyAfterWrite");
+    d.executeAfterWriteDataHistoryVersionProcessing =
+      JaxbReflect.getBooleanOptional(p, "isExecuteAfterWriteDataHistoryVersionProcessing");
+    d.additionalIndexes = JaxbReflect.getStringOptional(p, "getAdditionalIndexes");
+    dto.chartOfCalculationTypes = d;
+  }
+
+  public static void apply(SchemaVersion version, Object p, MdObjectPropertiesDto dto) {
+    MdChartOfCalculationTypesPropertiesDto d = dto.chartOfCalculationTypes;
+    if (d == null) {
+      throw new IllegalArgumentException("chartOfCalculationTypes required");
+    }
+    MdPropertiesBridgeSupport.applyCommon(p, dto);
+    JaxbReflect.setEnumOrKeep(p, "setObjectBelonging", d.objectBelonging);
+    JaxbReflect.setOptional(p, "setExtendedConfigurationObject", nullIfBlank(d.extendedConfigurationObject));
+    JaxbReflect.setOptional(p, "setUseStandardCommands", d.useStandardCommands);
+    MdPropertiesBridgeSupport.setDecimal(p, "setCodeLength", d.codeLength);
+    MdPropertiesBridgeSupport.setDecimal(p, "setDescriptionLength", d.descriptionLength);
+    JaxbReflect.setEnumOrKeep(p, "setCodeType", d.codeType);
+    JaxbReflect.setEnumOrKeep(p, "setCodeAllowedLength", d.codeAllowedLength);
+    JaxbReflect.setEnumOrKeep(p, "setEditType", d.editType);
+    MdPropertiesBridgeSupport.setFields(JaxbReflect.getOptional(p, "getInputByString"), d.inputByString);
+    JaxbReflect.setEnumOrKeep(p, "setCreateOnInput", d.createOnInput);
+    JaxbReflect.setEnumOrKeep(p, "setSearchStringModeOnInputByString", d.searchStringModeOnInputByString);
+    JaxbReflect.setEnumOrKeep(p, "setChoiceDataGetModeOnInputByString", d.choiceDataGetModeOnInputByString);
+    JaxbReflect.setEnumOrKeep(p, "setFullTextSearchOnInputByString", d.fullTextSearchOnInputByString);
+    JaxbReflect.setEnumOrKeep(p, "setChoiceHistoryOnInput", d.choiceHistoryOnInput);
+    JaxbReflect.setOptional(p, "setDefaultObjectForm", d.defaultObjectForm);
+    JaxbReflect.setOptional(p, "setDefaultListForm", d.defaultListForm);
+    JaxbReflect.setOptional(p, "setDefaultChoiceForm", d.defaultChoiceForm);
+    JaxbReflect.setOptional(p, "setAuxiliaryObjectForm", d.auxiliaryObjectForm);
+    JaxbReflect.setOptional(p, "setAuxiliaryListForm", d.auxiliaryListForm);
+    JaxbReflect.setOptional(p, "setAuxiliaryChoiceForm", d.auxiliaryChoiceForm);
+    JaxbReflect.setOptional(p, "setObjectModule", d.objectModule);
+    JaxbReflect.setOptional(p, "setManagerModule", d.managerModule);
+    MdListTypeRefs.replaceItems(JaxbReflect.getOptional(p, "getBasedOn"), d.basedOn);
+    JaxbReflect.setEnumOrKeep(p, "setDependenceOnCalculationTypes", d.dependenceOnCalculationTypes);
+    MdListTypeRefs.replaceItems(JaxbReflect.getOptional(p, "getBaseCalculationTypes"), d.baseCalculationTypes);
+    JaxbReflect.setOptional(p, "setActionPeriodUse", d.actionPeriodUse);
+    MdPropertiesBridgeSupport.applyStandardAttributes(version, p, d.standardAttributesXml);
+    MdPropertiesBridgeSupport.applyCharacteristics(version, p, d.characteristicsXml);
+    JaxbReflect.setEnumOrKeep(p, "setPredefinedDataUpdate", d.predefinedDataUpdate);
+    JaxbReflect.setOptional(p, "setIncludeHelpInContents", d.includeHelpInContents);
+    MdPropertiesBridgeSupport.setFields(JaxbReflect.getOptional(p, "getDataLockFields"), d.dataLockFields);
+    JaxbReflect.setEnumOrKeep(p, "setDataLockControlMode", d.dataLockControlMode);
+    JaxbReflect.setEnumOrKeep(p, "setFullTextSearch", d.fullTextSearch);
+    ensureAndSetRu(p, "getObjectPresentation", "setObjectPresentation", d.objectPresentationRu);
+    ensureAndSetRu(p, "getExtendedObjectPresentation", "setExtendedObjectPresentation",
+      d.extendedObjectPresentationRu);
+    ensureAndSetRu(p, "getListPresentation", "setListPresentation", d.listPresentationRu);
+    ensureAndSetRu(p, "getExtendedListPresentation", "setExtendedListPresentation", d.extendedListPresentationRu);
+    ensureAndSetRu(p, "getExplanation", "setExplanation", d.explanationRu);
+    JaxbReflect.setEnumOrKeep(p, "setDataHistory", d.dataHistory);
+    JaxbReflect.setOptional(p, "setUpdateDataHistoryImmediatelyAfterWrite", d.updateDataHistoryImmediatelyAfterWrite);
+    JaxbReflect.setOptional(p, "setExecuteAfterWriteDataHistoryVersionProcessing",
+      d.executeAfterWriteDataHistoryVersionProcessing);
+    JaxbReflect.setOptional(p, "setAdditionalIndexes", d.additionalIndexes);
+  }
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdChartOfCalculationTypesPropertiesDto.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdChartOfCalculationTypesPropertiesDto.java
@@ -1,0 +1,73 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Поля {@code ChartOfCalculationTypesProperties} для {@code cf-md-object-get/set}
+ * ({@code kind=chartOfCalculationTypes}).
+ * Enum-значения — имена Java-констант ({@code STRING}, {@code BOTH_WAYS}).
+ */
+public final class MdChartOfCalculationTypesPropertiesDto {
+
+  public String objectBelonging;
+  public String extendedConfigurationObject;
+  public boolean useStandardCommands;
+  public String codeLength;
+  public String descriptionLength;
+  public String codeType;
+  public String codeAllowedLength;
+  public String editType;
+  public List<String> inputByString;
+  public String createOnInput;
+  public String searchStringModeOnInputByString;
+  public String choiceDataGetModeOnInputByString;
+  public String fullTextSearchOnInputByString;
+  public String choiceHistoryOnInput;
+  public String defaultObjectForm;
+  public String defaultListForm;
+  public String defaultChoiceForm;
+  public String auxiliaryObjectForm;
+  public String auxiliaryListForm;
+  public String auxiliaryChoiceForm;
+  public String objectModule;
+  public String managerModule;
+  public List<String> basedOn;
+  /** Зависимость от видов расчёта: не зависит, по периоду действия, по периоду регистрации. */
+  public String dependenceOnCalculationTypes;
+  /** Базовые виды расчёта: ссылки на планы видов расчёта. */
+  public List<String> baseCalculationTypes;
+  /** Использование периода действия. */
+  public boolean actionPeriodUse;
+  public String standardAttributesXml;
+  public String characteristicsXml;
+  public String predefinedDataUpdate;
+  public boolean includeHelpInContents;
+  public List<String> dataLockFields;
+  public String dataLockControlMode;
+  public String fullTextSearch;
+  public String objectPresentationRu;
+  public String extendedObjectPresentationRu;
+  public String listPresentationRu;
+  public String extendedListPresentationRu;
+  public String explanationRu;
+  public String dataHistory;
+  public boolean updateDataHistoryImmediatelyAfterWrite;
+  public boolean executeAfterWriteDataHistoryVersionProcessing;
+  public String additionalIndexes;
+
+  public MdChartOfCalculationTypesPropertiesDto() {
+    this.inputByString = new ArrayList<>();
+    this.basedOn = new ArrayList<>();
+    this.baseCalculationTypes = new ArrayList<>();
+    this.dataLockFields = new ArrayList<>();
+  }
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdChartOfCharacteristicTypesPropertiesBridge.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdChartOfCharacteristicTypesPropertiesBridge.java
@@ -1,0 +1,155 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+import io.github.yellowhammer.designerxml.SchemaVersion;
+import io.github.yellowhammer.designerxml.reflect.JaxbReflect;
+
+import static io.github.yellowhammer.designerxml.cf.MdPropertiesBridgeSupport.enumName;
+import static io.github.yellowhammer.designerxml.cf.MdPropertiesBridgeSupport.ensureAndSetRu;
+import static io.github.yellowhammer.designerxml.cf.MdPropertiesBridgeSupport.nullIfBlank;
+
+/**
+ * Чтение и запись {@code ChartOfCharacteristicTypesProperties} через JAXB-рефлексию.
+ *
+ * <p>Предопределённые характеристики ({@code Predefined}) не трогаем: они правятся своими
+ * операциями.
+ */
+public final class MdChartOfCharacteristicTypesPropertiesBridge {
+
+  private MdChartOfCharacteristicTypesPropertiesBridge() {
+  }
+
+  public static void read(SchemaVersion version, Object p, MdObjectPropertiesDto dto) {
+    MdChartOfCharacteristicTypesPropertiesDto d = new MdChartOfCharacteristicTypesPropertiesDto();
+    d.objectBelonging = enumName(p, "getObjectBelonging");
+    d.extendedConfigurationObject = nullIfBlank(JaxbReflect.getStringOptional(p, "getExtendedConfigurationObject"));
+    d.useStandardCommands = JaxbReflect.getBooleanOptional(p, "isUseStandardCommands");
+    d.includeHelpInContents = JaxbReflect.getBooleanOptional(p, "isIncludeHelpInContents");
+    d.characteristicExtValues = JaxbReflect.getStringOptional(p, "getCharacteristicExtValues");
+    d.type = MdTypeDescriptionBridge.read(JaxbReflect.getOptional(p, "getType"));
+    d.hierarchical = JaxbReflect.getBooleanOptional(p, "isHierarchical");
+    d.foldersOnTop = JaxbReflect.getBooleanOptional(p, "isFoldersOnTop");
+    d.codeLength = MdPropertiesBridgeSupport.decimalOrZero(p, "getCodeLength");
+    d.codeAllowedLength = enumName(p, "getCodeAllowedLength");
+    d.descriptionLength = MdPropertiesBridgeSupport.decimalOrZero(p, "getDescriptionLength");
+    d.codeSeries = enumName(p, "getCodeSeries");
+    d.checkUnique = JaxbReflect.getBooleanOptional(p, "isCheckUnique");
+    d.autonumbering = JaxbReflect.getBooleanOptional(p, "isAutonumbering");
+    d.defaultPresentation = enumName(p, "getDefaultPresentation");
+    d.standardAttributesXml = MdPropertiesBridgeSupport.marshalStandardAttributesOrEmpty(
+      version, JaxbReflect.getOptional(p, "getStandardAttributes"));
+    d.characteristicsXml = MdPropertiesBridgeSupport.marshalCharacteristicsOrEmpty(
+      version, JaxbReflect.getOptional(p, "getCharacteristics"));
+    d.predefinedDataUpdate = enumName(p, "getPredefinedDataUpdate");
+    d.editType = enumName(p, "getEditType");
+    d.quickChoice = JaxbReflect.getBooleanOptional(p, "isQuickChoice");
+    d.choiceMode = enumName(p, "getChoiceMode");
+    MdPropertiesBridgeSupport.addFields(d.inputByString, JaxbReflect.getOptional(p, "getInputByString"));
+    d.createOnInput = enumName(p, "getCreateOnInput");
+    d.searchStringModeOnInputByString = enumName(p, "getSearchStringModeOnInputByString");
+    d.choiceDataGetModeOnInputByString = enumName(p, "getChoiceDataGetModeOnInputByString");
+    d.fullTextSearchOnInputByString = enumName(p, "getFullTextSearchOnInputByString");
+    d.choiceHistoryOnInput = enumName(p, "getChoiceHistoryOnInput");
+    d.defaultObjectForm = JaxbReflect.getStringOptional(p, "getDefaultObjectForm");
+    d.defaultFolderForm = JaxbReflect.getStringOptional(p, "getDefaultFolderForm");
+    d.defaultListForm = JaxbReflect.getStringOptional(p, "getDefaultListForm");
+    d.defaultChoiceForm = JaxbReflect.getStringOptional(p, "getDefaultChoiceForm");
+    d.defaultFolderChoiceForm = JaxbReflect.getStringOptional(p, "getDefaultFolderChoiceForm");
+    d.auxiliaryObjectForm = JaxbReflect.getStringOptional(p, "getAuxiliaryObjectForm");
+    d.auxiliaryFolderForm = JaxbReflect.getStringOptional(p, "getAuxiliaryFolderForm");
+    d.auxiliaryListForm = JaxbReflect.getStringOptional(p, "getAuxiliaryListForm");
+    d.auxiliaryChoiceForm = JaxbReflect.getStringOptional(p, "getAuxiliaryChoiceForm");
+    d.auxiliaryFolderChoiceForm = JaxbReflect.getStringOptional(p, "getAuxiliaryFolderChoiceForm");
+    d.objectModule = JaxbReflect.getStringOptional(p, "getObjectModule");
+    d.managerModule = JaxbReflect.getStringOptional(p, "getManagerModule");
+    MdPropertiesBridgeSupport.addItems(d.basedOn, JaxbReflect.getOptional(p, "getBasedOn"));
+    MdPropertiesBridgeSupport.addFields(d.dataLockFields, JaxbReflect.getOptional(p, "getDataLockFields"));
+    d.dataLockControlMode = enumName(p, "getDataLockControlMode");
+    d.fullTextSearch = enumName(p, "getFullTextSearch");
+    d.objectPresentationRu = LocalStringSync.firstRu(JaxbReflect.getOptional(p, "getObjectPresentation"));
+    d.extendedObjectPresentationRu =
+      LocalStringSync.firstRu(JaxbReflect.getOptional(p, "getExtendedObjectPresentation"));
+    d.listPresentationRu = LocalStringSync.firstRu(JaxbReflect.getOptional(p, "getListPresentation"));
+    d.extendedListPresentationRu = LocalStringSync.firstRu(JaxbReflect.getOptional(p, "getExtendedListPresentation"));
+    d.explanationRu = LocalStringSync.firstRu(JaxbReflect.getOptional(p, "getExplanation"));
+    d.dataHistory = enumName(p, "getDataHistory");
+    d.updateDataHistoryImmediatelyAfterWrite =
+      JaxbReflect.getBooleanOptional(p, "isUpdateDataHistoryImmediatelyAfterWrite");
+    d.executeAfterWriteDataHistoryVersionProcessing =
+      JaxbReflect.getBooleanOptional(p, "isExecuteAfterWriteDataHistoryVersionProcessing");
+    d.additionalIndexes = JaxbReflect.getStringOptional(p, "getAdditionalIndexes");
+    dto.chartOfCharacteristicTypes = d;
+  }
+
+  public static void apply(SchemaVersion version, Object p, MdObjectPropertiesDto dto) {
+    MdChartOfCharacteristicTypesPropertiesDto d = dto.chartOfCharacteristicTypes;
+    if (d == null) {
+      throw new IllegalArgumentException("chartOfCharacteristicTypes required");
+    }
+    MdPropertiesBridgeSupport.applyCommon(p, dto);
+    JaxbReflect.setEnumOrKeep(p, "setObjectBelonging", d.objectBelonging);
+    JaxbReflect.setOptional(p, "setExtendedConfigurationObject", nullIfBlank(d.extendedConfigurationObject));
+    JaxbReflect.setOptional(p, "setUseStandardCommands", d.useStandardCommands);
+    JaxbReflect.setOptional(p, "setIncludeHelpInContents", d.includeHelpInContents);
+    JaxbReflect.setOptional(p, "setCharacteristicExtValues", d.characteristicExtValues);
+    if (d.type != null) {
+      MdTypeDescriptionBridge.apply(JaxbReflect.ensureOptional(p, "getType", "setType"), d.type);
+    }
+    JaxbReflect.setOptional(p, "setHierarchical", d.hierarchical);
+    JaxbReflect.setOptional(p, "setFoldersOnTop", d.foldersOnTop);
+    MdPropertiesBridgeSupport.setDecimal(p, "setCodeLength", d.codeLength);
+    JaxbReflect.setEnumOrKeep(p, "setCodeAllowedLength", d.codeAllowedLength);
+    MdPropertiesBridgeSupport.setDecimal(p, "setDescriptionLength", d.descriptionLength);
+    JaxbReflect.setEnumOrKeep(p, "setCodeSeries", d.codeSeries);
+    JaxbReflect.setOptional(p, "setCheckUnique", d.checkUnique);
+    JaxbReflect.setOptional(p, "setAutonumbering", d.autonumbering);
+    JaxbReflect.setEnumOrKeep(p, "setDefaultPresentation", d.defaultPresentation);
+    MdPropertiesBridgeSupport.applyStandardAttributes(version, p, d.standardAttributesXml);
+    MdPropertiesBridgeSupport.applyCharacteristics(version, p, d.characteristicsXml);
+    JaxbReflect.setEnumOrKeep(p, "setPredefinedDataUpdate", d.predefinedDataUpdate);
+    JaxbReflect.setEnumOrKeep(p, "setEditType", d.editType);
+    JaxbReflect.setOptional(p, "setQuickChoice", d.quickChoice);
+    JaxbReflect.setEnumOrKeep(p, "setChoiceMode", d.choiceMode);
+    MdPropertiesBridgeSupport.setFields(JaxbReflect.getOptional(p, "getInputByString"), d.inputByString);
+    JaxbReflect.setEnumOrKeep(p, "setCreateOnInput", d.createOnInput);
+    JaxbReflect.setEnumOrKeep(p, "setSearchStringModeOnInputByString", d.searchStringModeOnInputByString);
+    JaxbReflect.setEnumOrKeep(p, "setChoiceDataGetModeOnInputByString", d.choiceDataGetModeOnInputByString);
+    JaxbReflect.setEnumOrKeep(p, "setFullTextSearchOnInputByString", d.fullTextSearchOnInputByString);
+    JaxbReflect.setEnumOrKeep(p, "setChoiceHistoryOnInput", d.choiceHistoryOnInput);
+    JaxbReflect.setOptional(p, "setDefaultObjectForm", d.defaultObjectForm);
+    JaxbReflect.setOptional(p, "setDefaultFolderForm", d.defaultFolderForm);
+    JaxbReflect.setOptional(p, "setDefaultListForm", d.defaultListForm);
+    JaxbReflect.setOptional(p, "setDefaultChoiceForm", d.defaultChoiceForm);
+    JaxbReflect.setOptional(p, "setDefaultFolderChoiceForm", d.defaultFolderChoiceForm);
+    JaxbReflect.setOptional(p, "setAuxiliaryObjectForm", d.auxiliaryObjectForm);
+    JaxbReflect.setOptional(p, "setAuxiliaryFolderForm", d.auxiliaryFolderForm);
+    JaxbReflect.setOptional(p, "setAuxiliaryListForm", d.auxiliaryListForm);
+    JaxbReflect.setOptional(p, "setAuxiliaryChoiceForm", d.auxiliaryChoiceForm);
+    JaxbReflect.setOptional(p, "setAuxiliaryFolderChoiceForm", d.auxiliaryFolderChoiceForm);
+    JaxbReflect.setOptional(p, "setObjectModule", d.objectModule);
+    JaxbReflect.setOptional(p, "setManagerModule", d.managerModule);
+    MdListTypeRefs.replaceItems(JaxbReflect.getOptional(p, "getBasedOn"), d.basedOn);
+    MdPropertiesBridgeSupport.setFields(JaxbReflect.getOptional(p, "getDataLockFields"), d.dataLockFields);
+    JaxbReflect.setEnumOrKeep(p, "setDataLockControlMode", d.dataLockControlMode);
+    JaxbReflect.setEnumOrKeep(p, "setFullTextSearch", d.fullTextSearch);
+    ensureAndSetRu(p, "getObjectPresentation", "setObjectPresentation", d.objectPresentationRu);
+    ensureAndSetRu(p, "getExtendedObjectPresentation", "setExtendedObjectPresentation",
+      d.extendedObjectPresentationRu);
+    ensureAndSetRu(p, "getListPresentation", "setListPresentation", d.listPresentationRu);
+    ensureAndSetRu(p, "getExtendedListPresentation", "setExtendedListPresentation", d.extendedListPresentationRu);
+    ensureAndSetRu(p, "getExplanation", "setExplanation", d.explanationRu);
+    JaxbReflect.setEnumOrKeep(p, "setDataHistory", d.dataHistory);
+    JaxbReflect.setOptional(p, "setUpdateDataHistoryImmediatelyAfterWrite", d.updateDataHistoryImmediatelyAfterWrite);
+    JaxbReflect.setOptional(p, "setExecuteAfterWriteDataHistoryVersionProcessing",
+      d.executeAfterWriteDataHistoryVersionProcessing);
+    JaxbReflect.setOptional(p, "setAdditionalIndexes", d.additionalIndexes);
+  }
+
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdChartOfCharacteristicTypesPropertiesDto.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdChartOfCharacteristicTypesPropertiesDto.java
@@ -1,0 +1,82 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Поля {@code ChartOfCharacteristicTypesProperties} для {@code cf-md-object-get/set}
+ * ({@code kind=chartOfCharacteristicTypes}).
+ * Enum-значения — имена Java-констант ({@code VARIABLE}, {@code BOTH_WAYS}).
+ */
+public final class MdChartOfCharacteristicTypesPropertiesDto {
+
+  public String objectBelonging;
+  public String extendedConfigurationObject;
+  public boolean useStandardCommands;
+  public boolean includeHelpInContents;
+  /** Дополнительные значения характеристик: ссылка на справочник либо пусто. */
+  public String characteristicExtValues;
+  /** Тип значения характеристики. */
+  public MdTypeDescriptionDto type;
+  public boolean hierarchical;
+  public boolean foldersOnTop;
+  public String codeLength;
+  public String codeAllowedLength;
+  public String descriptionLength;
+  /** Серии кодов: во всём плане либо в пределах подчинения. */
+  public String codeSeries;
+  public boolean checkUnique;
+  public boolean autonumbering;
+  public String defaultPresentation;
+  public String standardAttributesXml;
+  public String characteristicsXml;
+  public String predefinedDataUpdate;
+  public String editType;
+  public boolean quickChoice;
+  public String choiceMode;
+  public List<String> inputByString;
+  public String createOnInput;
+  public String searchStringModeOnInputByString;
+  public String choiceDataGetModeOnInputByString;
+  public String fullTextSearchOnInputByString;
+  public String choiceHistoryOnInput;
+  public String defaultObjectForm;
+  public String defaultFolderForm;
+  public String defaultListForm;
+  public String defaultChoiceForm;
+  public String defaultFolderChoiceForm;
+  public String auxiliaryObjectForm;
+  public String auxiliaryFolderForm;
+  public String auxiliaryListForm;
+  public String auxiliaryChoiceForm;
+  public String auxiliaryFolderChoiceForm;
+  public String objectModule;
+  public String managerModule;
+  public List<String> basedOn;
+  public List<String> dataLockFields;
+  public String dataLockControlMode;
+  public String fullTextSearch;
+  public String objectPresentationRu;
+  public String extendedObjectPresentationRu;
+  public String listPresentationRu;
+  public String extendedListPresentationRu;
+  public String explanationRu;
+  public String dataHistory;
+  public boolean updateDataHistoryImmediatelyAfterWrite;
+  public boolean executeAfterWriteDataHistoryVersionProcessing;
+  public String additionalIndexes;
+
+  public MdChartOfCharacteristicTypesPropertiesDto() {
+    this.inputByString = new ArrayList<>();
+    this.basedOn = new ArrayList<>();
+    this.dataLockFields = new ArrayList<>();
+  }
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdCommonAttributePropertiesBridge.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdCommonAttributePropertiesBridge.java
@@ -1,0 +1,86 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+import io.github.yellowhammer.designerxml.reflect.JaxbReflect;
+
+import static io.github.yellowhammer.designerxml.cf.MdPropertiesBridgeSupport.enumName;
+import static io.github.yellowhammer.designerxml.cf.MdPropertiesBridgeSupport.nullIfBlank;
+
+/**
+ * Чтение и запись {@code CommonAttributeProperties} через JAXB-рефлексию. Разделение данных и автоиспользование решают, где реквизит появится.
+ */
+public final class MdCommonAttributePropertiesBridge {
+
+  private MdCommonAttributePropertiesBridge() {
+  }
+
+  public static void read(Object p, MdObjectPropertiesDto dto) {
+    MdCommonAttributePropertiesDto d = new MdCommonAttributePropertiesDto();
+    d.objectBelonging = enumName(p, "getObjectBelonging");
+    d.extendedConfigurationObject = nullIfBlank(JaxbReflect.getStringOptional(p, "getExtendedConfigurationObject"));
+    d.type = MdTypeDescriptionBridge.read(JaxbReflect.getOptional(p, "getType"));
+    d.autoUse = enumName(p, "getAutoUse");
+    d.dataSeparation = enumName(p, "getDataSeparation");
+    d.separatedDataUse = enumName(p, "getSeparatedDataUse");
+    d.dataSeparationValue = JaxbReflect.getStringOptional(p, "getDataSeparationValue");
+    d.dataSeparationUse = JaxbReflect.getStringOptional(p, "getDataSeparationUse");
+    d.conditionalSeparation = JaxbReflect.getStringOptional(p, "getConditionalSeparation");
+    d.usersSeparation = enumName(p, "getUsersSeparation");
+    d.authenticationSeparation = enumName(p, "getAuthenticationSeparation");
+    d.configurationExtensionsSeparation = enumName(p, "getConfigurationExtensionsSeparation");
+    d.indexing = enumName(p, "getIndexing");
+    d.fullTextSearch = enumName(p, "getFullTextSearch");
+    d.dataHistory = enumName(p, "getDataHistory");
+    d.toolTipRu = LocalStringSync.firstRu(JaxbReflect.getOptional(p, "getToolTip"));
+    d.passwordMode = JaxbReflect.getBooleanOptional(p, "isPasswordMode");
+    d.multiLine = JaxbReflect.getBooleanOptional(p, "isMultiLine");
+    d.mask = JaxbReflect.getStringOptional(p, "getMask");
+    d.quickChoice = enumName(p, "getQuickChoice");
+    d.createOnInput = enumName(p, "getCreateOnInput");
+    d.choiceHistoryOnInput = enumName(p, "getChoiceHistoryOnInput");
+    d.fillChecking = enumName(p, "getFillChecking");
+    d.choiceForm = JaxbReflect.getStringOptional(p, "getChoiceForm");
+    dto.commonAttribute = d;
+  }
+
+  public static void apply(Object p, MdObjectPropertiesDto dto) {
+    MdCommonAttributePropertiesDto d = dto.commonAttribute;
+    if (d == null) {
+      throw new IllegalArgumentException("commonAttribute required");
+    }
+    MdPropertiesBridgeSupport.applyCommon(p, dto);
+    JaxbReflect.setEnumOrKeep(p, "setObjectBelonging", d.objectBelonging);
+    JaxbReflect.setOptional(p, "setExtendedConfigurationObject", nullIfBlank(d.extendedConfigurationObject));
+    if (d.type != null) {
+      MdTypeDescriptionBridge.apply(JaxbReflect.ensureOptional(p, "getType", "setType"), d.type);
+    }
+    JaxbReflect.setEnumOrKeep(p, "setAutoUse", d.autoUse);
+    JaxbReflect.setEnumOrKeep(p, "setDataSeparation", d.dataSeparation);
+    JaxbReflect.setEnumOrKeep(p, "setSeparatedDataUse", d.separatedDataUse);
+    JaxbReflect.setOptional(p, "setDataSeparationValue", d.dataSeparationValue);
+    JaxbReflect.setOptional(p, "setDataSeparationUse", d.dataSeparationUse);
+    JaxbReflect.setOptional(p, "setConditionalSeparation", d.conditionalSeparation);
+    JaxbReflect.setEnumOrKeep(p, "setUsersSeparation", d.usersSeparation);
+    JaxbReflect.setEnumOrKeep(p, "setAuthenticationSeparation", d.authenticationSeparation);
+    JaxbReflect.setEnumOrKeep(p, "setConfigurationExtensionsSeparation", d.configurationExtensionsSeparation);
+    JaxbReflect.setEnumOrKeep(p, "setIndexing", d.indexing);
+    JaxbReflect.setEnumOrKeep(p, "setFullTextSearch", d.fullTextSearch);
+    JaxbReflect.setEnumOrKeep(p, "setDataHistory", d.dataHistory);
+    MdPropertiesBridgeSupport.ensureAndSetRu(p, "getToolTip", "setToolTip", d.toolTipRu);
+    JaxbReflect.setOptional(p, "setPasswordMode", d.passwordMode);
+    JaxbReflect.setOptional(p, "setMultiLine", d.multiLine);
+    JaxbReflect.setOptional(p, "setMask", d.mask);
+    JaxbReflect.setEnumOrKeep(p, "setQuickChoice", d.quickChoice);
+    JaxbReflect.setEnumOrKeep(p, "setCreateOnInput", d.createOnInput);
+    JaxbReflect.setEnumOrKeep(p, "setChoiceHistoryOnInput", d.choiceHistoryOnInput);
+    JaxbReflect.setEnumOrKeep(p, "setFillChecking", d.fillChecking);
+    JaxbReflect.setOptional(p, "setChoiceForm", d.choiceForm);
+  }
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdCommonAttributePropertiesDto.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdCommonAttributePropertiesDto.java
@@ -1,0 +1,41 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+/**
+ * Поля {@code CommonAttributeProperties} для {@code cf-md-object-get/set} ({@code kind=commonAttribute}).
+ * Разделение данных и автоиспользование решают, где реквизит появится.
+ */
+public final class MdCommonAttributePropertiesDto {
+
+  public String objectBelonging;
+  public String extendedConfigurationObject;
+  public MdTypeDescriptionDto type;
+  public String autoUse;
+  public String dataSeparation;
+  public String separatedDataUse;
+  public String dataSeparationValue;
+  public String dataSeparationUse;
+  public String conditionalSeparation;
+  public String usersSeparation;
+  public String authenticationSeparation;
+  public String configurationExtensionsSeparation;
+  public String indexing;
+  public String fullTextSearch;
+  public String dataHistory;
+  public String toolTipRu;
+  public boolean passwordMode;
+  public boolean multiLine;
+  public String mask;
+  public String quickChoice;
+  public String createOnInput;
+  public String choiceHistoryOnInput;
+  public String fillChecking;
+  public String choiceForm;
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdCommonCommandPropertiesBridge.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdCommonCommandPropertiesBridge.java
@@ -1,0 +1,62 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+import io.github.yellowhammer.designerxml.reflect.JaxbReflect;
+
+import static io.github.yellowhammer.designerxml.cf.MdPropertiesBridgeSupport.enumName;
+import static io.github.yellowhammer.designerxml.cf.MdPropertiesBridgeSupport.nullIfBlank;
+
+/**
+ * Чтение и запись {@code CommonCommandProperties} через JAXB-рефлексию. 
+ */
+public final class MdCommonCommandPropertiesBridge {
+
+  private MdCommonCommandPropertiesBridge() {
+  }
+
+  public static void read(Object p, MdObjectPropertiesDto dto) {
+    MdCommonCommandPropertiesDto d = new MdCommonCommandPropertiesDto();
+    d.objectBelonging = enumName(p, "getObjectBelonging");
+    d.extendedConfigurationObject = nullIfBlank(JaxbReflect.getStringOptional(p, "getExtendedConfigurationObject"));
+    d.group = JaxbReflect.getStringOptional(p, "getGroup");
+    d.representation = enumName(p, "getRepresentation");
+    d.toolTipRu = LocalStringSync.firstRu(JaxbReflect.getOptional(p, "getToolTip"));
+    d.shortcut = JaxbReflect.getStringOptional(p, "getShortcut");
+    d.commandModule = JaxbReflect.getStringOptional(p, "getCommandModule");
+    d.includeHelpInContents = JaxbReflect.getBooleanOptional(p, "isIncludeHelpInContents");
+    d.commandParameterType = MdTypeDescriptionBridge.read(JaxbReflect.getOptional(p, "getCommandParameterType"));
+    d.parameterUseMode = enumName(p, "getParameterUseMode");
+    d.modifiesData = JaxbReflect.getBooleanOptional(p, "isModifiesData");
+    d.onMainServerUnavalableBehavior = enumName(p, "getOnMainServerUnavalableBehavior");
+    dto.commonCommand = d;
+  }
+
+  public static void apply(Object p, MdObjectPropertiesDto dto) {
+    MdCommonCommandPropertiesDto d = dto.commonCommand;
+    if (d == null) {
+      throw new IllegalArgumentException("commonCommand required");
+    }
+    MdPropertiesBridgeSupport.applyCommon(p, dto);
+    JaxbReflect.setEnumOrKeep(p, "setObjectBelonging", d.objectBelonging);
+    JaxbReflect.setOptional(p, "setExtendedConfigurationObject", nullIfBlank(d.extendedConfigurationObject));
+    JaxbReflect.setOptional(p, "setGroup", d.group);
+    JaxbReflect.setEnumOrKeep(p, "setRepresentation", d.representation);
+    MdPropertiesBridgeSupport.ensureAndSetRu(p, "getToolTip", "setToolTip", d.toolTipRu);
+    JaxbReflect.setOptional(p, "setShortcut", d.shortcut);
+    JaxbReflect.setOptional(p, "setCommandModule", d.commandModule);
+    JaxbReflect.setOptional(p, "setncludeHelpInContents", d.includeHelpInContents);
+    if (d.commandParameterType != null) {
+      MdTypeDescriptionBridge.apply(JaxbReflect.ensureOptional(p, "getCommandParameterType", "setCommandParameterType"), d.commandParameterType);
+    }
+    JaxbReflect.setEnumOrKeep(p, "setParameterUseMode", d.parameterUseMode);
+    JaxbReflect.setOptional(p, "setodifiesData", d.modifiesData);
+    JaxbReflect.setEnumOrKeep(p, "setOnMainServerUnavalableBehavior", d.onMainServerUnavalableBehavior);
+  }
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdCommonCommandPropertiesDto.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdCommonCommandPropertiesDto.java
@@ -1,0 +1,29 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+/**
+ * Поля {@code CommonCommandProperties} для {@code cf-md-object-get/set} ({@code kind=commonCommand}).
+ * Группа команды и тип параметра решают, где команда появится.
+ */
+public final class MdCommonCommandPropertiesDto {
+
+  public String objectBelonging;
+  public String extendedConfigurationObject;
+  public String group;
+  public String representation;
+  public String toolTipRu;
+  public String shortcut;
+  public String commandModule;
+  public boolean includeHelpInContents;
+  public MdTypeDescriptionDto commandParameterType;
+  public String parameterUseMode;
+  public boolean modifiesData;
+  public String onMainServerUnavalableBehavior;
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdCommonPicturePropertiesBridge.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdCommonPicturePropertiesBridge.java
@@ -1,0 +1,44 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+import io.github.yellowhammer.designerxml.reflect.JaxbReflect;
+
+import static io.github.yellowhammer.designerxml.cf.MdPropertiesBridgeSupport.enumName;
+import static io.github.yellowhammer.designerxml.cf.MdPropertiesBridgeSupport.nullIfBlank;
+
+/**
+ * Чтение и запись {@code CommonPictureProperties} через JAXB-рефлексию. Файл картинки правится не панелью, здесь только признаки доступности.
+ */
+public final class MdCommonPicturePropertiesBridge {
+
+  private MdCommonPicturePropertiesBridge() {
+  }
+
+  public static void read(Object p, MdObjectPropertiesDto dto) {
+    MdCommonPicturePropertiesDto d = new MdCommonPicturePropertiesDto();
+    d.objectBelonging = enumName(p, "getObjectBelonging");
+    d.extendedConfigurationObject = nullIfBlank(JaxbReflect.getStringOptional(p, "getExtendedConfigurationObject"));
+    d.availabilityForChoice = JaxbReflect.getBooleanOptional(p, "isAvailabilityForChoice");
+    d.availabilityForAppearance = JaxbReflect.getBooleanOptional(p, "isAvailabilityForAppearance");
+    dto.commonPicture = d;
+  }
+
+  public static void apply(Object p, MdObjectPropertiesDto dto) {
+    MdCommonPicturePropertiesDto d = dto.commonPicture;
+    if (d == null) {
+      throw new IllegalArgumentException("commonPicture required");
+    }
+    MdPropertiesBridgeSupport.applyCommon(p, dto);
+    JaxbReflect.setEnumOrKeep(p, "setObjectBelonging", d.objectBelonging);
+    JaxbReflect.setOptional(p, "setExtendedConfigurationObject", nullIfBlank(d.extendedConfigurationObject));
+    JaxbReflect.setOptional(p, "setAvailabilityForChoice", d.availabilityForChoice);
+    JaxbReflect.setOptional(p, "setAvailabilityForAppearance", d.availabilityForAppearance);
+  }
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdCommonPicturePropertiesDto.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdCommonPicturePropertiesDto.java
@@ -1,0 +1,21 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+/**
+ * Поля {@code CommonPictureProperties} для {@code cf-md-object-get/set} ({@code kind=commonPicture}).
+ * Файл картинки правится не панелью, здесь только признаки доступности.
+ */
+public final class MdCommonPicturePropertiesDto {
+
+  public String objectBelonging;
+  public String extendedConfigurationObject;
+  public boolean availabilityForChoice;
+  public boolean availabilityForAppearance;
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdDocumentJournalPropertiesBridge.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdDocumentJournalPropertiesBridge.java
@@ -1,0 +1,82 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+import io.github.yellowhammer.designerxml.SchemaVersion;
+import io.github.yellowhammer.designerxml.reflect.JaxbReflect;
+
+import jakarta.xml.bind.JAXBException;
+
+import static io.github.yellowhammer.designerxml.cf.MdPropertiesBridgeSupport.enumName;
+import static io.github.yellowhammer.designerxml.cf.MdPropertiesBridgeSupport.ensureAndSetRu;
+import static io.github.yellowhammer.designerxml.cf.MdPropertiesBridgeSupport.nullIfBlank;
+
+/**
+ * Чтение и запись {@code DocumentJournalProperties} через JAXB-рефлексию.
+ */
+public final class MdDocumentJournalPropertiesBridge {
+
+  private MdDocumentJournalPropertiesBridge() {
+  }
+
+  public static void read(SchemaVersion version, Object p, MdObjectPropertiesDto dto) {
+    MdDocumentJournalPropertiesDto d = new MdDocumentJournalPropertiesDto();
+    d.objectBelonging = enumName(p, "getObjectBelonging");
+    d.extendedConfigurationObject = nullIfBlank(JaxbReflect.getStringOptional(p, "getExtendedConfigurationObject"));
+    d.useStandardCommands = JaxbReflect.getBooleanOptional(p, "isUseStandardCommands");
+    d.defaultForm = JaxbReflect.getStringOptional(p, "getDefaultForm");
+    d.auxiliaryForm = JaxbReflect.getStringOptional(p, "getAuxiliaryForm");
+    d.managerModule = JaxbReflect.getStringOptional(p, "getManagerModule");
+    d.includeHelpInContents = JaxbReflect.getBooleanOptional(p, "isIncludeHelpInContents");
+    d.standardAttributesXml = MdPropertiesBridgeSupport.marshalStandardAttributesOrEmpty(
+      version, JaxbReflect.getOptional(p, "getStandardAttributes"));
+    d.listPresentationRu = LocalStringSync.firstRu(JaxbReflect.getOptional(p, "getListPresentation"));
+    d.extendedListPresentationRu = LocalStringSync.firstRu(JaxbReflect.getOptional(p, "getExtendedListPresentation"));
+    d.explanationRu = LocalStringSync.firstRu(JaxbReflect.getOptional(p, "getExplanation"));
+    d.additionalIndexes = JaxbReflect.getStringOptional(p, "getAdditionalIndexes");
+    Object registered = JaxbReflect.getOptional(p, "getRegisteredDocuments");
+    if (registered != null) {
+      d.registeredDocuments.addAll(MdListTypeRefs.readItemTexts(JaxbReflect.list(registered, "getItem")));
+    }
+    dto.documentJournal = d;
+  }
+
+  public static void apply(SchemaVersion version, Object p, MdObjectPropertiesDto dto) {
+    MdDocumentJournalPropertiesDto d = dto.documentJournal;
+    if (d == null) {
+      throw new IllegalArgumentException("documentJournal required");
+    }
+    MdPropertiesBridgeSupport.applyCommon(p, dto);
+    JaxbReflect.setEnumOrKeep(p, "setObjectBelonging", d.objectBelonging);
+    JaxbReflect.setOptional(p, "setExtendedConfigurationObject", nullIfBlank(d.extendedConfigurationObject));
+    JaxbReflect.setOptional(p, "setUseStandardCommands", d.useStandardCommands);
+    JaxbReflect.setOptional(p, "setDefaultForm", d.defaultForm);
+    JaxbReflect.setOptional(p, "setAuxiliaryForm", d.auxiliaryForm);
+    JaxbReflect.setOptional(p, "setManagerModule", d.managerModule);
+    JaxbReflect.setOptional(p, "setIncludeHelpInContents", d.includeHelpInContents);
+    applyStandardAttributes(version, p, d);
+    ensureAndSetRu(p, "getListPresentation", "setListPresentation", d.listPresentationRu);
+    ensureAndSetRu(p, "getExtendedListPresentation", "setExtendedListPresentation", d.extendedListPresentationRu);
+    ensureAndSetRu(p, "getExplanation", "setExplanation", d.explanationRu);
+    JaxbReflect.setOptional(p, "setAdditionalIndexes", d.additionalIndexes);
+    MdListTypeRefs.replaceItems(JaxbReflect.getOptional(p, "getRegisteredDocuments"), d.registeredDocuments);
+  }
+
+  private static void applyStandardAttributes(SchemaVersion version, Object p, MdDocumentJournalPropertiesDto d) {
+    if (d.standardAttributesXml == null || d.standardAttributesXml.isBlank()) {
+      return;
+    }
+    try {
+      JaxbReflect.setOptional(p, "setStandardAttributes",
+        MdCfCatalogSubtreeXml.unmarshalStandardAttributes(version, d.standardAttributesXml.trim()));
+    } catch (JAXBException e) {
+      throw new IllegalArgumentException("standardAttributesXml: " + e.getMessage(), e);
+    }
+  }
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdDocumentJournalPropertiesDto.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdDocumentJournalPropertiesDto.java
@@ -1,0 +1,39 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Поля {@code DocumentJournalProperties} для {@code cf-md-object-get/set}
+ * ({@code kind=documentJournal}).
+ * Enum-значения — имена Java-констант ({@code ADOPTED}).
+ */
+public final class MdDocumentJournalPropertiesDto {
+
+  public String objectBelonging;
+  public String extendedConfigurationObject;
+  public boolean useStandardCommands;
+  public String defaultForm;
+  public String auxiliaryForm;
+  public String managerModule;
+  public boolean includeHelpInContents;
+  public String standardAttributesXml;
+  public String listPresentationRu;
+  public String extendedListPresentationRu;
+  public String explanationRu;
+  public String additionalIndexes;
+  /** Регистрируемые документы: ссылки вида {@code Document.ИмяДокумента}. */
+  public List<String> registeredDocuments;
+
+  public MdDocumentJournalPropertiesDto() {
+    this.registeredDocuments = new ArrayList<>();
+  }
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdDocumentNumeratorPropertiesBridge.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdDocumentNumeratorPropertiesBridge.java
@@ -1,0 +1,50 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+import io.github.yellowhammer.designerxml.reflect.JaxbReflect;
+
+import static io.github.yellowhammer.designerxml.cf.MdPropertiesBridgeSupport.enumName;
+import static io.github.yellowhammer.designerxml.cf.MdPropertiesBridgeSupport.nullIfBlank;
+
+/**
+ * Чтение и запись {@code DocumentNumeratorProperties} через JAXB-рефлексию. 
+ */
+public final class MdDocumentNumeratorPropertiesBridge {
+
+  private MdDocumentNumeratorPropertiesBridge() {
+  }
+
+  public static void read(Object p, MdObjectPropertiesDto dto) {
+    MdDocumentNumeratorPropertiesDto d = new MdDocumentNumeratorPropertiesDto();
+    d.objectBelonging = enumName(p, "getObjectBelonging");
+    d.extendedConfigurationObject = nullIfBlank(JaxbReflect.getStringOptional(p, "getExtendedConfigurationObject"));
+    d.numberType = enumName(p, "getNumberType");
+    d.numberLength = MdPropertiesBridgeSupport.decimalOrZero(p, "getNumberLength");
+    d.numberAllowedLength = enumName(p, "getNumberAllowedLength");
+    d.numberPeriodicity = enumName(p, "getNumberPeriodicity");
+    d.checkUnique = JaxbReflect.getBooleanOptional(p, "isCheckUnique");
+    dto.documentNumerator = d;
+  }
+
+  public static void apply(Object p, MdObjectPropertiesDto dto) {
+    MdDocumentNumeratorPropertiesDto d = dto.documentNumerator;
+    if (d == null) {
+      throw new IllegalArgumentException("documentNumerator required");
+    }
+    MdPropertiesBridgeSupport.applyCommon(p, dto);
+    JaxbReflect.setEnumOrKeep(p, "setObjectBelonging", d.objectBelonging);
+    JaxbReflect.setOptional(p, "setExtendedConfigurationObject", nullIfBlank(d.extendedConfigurationObject));
+    JaxbReflect.setEnumOrKeep(p, "setNumberType", d.numberType);
+    MdPropertiesBridgeSupport.setDecimal(p, "setNumberLength", d.numberLength);
+    JaxbReflect.setEnumOrKeep(p, "setNumberAllowedLength", d.numberAllowedLength);
+    JaxbReflect.setEnumOrKeep(p, "setNumberPeriodicity", d.numberPeriodicity);
+    JaxbReflect.setOptional(p, "setheckUnique", d.checkUnique);
+  }
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdDocumentNumeratorPropertiesDto.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdDocumentNumeratorPropertiesDto.java
@@ -1,0 +1,24 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+/**
+ * Поля {@code DocumentNumeratorProperties} для {@code cf-md-object-get/set} ({@code kind=documentNumerator}).
+ * Нумерация общая для документов, которые ссылаются на нумератор.
+ */
+public final class MdDocumentNumeratorPropertiesDto {
+
+  public String objectBelonging;
+  public String extendedConfigurationObject;
+  public String numberType;
+  public String numberLength;
+  public String numberAllowedLength;
+  public String numberPeriodicity;
+  public boolean checkUnique;
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdEventSubscriptionPropertiesBridge.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdEventSubscriptionPropertiesBridge.java
@@ -1,0 +1,48 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+import io.github.yellowhammer.designerxml.reflect.JaxbReflect;
+
+import static io.github.yellowhammer.designerxml.cf.MdPropertiesBridgeSupport.enumName;
+import static io.github.yellowhammer.designerxml.cf.MdPropertiesBridgeSupport.nullIfBlank;
+
+/**
+ * Чтение и запись {@code EventSubscriptionProperties} через JAXB-рефлексию. 
+ */
+public final class MdEventSubscriptionPropertiesBridge {
+
+  private MdEventSubscriptionPropertiesBridge() {
+  }
+
+  public static void read(Object p, MdObjectPropertiesDto dto) {
+    MdEventSubscriptionPropertiesDto d = new MdEventSubscriptionPropertiesDto();
+    d.objectBelonging = enumName(p, "getObjectBelonging");
+    d.extendedConfigurationObject = nullIfBlank(JaxbReflect.getStringOptional(p, "getExtendedConfigurationObject"));
+    d.source = MdTypeDescriptionBridge.read(JaxbReflect.getOptional(p, "getSource"));
+    d.event = JaxbReflect.getStringOptional(p, "getEvent");
+    d.handler = JaxbReflect.getStringOptional(p, "getHandler");
+    dto.eventSubscription = d;
+  }
+
+  public static void apply(Object p, MdObjectPropertiesDto dto) {
+    MdEventSubscriptionPropertiesDto d = dto.eventSubscription;
+    if (d == null) {
+      throw new IllegalArgumentException("eventSubscription required");
+    }
+    MdPropertiesBridgeSupport.applyCommon(p, dto);
+    JaxbReflect.setEnumOrKeep(p, "setObjectBelonging", d.objectBelonging);
+    JaxbReflect.setOptional(p, "setExtendedConfigurationObject", nullIfBlank(d.extendedConfigurationObject));
+    if (d.source != null) {
+      MdTypeDescriptionBridge.apply(JaxbReflect.ensureOptional(p, "getSource", "setSource"), d.source);
+    }
+    JaxbReflect.setOptional(p, "setEvent", d.event);
+    JaxbReflect.setOptional(p, "setHandler", d.handler);
+  }
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdEventSubscriptionPropertiesDto.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdEventSubscriptionPropertiesDto.java
@@ -1,0 +1,22 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+/**
+ * Поля {@code EventSubscriptionProperties} для {@code cf-md-object-get/set} ({@code kind=eventSubscription}).
+ * Источник, событие и обработчик подписки.
+ */
+public final class MdEventSubscriptionPropertiesDto {
+
+  public String objectBelonging;
+  public String extendedConfigurationObject;
+  public MdTypeDescriptionDto source;
+  public String event;
+  public String handler;
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdExchangePlanPropertiesBridge.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdExchangePlanPropertiesBridge.java
@@ -1,0 +1,132 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+import io.github.yellowhammer.designerxml.SchemaVersion;
+import io.github.yellowhammer.designerxml.reflect.JaxbReflect;
+
+import static io.github.yellowhammer.designerxml.cf.MdPropertiesBridgeSupport.enumName;
+import static io.github.yellowhammer.designerxml.cf.MdPropertiesBridgeSupport.ensureAndSetRu;
+import static io.github.yellowhammer.designerxml.cf.MdPropertiesBridgeSupport.nullIfBlank;
+
+/**
+ * Чтение и запись {@code ExchangePlanProperties} через JAXB-рефлексию.
+ *
+ * <p>Состав плана обмена ({@code Content}) не трогаем: он правится своими операциями.
+ */
+public final class MdExchangePlanPropertiesBridge {
+
+  private MdExchangePlanPropertiesBridge() {
+  }
+
+  public static void read(SchemaVersion version, Object p, MdObjectPropertiesDto dto) {
+    MdExchangePlanPropertiesDto d = new MdExchangePlanPropertiesDto();
+    d.objectBelonging = enumName(p, "getObjectBelonging");
+    d.extendedConfigurationObject = nullIfBlank(JaxbReflect.getStringOptional(p, "getExtendedConfigurationObject"));
+    d.useStandardCommands = JaxbReflect.getBooleanOptional(p, "isUseStandardCommands");
+    d.codeLength = MdPropertiesBridgeSupport.decimalOrZero(p, "getCodeLength");
+    d.codeAllowedLength = enumName(p, "getCodeAllowedLength");
+    d.descriptionLength = MdPropertiesBridgeSupport.decimalOrZero(p, "getDescriptionLength");
+    d.defaultPresentation = enumName(p, "getDefaultPresentation");
+    d.editType = enumName(p, "getEditType");
+    d.quickChoice = JaxbReflect.getBooleanOptional(p, "isQuickChoice");
+    d.choiceMode = enumName(p, "getChoiceMode");
+    MdPropertiesBridgeSupport.addFields(d.inputByString, JaxbReflect.getOptional(p, "getInputByString"));
+    d.searchStringModeOnInputByString = enumName(p, "getSearchStringModeOnInputByString");
+    d.fullTextSearchOnInputByString = enumName(p, "getFullTextSearchOnInputByString");
+    d.choiceDataGetModeOnInputByString = enumName(p, "getChoiceDataGetModeOnInputByString");
+    d.choiceHistoryOnInput = enumName(p, "getChoiceHistoryOnInput");
+    d.createOnInput = enumName(p, "getCreateOnInput");
+    d.defaultObjectForm = JaxbReflect.getStringOptional(p, "getDefaultObjectForm");
+    d.defaultListForm = JaxbReflect.getStringOptional(p, "getDefaultListForm");
+    d.defaultChoiceForm = JaxbReflect.getStringOptional(p, "getDefaultChoiceForm");
+    d.auxiliaryObjectForm = JaxbReflect.getStringOptional(p, "getAuxiliaryObjectForm");
+    d.auxiliaryListForm = JaxbReflect.getStringOptional(p, "getAuxiliaryListForm");
+    d.auxiliaryChoiceForm = JaxbReflect.getStringOptional(p, "getAuxiliaryChoiceForm");
+    d.objectModule = JaxbReflect.getStringOptional(p, "getObjectModule");
+    d.managerModule = JaxbReflect.getStringOptional(p, "getManagerModule");
+    d.standardAttributesXml = MdPropertiesBridgeSupport.marshalStandardAttributesOrEmpty(
+      version, JaxbReflect.getOptional(p, "getStandardAttributes"));
+    d.characteristicsXml = MdPropertiesBridgeSupport.marshalCharacteristicsOrEmpty(
+      version, JaxbReflect.getOptional(p, "getCharacteristics"));
+    MdPropertiesBridgeSupport.addItems(d.basedOn, JaxbReflect.getOptional(p, "getBasedOn"));
+    d.distributedInfoBase = JaxbReflect.getBooleanOptional(p, "isDistributedInfoBase");
+    d.includeConfigurationExtensions = JaxbReflect.getBooleanOptional(p, "isIncludeConfigurationExtensions");
+    d.includeHelpInContents = JaxbReflect.getBooleanOptional(p, "isIncludeHelpInContents");
+    MdPropertiesBridgeSupport.addFields(d.dataLockFields, JaxbReflect.getOptional(p, "getDataLockFields"));
+    d.dataLockControlMode = enumName(p, "getDataLockControlMode");
+    d.fullTextSearch = enumName(p, "getFullTextSearch");
+    d.objectPresentationRu = LocalStringSync.firstRu(JaxbReflect.getOptional(p, "getObjectPresentation"));
+    d.extendedObjectPresentationRu =
+      LocalStringSync.firstRu(JaxbReflect.getOptional(p, "getExtendedObjectPresentation"));
+    d.listPresentationRu = LocalStringSync.firstRu(JaxbReflect.getOptional(p, "getListPresentation"));
+    d.extendedListPresentationRu = LocalStringSync.firstRu(JaxbReflect.getOptional(p, "getExtendedListPresentation"));
+    d.explanationRu = LocalStringSync.firstRu(JaxbReflect.getOptional(p, "getExplanation"));
+    d.dataHistory = enumName(p, "getDataHistory");
+    d.updateDataHistoryImmediatelyAfterWrite =
+      JaxbReflect.getBooleanOptional(p, "isUpdateDataHistoryImmediatelyAfterWrite");
+    d.executeAfterWriteDataHistoryVersionProcessing =
+      JaxbReflect.getBooleanOptional(p, "isExecuteAfterWriteDataHistoryVersionProcessing");
+    d.additionalIndexes = JaxbReflect.getStringOptional(p, "getAdditionalIndexes");
+    dto.exchangePlan = d;
+  }
+
+  public static void apply(SchemaVersion version, Object p, MdObjectPropertiesDto dto) {
+    MdExchangePlanPropertiesDto d = dto.exchangePlan;
+    if (d == null) {
+      throw new IllegalArgumentException("exchangePlan required");
+    }
+    MdPropertiesBridgeSupport.applyCommon(p, dto);
+    JaxbReflect.setEnumOrKeep(p, "setObjectBelonging", d.objectBelonging);
+    JaxbReflect.setOptional(p, "setExtendedConfigurationObject", nullIfBlank(d.extendedConfigurationObject));
+    JaxbReflect.setOptional(p, "setUseStandardCommands", d.useStandardCommands);
+    MdPropertiesBridgeSupport.setDecimal(p, "setCodeLength", d.codeLength);
+    JaxbReflect.setEnumOrKeep(p, "setCodeAllowedLength", d.codeAllowedLength);
+    MdPropertiesBridgeSupport.setDecimal(p, "setDescriptionLength", d.descriptionLength);
+    JaxbReflect.setEnumOrKeep(p, "setDefaultPresentation", d.defaultPresentation);
+    JaxbReflect.setEnumOrKeep(p, "setEditType", d.editType);
+    JaxbReflect.setOptional(p, "setQuickChoice", d.quickChoice);
+    JaxbReflect.setEnumOrKeep(p, "setChoiceMode", d.choiceMode);
+    MdPropertiesBridgeSupport.setFields(JaxbReflect.getOptional(p, "getInputByString"), d.inputByString);
+    JaxbReflect.setEnumOrKeep(p, "setSearchStringModeOnInputByString", d.searchStringModeOnInputByString);
+    JaxbReflect.setEnumOrKeep(p, "setFullTextSearchOnInputByString", d.fullTextSearchOnInputByString);
+    JaxbReflect.setEnumOrKeep(p, "setChoiceDataGetModeOnInputByString", d.choiceDataGetModeOnInputByString);
+    JaxbReflect.setEnumOrKeep(p, "setChoiceHistoryOnInput", d.choiceHistoryOnInput);
+    JaxbReflect.setEnumOrKeep(p, "setCreateOnInput", d.createOnInput);
+    JaxbReflect.setOptional(p, "setDefaultObjectForm", d.defaultObjectForm);
+    JaxbReflect.setOptional(p, "setDefaultListForm", d.defaultListForm);
+    JaxbReflect.setOptional(p, "setDefaultChoiceForm", d.defaultChoiceForm);
+    JaxbReflect.setOptional(p, "setAuxiliaryObjectForm", d.auxiliaryObjectForm);
+    JaxbReflect.setOptional(p, "setAuxiliaryListForm", d.auxiliaryListForm);
+    JaxbReflect.setOptional(p, "setAuxiliaryChoiceForm", d.auxiliaryChoiceForm);
+    JaxbReflect.setOptional(p, "setObjectModule", d.objectModule);
+    JaxbReflect.setOptional(p, "setManagerModule", d.managerModule);
+    MdPropertiesBridgeSupport.applyStandardAttributes(version, p, d.standardAttributesXml);
+    MdPropertiesBridgeSupport.applyCharacteristics(version, p, d.characteristicsXml);
+    MdListTypeRefs.replaceItems(JaxbReflect.getOptional(p, "getBasedOn"), d.basedOn);
+    JaxbReflect.setOptional(p, "setDistributedInfoBase", d.distributedInfoBase);
+    JaxbReflect.setOptional(p, "setIncludeConfigurationExtensions", d.includeConfigurationExtensions);
+    JaxbReflect.setOptional(p, "setIncludeHelpInContents", d.includeHelpInContents);
+    MdPropertiesBridgeSupport.setFields(JaxbReflect.getOptional(p, "getDataLockFields"), d.dataLockFields);
+    JaxbReflect.setEnumOrKeep(p, "setDataLockControlMode", d.dataLockControlMode);
+    JaxbReflect.setEnumOrKeep(p, "setFullTextSearch", d.fullTextSearch);
+    ensureAndSetRu(p, "getObjectPresentation", "setObjectPresentation", d.objectPresentationRu);
+    ensureAndSetRu(p, "getExtendedObjectPresentation", "setExtendedObjectPresentation",
+      d.extendedObjectPresentationRu);
+    ensureAndSetRu(p, "getListPresentation", "setListPresentation", d.listPresentationRu);
+    ensureAndSetRu(p, "getExtendedListPresentation", "setExtendedListPresentation", d.extendedListPresentationRu);
+    ensureAndSetRu(p, "getExplanation", "setExplanation", d.explanationRu);
+    JaxbReflect.setEnumOrKeep(p, "setDataHistory", d.dataHistory);
+    JaxbReflect.setOptional(p, "setUpdateDataHistoryImmediatelyAfterWrite", d.updateDataHistoryImmediatelyAfterWrite);
+    JaxbReflect.setOptional(p, "setExecuteAfterWriteDataHistoryVersionProcessing",
+      d.executeAfterWriteDataHistoryVersionProcessing);
+    JaxbReflect.setOptional(p, "setAdditionalIndexes", d.additionalIndexes);
+  }
+
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdExchangePlanPropertiesDto.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdExchangePlanPropertiesDto.java
@@ -1,0 +1,75 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Поля {@code ExchangePlanProperties} для {@code cf-md-object-get/set}
+ * ({@code kind=exchangePlan}).
+ * Enum-значения — имена Java-констант ({@code VARIABLE}, {@code BOTH_WAYS}).
+ *
+ * <p>Состав плана обмена ({@code Content}) здесь не представлен: он правится отдельно,
+ * при записи свойств остаётся нетронутым.
+ */
+public final class MdExchangePlanPropertiesDto {
+
+  public String objectBelonging;
+  public String extendedConfigurationObject;
+  public boolean useStandardCommands;
+  public String codeLength;
+  public String codeAllowedLength;
+  public String descriptionLength;
+  /** Основное представление: в виде кода либо в виде наименования. */
+  public String defaultPresentation;
+  /** Способ редактирования: в списке, в диалоге, обоими способами. */
+  public String editType;
+  public boolean quickChoice;
+  public String choiceMode;
+  public List<String> inputByString;
+  public String searchStringModeOnInputByString;
+  public String fullTextSearchOnInputByString;
+  public String choiceDataGetModeOnInputByString;
+  public String choiceHistoryOnInput;
+  public String createOnInput;
+  public String defaultObjectForm;
+  public String defaultListForm;
+  public String defaultChoiceForm;
+  public String auxiliaryObjectForm;
+  public String auxiliaryListForm;
+  public String auxiliaryChoiceForm;
+  public String objectModule;
+  public String managerModule;
+  public String standardAttributesXml;
+  public String characteristicsXml;
+  public List<String> basedOn;
+  /** Распределённая информационная база. */
+  public boolean distributedInfoBase;
+  public boolean includeConfigurationExtensions;
+  public boolean includeHelpInContents;
+  public List<String> dataLockFields;
+  public String dataLockControlMode;
+  public String fullTextSearch;
+  public String objectPresentationRu;
+  public String extendedObjectPresentationRu;
+  public String listPresentationRu;
+  public String extendedListPresentationRu;
+  public String explanationRu;
+  public String dataHistory;
+  public boolean updateDataHistoryImmediatelyAfterWrite;
+  public boolean executeAfterWriteDataHistoryVersionProcessing;
+  public String additionalIndexes;
+
+  public MdExchangePlanPropertiesDto() {
+    this.inputByString = new ArrayList<>();
+    this.basedOn = new ArrayList<>();
+    this.dataLockFields = new ArrayList<>();
+  }
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdExternalDataSourcePropertiesBridge.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdExternalDataSourcePropertiesBridge.java
@@ -1,0 +1,42 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+import io.github.yellowhammer.designerxml.reflect.JaxbReflect;
+
+import static io.github.yellowhammer.designerxml.cf.MdPropertiesBridgeSupport.enumName;
+import static io.github.yellowhammer.designerxml.cf.MdPropertiesBridgeSupport.nullIfBlank;
+
+/**
+ * Чтение и запись {@code ExternalDataSourceProperties} через JAXB-рефлексию. 
+ */
+public final class MdExternalDataSourcePropertiesBridge {
+
+  private MdExternalDataSourcePropertiesBridge() {
+  }
+
+  public static void read(Object p, MdObjectPropertiesDto dto) {
+    MdExternalDataSourcePropertiesDto d = new MdExternalDataSourcePropertiesDto();
+    d.objectBelonging = enumName(p, "getObjectBelonging");
+    d.extendedConfigurationObject = nullIfBlank(JaxbReflect.getStringOptional(p, "getExtendedConfigurationObject"));
+    d.dataLockControlMode = enumName(p, "getDataLockControlMode");
+    dto.externalDataSource = d;
+  }
+
+  public static void apply(Object p, MdObjectPropertiesDto dto) {
+    MdExternalDataSourcePropertiesDto d = dto.externalDataSource;
+    if (d == null) {
+      throw new IllegalArgumentException("externalDataSource required");
+    }
+    MdPropertiesBridgeSupport.applyCommon(p, dto);
+    JaxbReflect.setEnumOrKeep(p, "setObjectBelonging", d.objectBelonging);
+    JaxbReflect.setOptional(p, "setExtendedConfigurationObject", nullIfBlank(d.extendedConfigurationObject));
+    JaxbReflect.setEnumOrKeep(p, "setDataLockControlMode", d.dataLockControlMode);
+  }
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdExternalDataSourcePropertiesDto.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdExternalDataSourcePropertiesDto.java
@@ -1,0 +1,20 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+/**
+ * Поля {@code ExternalDataSourceProperties} для {@code cf-md-object-get/set} ({@code kind=externalDataSource}).
+ * 
+ */
+public final class MdExternalDataSourcePropertiesDto {
+
+  public String objectBelonging;
+  public String extendedConfigurationObject;
+  public String dataLockControlMode;
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectChildMutations.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectChildMutations.java
@@ -309,6 +309,59 @@ public final class MdObjectChildMutations {
    * @throws IOException если не удалось прочитать/записать XML
    * @throws JAXBException если итоговый XML невалиден для JAXB-модели
    */
+  /**
+   * Добавляет команду объекта в корневой {@code ChildObjects}.
+   *
+   * Модуль команды платформа заводит сама при первом открытии, поэтому здесь только узел команды.
+   *
+   * @param objectXml путь к XML объекта
+   * @param version версия схемы Designer XML
+   * @param newName имя команды
+   * @throws IOException если не удалось прочитать/записать XML
+   * @throws JAXBException если итоговый XML невалиден для JAXB-модели
+   */
+  public static void addCommand(Path objectXml, SchemaVersion version, String newName)
+    throws IOException, JAXBException {
+    mutateAndWrite(objectXml, version, (xml, containerLocal) -> {
+      ensureNotBlank(newName, "Введите имя команды.");
+      ensureMissingNamedChild(xml, containerLocal, "Command", newName, "Команда уже существует: " + newName);
+      return insertIntoRootChildObjects(xml, containerLocal, buildCommandSnippet(newName));
+    });
+  }
+
+  /**
+   * Переименовывает команду объекта.
+   *
+   * @param objectXml путь к XML объекта
+   * @param version версия схемы Designer XML
+   * @param oldName текущее имя команды
+   * @param newName новое имя команды
+   * @throws IOException если не удалось прочитать/записать XML
+   * @throws JAXBException если итоговый XML невалиден для JAXB-модели
+   */
+  public static void renameCommand(Path objectXml, SchemaVersion version, String oldName, String newName)
+    throws IOException, JAXBException {
+    mutateAndWrite(objectXml, version, (xml, containerLocal) ->
+      renameNamedChild(xml, containerLocal, "Command", oldName, newName, "Команда"));
+    CommandFiles.renameCommandDirectory(objectXml, oldName, newName);
+  }
+
+  /**
+   * Удаляет команду объекта вместе с каталогом её модуля.
+   *
+   * @param objectXml путь к XML объекта
+   * @param version версия схемы Designer XML
+   * @param name имя удаляемой команды
+   * @throws IOException если не удалось прочитать/записать XML
+   * @throws JAXBException если итоговый XML невалиден для JAXB-модели
+   */
+  public static void deleteCommand(Path objectXml, SchemaVersion version, String name)
+    throws IOException, JAXBException {
+    mutateAndWrite(objectXml, version, (xml, containerLocal) ->
+      deleteNamedChild(xml, containerLocal, "Command", name, "Команда"));
+    CommandFiles.deleteCommandDirectory(objectXml, name);
+  }
+
   public static void addEnumValue(Path objectXml, SchemaVersion version, String newName)
     throws IOException, JAXBException {
     mutateAndWrite(objectXml, version, (xml, containerLocal) -> {
@@ -845,6 +898,22 @@ public final class MdObjectChildMutations {
   }
 
   /**
+   * Переставляет команды корневого {@code ChildObjects} в заданном порядке.
+   *
+   * @param objectXml путь к XML объекта
+   * @param version версия схемы Designer XML
+   * @param order имена команд в нужном порядке
+   * @throws IOException если не удалось прочитать/записать XML
+   * @throws JAXBException если итоговый XML невалиден для JAXB-модели
+   */
+  public static void reorderCommands(Path objectXml, SchemaVersion version, List<String> order)
+    throws IOException, JAXBException {
+    mutateAndWrite(objectXml, version, (xml, containerLocal) ->
+      reorderNamedRegions(xml, order, "Команда",
+        name -> MdObjectXmlRegions.findNamedChildObjectRegion(xml, containerLocal, "Command", name)));
+  }
+
+  /**
    * Переставляет табличные части корневого {@code ChildObjects} в заданном порядке.
    */
   public static void reorderTabularSections(Path objectXml, SchemaVersion version, List<String> order)
@@ -993,6 +1062,31 @@ public final class MdObjectChildMutations {
       + indent + "\t\t<v8:AllowedLength>Variable</v8:AllowedLength>\n"
       + indent + "\t</v8:StringQualifiers>\n"
       + indent + "</Type>\n";
+  }
+
+  private static String buildCommandSnippet(String name) {
+    // Состав узла - как у команды, созданной конфигуратором: тип параметра пустой, поведение авто.
+    return "<Command uuid=\"" + UUID.randomUUID() + "\">\n"
+      + "\t<Properties>\n"
+      + "\t\t<Name>" + escapeXml(name) + "</Name>\n"
+      + "\t\t<Synonym>\n"
+      + "\t\t\t<v8:item>\n"
+      + "\t\t\t\t<v8:lang>ru</v8:lang>\n"
+      + "\t\t\t\t<v8:content>" + escapeXml(name) + "</v8:content>\n"
+      + "\t\t\t</v8:item>\n"
+      + "\t\t</Synonym>\n"
+      + "\t\t<Comment/>\n"
+      + "\t\t<Group>FormCommandBarImportant</Group>\n"
+      + "\t\t<CommandParameterType/>\n"
+      + "\t\t<ParameterUseMode>Single</ParameterUseMode>\n"
+      + "\t\t<ModifiesData>false</ModifiesData>\n"
+      + "\t\t<Representation>Auto</Representation>\n"
+      + "\t\t<ToolTip/>\n"
+      + "\t\t<Picture/>\n"
+      + "\t\t<Shortcut/>\n"
+      + "\t\t<OnMainServerUnavalableBehavior>Auto</OnMainServerUnavalableBehavior>\n"
+      + "\t</Properties>\n"
+      + "</Command>";
   }
 
   private static String buildEnumValueSnippet(String name, String synonymRu, String comment) {

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesDiff.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesDiff.java
@@ -411,10 +411,12 @@ public final class MdObjectPropertiesDiff {
       case "catalog" -> catalogMask(baseline, incoming);
       case "document" -> documentMask(baseline, incoming);
       case "exchangePlan" -> docLikeMask(baseline, incoming);
-      case "constant", "enum", "report", "dataProcessor", "task", "chartOfAccounts",
+      case "constant", "enum", "report", "dataProcessor", "documentJournal", "task", "businessProcess",
+           "chartOfAccounts",
            "chartOfCharacteristicTypes", "chartOfCalculationTypes", "commonModule",
            "informationRegister", "accumulationRegister",
            "sessionParameter", "commonAttribute", "commonPicture", "documentNumerator",
+           "eventSubscription", "scheduledJob", "commonCommand",
            "externalDataSource", "role" -> docLikeMask(baseline, incoming);
       case "subsystem" -> subsystemMask(baseline, incoming);
       default -> new ChangeMask(true, true);
@@ -462,7 +464,26 @@ public final class MdObjectPropertiesDiff {
     return MdFlatDtoSupport.equalsFlat(a.enumeration, b.enumeration, lenientXmlBlobs)
       && MdFlatDtoSupport.equalsFlat(a.constant, b.constant, lenientXmlBlobs)
       && MdFlatDtoSupport.equalsFlat(a.commonModule, b.commonModule, lenientXmlBlobs)
-      && MdFlatDtoSupport.equalsFlat(a.register, b.register, lenientXmlBlobs);
+      && MdFlatDtoSupport.equalsFlat(a.register, b.register, lenientXmlBlobs)
+      && MdFlatDtoSupport.equalsFlat(a.report, b.report, lenientXmlBlobs)
+      && MdFlatDtoSupport.equalsFlat(a.documentJournal, b.documentJournal, lenientXmlBlobs)
+      && MdFlatDtoSupport.equalsFlat(a.exchangePlan, b.exchangePlan, lenientXmlBlobs)
+      && MdFlatDtoSupport.equalsFlat(
+        a.chartOfCharacteristicTypes, b.chartOfCharacteristicTypes, lenientXmlBlobs)
+      && MdFlatDtoSupport.equalsFlat(a.task, b.task, lenientXmlBlobs)
+      && MdFlatDtoSupport.equalsFlat(a.businessProcess, b.businessProcess, lenientXmlBlobs)
+      && MdFlatDtoSupport.equalsFlat(a.chartOfAccounts, b.chartOfAccounts, lenientXmlBlobs)
+      && MdFlatDtoSupport.equalsFlat(
+        a.chartOfCalculationTypes, b.chartOfCalculationTypes, lenientXmlBlobs)
+      && MdFlatDtoSupport.equalsFlat(a.sessionParameter, b.sessionParameter, lenientXmlBlobs)
+      && MdFlatDtoSupport.equalsFlat(a.documentNumerator, b.documentNumerator, lenientXmlBlobs)
+      && MdFlatDtoSupport.equalsFlat(a.eventSubscription, b.eventSubscription, lenientXmlBlobs)
+      && MdFlatDtoSupport.equalsFlat(a.scheduledJob, b.scheduledJob, lenientXmlBlobs)
+      && MdFlatDtoSupport.equalsFlat(a.commonCommand, b.commonCommand, lenientXmlBlobs)
+      && MdFlatDtoSupport.equalsFlat(a.commonAttribute, b.commonAttribute, lenientXmlBlobs)
+      && MdFlatDtoSupport.equalsFlat(a.commonPicture, b.commonPicture, lenientXmlBlobs)
+      && MdFlatDtoSupport.equalsFlat(a.role, b.role, lenientXmlBlobs)
+      && MdFlatDtoSupport.equalsFlat(a.externalDataSource, b.externalDataSource, lenientXmlBlobs);
   }
 
   private static ChangeMask subsystemMask(MdObjectPropertiesDto baseline, MdObjectPropertiesDto incoming) {

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesDto.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesDto.java
@@ -19,7 +19,8 @@ import java.util.List;
  * {@code chartOfCalculationTypes} | {@code commonModule} | {@code subsystem} | {@code sessionParameter} |
  * {@code exchangePlan} | {@code commonAttribute} | {@code commonPicture} | {@code documentNumerator} |
  * {@code externalDataSource} | {@code role} | {@code eventSubscription} | {@code scheduledJob} |
- * {@code commonCommand} | {@code informationRegister} | {@code accumulationRegister}.
+ * {@code commonCommand} | {@code informationRegister} | {@code accumulationRegister} |
+ * {@code documentJournal} | {@code businessProcess}.
  */
 public final class MdObjectPropertiesDto {
 
@@ -56,6 +57,49 @@ public final class MdObjectPropertiesDto {
    * иначе {@code null}.
    */
   public MdRegisterPropertiesDto register;
+  /** Поля отчёта и обработки для {@code kind=report} и {@code kind=dataProcessor}; иначе {@code null}. */
+  public MdReportPropertiesDto report;
+  /** Поля журнала документов для {@code kind=documentJournal}; иначе {@code null}. */
+  public MdDocumentJournalPropertiesDto documentJournal;
+  /** Поля плана обмена для {@code kind=exchangePlan}; иначе {@code null}. */
+  public MdExchangePlanPropertiesDto exchangePlan;
+  /** Поля плана видов характеристик для {@code kind=chartOfCharacteristicTypes}; иначе {@code null}. */
+  public MdChartOfCharacteristicTypesPropertiesDto chartOfCharacteristicTypes;
+  /** Поля задачи для {@code kind=task}; иначе {@code null}. */
+  public MdTaskPropertiesDto task;
+  /** Поля бизнес-процесса для {@code kind=businessProcess}; иначе {@code null}. */
+  public MdBusinessProcessPropertiesDto businessProcess;
+  /** Поля плана счетов для {@code kind=chartOfAccounts}; иначе {@code null}. */
+  public MdChartOfAccountsPropertiesDto chartOfAccounts;
+  /** Поля плана видов расчёта для {@code kind=chartOfCalculationTypes}; иначе {@code null}. */
+  public MdChartOfCalculationTypesPropertiesDto chartOfCalculationTypes;
+
+  /** Свойства параметра сеанса (kind=sessionParameter). */
+  public MdSessionParameterPropertiesDto sessionParameter;
+
+  /** Свойства нумератора документов (kind=documentNumerator). */
+  public MdDocumentNumeratorPropertiesDto documentNumerator;
+
+  /** Свойства подписки на событие (kind=eventSubscription). */
+  public MdEventSubscriptionPropertiesDto eventSubscription;
+
+  /** Свойства регламентного задания (kind=scheduledJob). */
+  public MdScheduledJobPropertiesDto scheduledJob;
+
+  /** Свойства общей команды (kind=commonCommand). */
+  public MdCommonCommandPropertiesDto commonCommand;
+
+  /** Свойства общего реквизита (kind=commonAttribute). */
+  public MdCommonAttributePropertiesDto commonAttribute;
+
+  /** Свойства общей картинки (kind=commonPicture). */
+  public MdCommonPicturePropertiesDto commonPicture;
+
+  /** Свойства роли (kind=role). */
+  public MdRolePropertiesDto role;
+
+  /** Свойства внешнего источника данных (kind=externalDataSource). */
+  public MdExternalDataSourcePropertiesDto externalDataSource;
 
   public MdObjectPropertiesDto() {
     this.attributes = new ArrayList<>();

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesEdit.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesEdit.java
@@ -53,7 +53,9 @@ public final class MdObjectPropertiesEdit {
     new SimpleKindDef("role", "getRole"),
     new SimpleKindDef("eventSubscription", "getEventSubscription"),
     new SimpleKindDef("scheduledJob", "getScheduledJob"),
-    new SimpleKindDef("commonCommand", "getCommonCommand")
+    new SimpleKindDef("commonCommand", "getCommonCommand"),
+    new SimpleKindDef("documentJournal", "getDocumentJournal"),
+    new SimpleKindDef("businessProcess", "getBusinessProcess")
   );
 
   private MdObjectPropertiesEdit() {
@@ -195,19 +197,28 @@ public final class MdObjectPropertiesEdit {
     if (catalog) {
       MdCatalogPropertiesBridge.read(version, props, dto);
     }
+    if ("exchangePlan".equals(kind)) {
+      MdExchangePlanPropertiesBridge.read(version, props, dto);
+    }
     if ("document".equals(kind)) {
       MdDocumentPropertiesBridge.read(version, props, dto);
     }
-    Object co = JaxbReflect.get(node, "getChildObjects");
-    if (co != null) {
-      for (Object a : JaxbReflect.<Object>list(co, "getAttribute")) {
-        dto.attributes.add(namedDto(a));
-      }
-      for (Object ts : JaxbReflect.<Object>list(co, "getTabularSection")) {
-        dto.tabularSections.add(namedDto(ts));
-      }
-    }
+    readCatalogLikeChildren(node, dto);
     return dto;
+  }
+
+  /** Реквизиты и табличные части объекта: состав одинаков у справочника, документа, ПВХ и других. */
+  private static void readCatalogLikeChildren(Object node, MdObjectPropertiesDto dto) {
+    Object co = invokeNoArgOrNull(node, "getChildObjects");
+    if (co == null) {
+      return;
+    }
+    for (Object a : JaxbReflect.<Object>list(co, "getAttribute")) {
+      dto.attributes.add(namedDto(a));
+    }
+    for (Object ts : JaxbReflect.<Object>list(co, "getTabularSection")) {
+      dto.tabularSections.add(namedDto(ts));
+    }
   }
 
   private static MdObjectPropertiesDto base(Object props, String kind) {
@@ -279,7 +290,12 @@ public final class MdObjectPropertiesEdit {
       }
       case "exchangePlan" -> {
         Object ep = require(mdo, "getExchangePlan", "ExchangePlan");
-        applyCatalogLike(JaxbReflect.get(ep, "getProperties"), dto);
+        Object epProps = JaxbReflect.get(ep, "getProperties");
+        if (dto.exchangePlan != null) {
+          MdExchangePlanPropertiesBridge.apply(version, epProps, dto);
+        } else {
+          applyCatalogLike(epProps, dto);
+        }
         applyAttrs(JaxbReflect.get(ep, "getChildObjects"), dto);
       }
       case "subsystem" -> applySubsystem(require(mdo, "getSubsystem", "Subsystem"), dto);
@@ -403,7 +419,38 @@ public final class MdObjectPropertiesEdit {
         readEnumValues(objectNode, dto);
       }
       case "constant" -> MdConstantPropertiesBridge.read(props, dto);
+      case "report", "dataProcessor" -> MdReportPropertiesBridge.read(props, dto);
+      case "documentJournal" -> MdDocumentJournalPropertiesBridge.read(version, props, dto);
+      case "chartOfCalculationTypes" -> {
+        MdChartOfCalculationTypesPropertiesBridge.read(version, props, dto);
+        readCatalogLikeChildren(objectNode, dto);
+      }
+      case "chartOfAccounts" -> {
+        MdChartOfAccountsPropertiesBridge.read(version, props, dto);
+        readCatalogLikeChildren(objectNode, dto);
+      }
+      case "businessProcess" -> {
+        MdBusinessProcessPropertiesBridge.read(version, props, dto);
+        readCatalogLikeChildren(objectNode, dto);
+      }
+      case "task" -> {
+        MdTaskPropertiesBridge.read(version, props, dto);
+        readCatalogLikeChildren(objectNode, dto);
+      }
+      case "chartOfCharacteristicTypes" -> {
+        MdChartOfCharacteristicTypesPropertiesBridge.read(version, props, dto);
+        readCatalogLikeChildren(objectNode, dto);
+      }
       case "commonModule" -> MdCommonModulePropertiesBridge.read(props, dto);
+      case "sessionParameter" -> MdSessionParameterPropertiesBridge.read(props, dto);
+      case "documentNumerator" -> MdDocumentNumeratorPropertiesBridge.read(props, dto);
+      case "eventSubscription" -> MdEventSubscriptionPropertiesBridge.read(props, dto);
+      case "scheduledJob" -> MdScheduledJobPropertiesBridge.read(props, dto);
+      case "commonCommand" -> MdCommonCommandPropertiesBridge.read(props, dto);
+      case "commonAttribute" -> MdCommonAttributePropertiesBridge.read(props, dto);
+      case "commonPicture" -> MdCommonPicturePropertiesBridge.read(props, dto);
+      case "role" -> MdRolePropertiesBridge.read(props, dto);
+      case "externalDataSource" -> MdExternalDataSourcePropertiesBridge.read(props, dto);
       case "informationRegister", "accumulationRegister" -> {
         MdRegisterPropertiesBridge.read(version, props, dto);
         readRegisterChildren(objectNode, dto);
@@ -423,6 +470,75 @@ public final class MdObjectPropertiesEdit {
     }
     if ("constant".equals(dto.kind) && dto.constant != null) {
       MdConstantPropertiesBridge.apply(props, dto);
+      return;
+    }
+    if (isReportKind(dto.kind) && dto.report != null) {
+      MdReportPropertiesBridge.apply(props, dto);
+      return;
+    }
+    if ("documentJournal".equals(dto.kind) && dto.documentJournal != null) {
+      MdDocumentJournalPropertiesBridge.apply(version, props, dto);
+      return;
+    }
+    if ("chartOfCalculationTypes".equals(dto.kind) && dto.chartOfCalculationTypes != null) {
+      MdChartOfCalculationTypesPropertiesBridge.apply(version, props, dto);
+      applyAttrs(JaxbReflect.get(objectNode, "getChildObjects"), dto);
+      return;
+    }
+    if ("chartOfAccounts".equals(dto.kind) && dto.chartOfAccounts != null) {
+      MdChartOfAccountsPropertiesBridge.apply(version, props, dto);
+      applyAttrs(JaxbReflect.get(objectNode, "getChildObjects"), dto);
+      return;
+    }
+    if ("businessProcess".equals(dto.kind) && dto.businessProcess != null) {
+      MdBusinessProcessPropertiesBridge.apply(version, props, dto);
+      applyAttrs(JaxbReflect.get(objectNode, "getChildObjects"), dto);
+      return;
+    }
+    if ("task".equals(dto.kind) && dto.task != null) {
+      MdTaskPropertiesBridge.apply(version, props, dto);
+      applyAttrs(JaxbReflect.get(objectNode, "getChildObjects"), dto);
+      return;
+    }
+    if ("chartOfCharacteristicTypes".equals(dto.kind) && dto.chartOfCharacteristicTypes != null) {
+      MdChartOfCharacteristicTypesPropertiesBridge.apply(version, props, dto);
+      applyAttrs(JaxbReflect.get(objectNode, "getChildObjects"), dto);
+      return;
+    }
+    if ("sessionParameter".equals(dto.kind) && dto.sessionParameter != null) {
+      MdSessionParameterPropertiesBridge.apply(props, dto);
+      return;
+    }
+    if ("documentNumerator".equals(dto.kind) && dto.documentNumerator != null) {
+      MdDocumentNumeratorPropertiesBridge.apply(props, dto);
+      return;
+    }
+    if ("eventSubscription".equals(dto.kind) && dto.eventSubscription != null) {
+      MdEventSubscriptionPropertiesBridge.apply(props, dto);
+      return;
+    }
+    if ("scheduledJob".equals(dto.kind) && dto.scheduledJob != null) {
+      MdScheduledJobPropertiesBridge.apply(props, dto);
+      return;
+    }
+    if ("commonCommand".equals(dto.kind) && dto.commonCommand != null) {
+      MdCommonCommandPropertiesBridge.apply(props, dto);
+      return;
+    }
+    if ("commonAttribute".equals(dto.kind) && dto.commonAttribute != null) {
+      MdCommonAttributePropertiesBridge.apply(props, dto);
+      return;
+    }
+    if ("commonPicture".equals(dto.kind) && dto.commonPicture != null) {
+      MdCommonPicturePropertiesBridge.apply(props, dto);
+      return;
+    }
+    if ("role".equals(dto.kind) && dto.role != null) {
+      MdRolePropertiesBridge.apply(props, dto);
+      return;
+    }
+    if ("externalDataSource".equals(dto.kind) && dto.externalDataSource != null) {
+      MdExternalDataSourcePropertiesBridge.apply(props, dto);
       return;
     }
     if ("commonModule".equals(dto.kind) && dto.commonModule != null) {
@@ -608,6 +724,11 @@ public final class MdObjectPropertiesEdit {
 
   private static String toStringOrEmpty(Object value) {
     return value == null ? "" : String.valueOf(value);
+  }
+
+  /** Отчёт и обработка описываются одним DTO: наборы свойств совпадают, кроме полей отчёта. */
+  static boolean isReportKind(String kind) {
+    return "report".equals(kind) || "dataProcessor".equals(kind);
   }
 
   private static SimpleKindDef simpleKindByName(String kind) {

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesGranularPatch.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesGranularPatch.java
@@ -88,9 +88,14 @@ public final class MdObjectPropertiesGranularPatch {
     } catch (XMLStreamException e) {
       return Optional.empty();
     }
-    reps.sort(Comparator.comparingInt(Replacement::start).reversed());
+    Optional<List<Replacement>> safe = withoutOverlaps(reps);
+    if (safe.isEmpty()) {
+      return Optional.empty();
+    }
+    List<Replacement> ordered = new ArrayList<>(safe.get());
+    ordered.sort(Comparator.comparingInt(Replacement::start).reversed());
     StringBuilder sb = new StringBuilder(xmlUtf8);
-    for (Replacement r : reps) {
+    for (Replacement r : ordered) {
       sb.replace(r.start, r.end, r.text);
     }
     byte[] bytes = sb.toString().getBytes(StandardCharsets.UTF_8);
@@ -167,9 +172,11 @@ public final class MdObjectPropertiesGranularPatch {
       case "constant" -> "Constant";
       case "enum" -> "Enum";
       case "document" -> "Document";
+      case "documentJournal" -> "DocumentJournal";
       case "report" -> "Report";
       case "dataProcessor" -> "DataProcessor";
       case "task" -> "Task";
+      case "businessProcess" -> "BusinessProcess";
       case "chartOfAccounts" -> "ChartOfAccounts";
       case "chartOfCharacteristicTypes" -> "ChartOfCharacteristicTypes";
       case "chartOfCalculationTypes" -> "ChartOfCalculationTypes";
@@ -182,6 +189,9 @@ public final class MdObjectPropertiesGranularPatch {
       case "commonAttribute" -> "CommonAttribute";
       case "commonPicture" -> "CommonPicture";
       case "documentNumerator" -> "DocumentNumerator";
+      case "eventSubscription" -> "EventSubscription";
+      case "scheduledJob" -> "ScheduledJob";
+      case "commonCommand" -> "CommonCommand";
       case "externalDataSource" -> "ExternalDataSource";
       case "role" -> "Role";
       default -> "";
@@ -189,6 +199,39 @@ public final class MdObjectPropertiesGranularPatch {
   }
 
   private record Replacement(int start, int end, String text) {
+  }
+
+  /**
+   * Отсеивает повторную правку того же участка и запрещает пересекающиеся правки.
+   *
+   * Одну и ту же область нельзя править дважды: смещения считаются по исходному тексту, и вторая
+   * правка резала бы уже изменённый XML. Повтор с тем же содержимым безвреден и просто отбрасывается,
+   * а несовместимое пересечение отменяет точечную запись - объект будет записан целиком.
+   *
+   * @param reps Правки в порядке появления.
+   * @return Правки без повторов либо пусто, если правки пересекаются по-разному.
+   */
+  private static Optional<List<Replacement>> withoutOverlaps(List<Replacement> reps) {
+    List<Replacement> out = new ArrayList<>();
+    for (Replacement candidate : reps) {
+      Replacement same = null;
+      for (Replacement kept : out) {
+        boolean intersects = candidate.start() < kept.end() && kept.start() < candidate.end();
+        if (!intersects) {
+          continue;
+        }
+        if (kept.start() == candidate.start() && kept.end() == candidate.end()
+          && kept.text().equals(candidate.text())) {
+          same = kept;
+          continue;
+        }
+        return Optional.empty();
+      }
+      if (same == null) {
+        out.add(candidate);
+      }
+    }
+    return Optional.of(out);
   }
 
   private static String formatReplacementPreservingIndent(

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesJsonCoalesce.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesJsonCoalesce.java
@@ -82,6 +82,59 @@ public final class MdObjectPropertiesJsonCoalesce {
     if ("commonModule".equals(incoming.kind) && baseline.commonModule != null) {
       incoming.commonModule = coalesceFlat(incoming.commonModule, baseline.commonModule);
     }
+    if (MdObjectPropertiesEdit.isReportKind(incoming.kind) && baseline.report != null) {
+      incoming.report = coalesceFlat(incoming.report, baseline.report);
+    }
+    if ("documentJournal".equals(incoming.kind) && baseline.documentJournal != null) {
+      incoming.documentJournal = coalesceFlat(incoming.documentJournal, baseline.documentJournal);
+    }
+    if ("exchangePlan".equals(incoming.kind) && baseline.exchangePlan != null) {
+      incoming.exchangePlan = coalesceFlat(incoming.exchangePlan, baseline.exchangePlan);
+    }
+    if ("chartOfCalculationTypes".equals(incoming.kind) && baseline.chartOfCalculationTypes != null) {
+      incoming.chartOfCalculationTypes =
+        coalesceFlat(incoming.chartOfCalculationTypes, baseline.chartOfCalculationTypes);
+    }
+    if ("sessionParameter".equals(incoming.kind) && baseline.sessionParameter != null) {
+      incoming.sessionParameter = coalesceFlat(incoming.sessionParameter, baseline.sessionParameter);
+    }
+    if ("documentNumerator".equals(incoming.kind) && baseline.documentNumerator != null) {
+      incoming.documentNumerator = coalesceFlat(incoming.documentNumerator, baseline.documentNumerator);
+    }
+    if ("eventSubscription".equals(incoming.kind) && baseline.eventSubscription != null) {
+      incoming.eventSubscription = coalesceFlat(incoming.eventSubscription, baseline.eventSubscription);
+    }
+    if ("scheduledJob".equals(incoming.kind) && baseline.scheduledJob != null) {
+      incoming.scheduledJob = coalesceFlat(incoming.scheduledJob, baseline.scheduledJob);
+    }
+    if ("commonCommand".equals(incoming.kind) && baseline.commonCommand != null) {
+      incoming.commonCommand = coalesceFlat(incoming.commonCommand, baseline.commonCommand);
+    }
+    if ("commonAttribute".equals(incoming.kind) && baseline.commonAttribute != null) {
+      incoming.commonAttribute = coalesceFlat(incoming.commonAttribute, baseline.commonAttribute);
+    }
+    if ("commonPicture".equals(incoming.kind) && baseline.commonPicture != null) {
+      incoming.commonPicture = coalesceFlat(incoming.commonPicture, baseline.commonPicture);
+    }
+    if ("role".equals(incoming.kind) && baseline.role != null) {
+      incoming.role = coalesceFlat(incoming.role, baseline.role);
+    }
+    if ("externalDataSource".equals(incoming.kind) && baseline.externalDataSource != null) {
+      incoming.externalDataSource = coalesceFlat(incoming.externalDataSource, baseline.externalDataSource);
+    }
+    if ("chartOfAccounts".equals(incoming.kind) && baseline.chartOfAccounts != null) {
+      incoming.chartOfAccounts = coalesceFlat(incoming.chartOfAccounts, baseline.chartOfAccounts);
+    }
+    if ("businessProcess".equals(incoming.kind) && baseline.businessProcess != null) {
+      incoming.businessProcess = coalesceFlat(incoming.businessProcess, baseline.businessProcess);
+    }
+    if ("task".equals(incoming.kind) && baseline.task != null) {
+      incoming.task = coalesceFlat(incoming.task, baseline.task);
+    }
+    if ("chartOfCharacteristicTypes".equals(incoming.kind) && baseline.chartOfCharacteristicTypes != null) {
+      incoming.chartOfCharacteristicTypes =
+        coalesceFlat(incoming.chartOfCharacteristicTypes, baseline.chartOfCharacteristicTypes);
+    }
     if (isRegisterKind(incoming.kind) && baseline.register != null) {
       incoming.register = coalesceFlat(incoming.register, baseline.register);
       canonicalizeRegisterXmlBlobsFromBaselineIfLooseEqual(incoming.register, baseline.register);

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesLeafDiff.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesLeafDiff.java
@@ -78,21 +78,165 @@ public final class MdObjectPropertiesLeafDiff {
     if (kind == null) {
       return List.of();
     }
+    List<GranularPatchChange> out = new ArrayList<>(kindPropertyChanges(kind, baseline, incoming));
+    // Синонимы и комментарии дочерних узлов собираем один раз на все виды: иначе одна правка
+    // попадала бы в список дважды и вторая резала бы уже изменённый XML по старым смещениям.
+    appendNamedChildSynonymComment("Attribute", baseline.attributes, incoming.attributes, out);
+    appendNamedChildSynonymComment("TabularSection", baseline.tabularSections, incoming.tabularSections, out);
+    return out;
+  }
+
+  private static List<GranularPatchChange> kindPropertyChanges(
+    String kind,
+    MdObjectPropertiesDto baseline,
+    MdObjectPropertiesDto incoming) {
     return switch (kind) {
       case "subsystem" -> subsystemPropertyChanges(baseline, incoming);
       case "catalog" -> catalogPropertyChanges(baseline, incoming);
       case "document" -> documentPropertyChanges(baseline, incoming);
-      case "exchangePlan" -> docLikePropertyChanges(baseline, incoming);
+      case "exchangePlan" -> exchangePlanPropertyChanges(baseline, incoming);
       case "enum" -> enumPropertyChanges(baseline, incoming);
       case "constant" -> constantPropertyChanges(baseline, incoming);
       case "commonModule" -> commonModulePropertyChanges(baseline, incoming);
+      case "sessionParameter" -> simpleKindChanges(baseline, incoming,
+        (b, i, out) -> MdSimplePropertiesGranularSerial.appendSessionParameterScalarChanges(
+          b.sessionParameter, i.sessionParameter, out),
+        baseline.sessionParameter != null && incoming.sessionParameter != null);
+      case "documentNumerator" -> simpleKindChanges(baseline, incoming,
+        (b, i, out) -> MdSimplePropertiesGranularSerial.appendDocumentNumeratorScalarChanges(
+          b.documentNumerator, i.documentNumerator, out),
+        baseline.documentNumerator != null && incoming.documentNumerator != null);
+      case "eventSubscription" -> simpleKindChanges(baseline, incoming,
+        (b, i, out) -> MdSimplePropertiesGranularSerial.appendEventSubscriptionScalarChanges(
+          b.eventSubscription, i.eventSubscription, out),
+        baseline.eventSubscription != null && incoming.eventSubscription != null);
+      case "scheduledJob" -> simpleKindChanges(baseline, incoming,
+        (b, i, out) -> MdSimplePropertiesGranularSerial.appendScheduledJobScalarChanges(
+          b.scheduledJob, i.scheduledJob, out),
+        baseline.scheduledJob != null && incoming.scheduledJob != null);
+      case "commonCommand" -> simpleKindChanges(baseline, incoming,
+        (b, i, out) -> MdSimplePropertiesGranularSerial.appendCommonCommandScalarChanges(
+          b.commonCommand, i.commonCommand, out),
+        baseline.commonCommand != null && incoming.commonCommand != null);
       case "informationRegister", "accumulationRegister" -> registerPropertyChanges(baseline, incoming);
-      case "report", "dataProcessor", "task", "chartOfAccounts",
-           "chartOfCharacteristicTypes", "chartOfCalculationTypes",
-           "sessionParameter", "commonAttribute", "commonPicture", "documentNumerator",
-           "externalDataSource", "role" -> docLikePropertyChanges(baseline, incoming);
+      case "report", "dataProcessor" -> reportPropertyChanges(baseline, incoming);
+      case "documentJournal" -> documentJournalPropertyChanges(baseline, incoming);
+      case "chartOfCharacteristicTypes" -> chartOfCharacteristicTypesPropertyChanges(baseline, incoming);
+      case "task" -> taskPropertyChanges(baseline, incoming);
+      case "businessProcess" -> businessProcessPropertyChanges(baseline, incoming);
+      case "chartOfAccounts" -> chartOfAccountsPropertyChanges(baseline, incoming);
+      case "chartOfCalculationTypes" -> chartOfCalculationTypesPropertyChanges(baseline, incoming);
+      case "commonAttribute" -> simpleKindChanges(baseline, incoming,
+        (b, i, out) -> MdSimplePropertiesGranularSerial.appendCommonAttributeScalarChanges(
+          b.commonAttribute, i.commonAttribute, out),
+        baseline.commonAttribute != null && incoming.commonAttribute != null);
+      case "commonPicture" -> simpleKindChanges(baseline, incoming,
+        (b, i, out) -> MdSimplePropertiesGranularSerial.appendCommonPictureScalarChanges(
+          b.commonPicture, i.commonPicture, out),
+        baseline.commonPicture != null && incoming.commonPicture != null);
+      case "role" -> simpleKindChanges(baseline, incoming,
+        (b, i, out) -> MdSimplePropertiesGranularSerial.appendRoleScalarChanges(b.role, i.role, out),
+        baseline.role != null && incoming.role != null);
+      case "externalDataSource" -> simpleKindChanges(baseline, incoming,
+        (b, i, out) -> MdSimplePropertiesGranularSerial.appendExternalDataSourceScalarChanges(
+          b.externalDataSource, i.externalDataSource, out),
+        baseline.externalDataSource != null && incoming.externalDataSource != null);
       default -> List.of();
     };
+  }
+
+  private static List<GranularPatchChange> reportPropertyChanges(
+    MdObjectPropertiesDto baseline,
+    MdObjectPropertiesDto incoming) {
+    if (baseline.report == null || incoming.report == null) {
+      return docLikePropertyChanges(baseline, incoming);
+    }
+    List<GranularPatchChange> out = docLikePropertyChanges(baseline, incoming);
+    MdSimplePropertiesGranularSerial.appendReportScalarChanges(baseline.report, incoming.report, out);
+    return out;
+  }
+
+  private static List<GranularPatchChange> chartOfCalculationTypesPropertyChanges(
+    MdObjectPropertiesDto baseline,
+    MdObjectPropertiesDto incoming) {
+    if (baseline.chartOfCalculationTypes == null || incoming.chartOfCalculationTypes == null) {
+      return docLikePropertyChanges(baseline, incoming);
+    }
+    List<GranularPatchChange> out = docLikePropertyChanges(baseline, incoming);
+    MdSimplePropertiesGranularSerial.appendChartOfCalculationTypesScalarChanges(
+      baseline.chartOfCalculationTypes, incoming.chartOfCalculationTypes, out);
+    return out;
+  }
+
+  private static List<GranularPatchChange> chartOfAccountsPropertyChanges(
+    MdObjectPropertiesDto baseline,
+    MdObjectPropertiesDto incoming) {
+    if (baseline.chartOfAccounts == null || incoming.chartOfAccounts == null) {
+      return docLikePropertyChanges(baseline, incoming);
+    }
+    List<GranularPatchChange> out = docLikePropertyChanges(baseline, incoming);
+    MdSimplePropertiesGranularSerial.appendChartOfAccountsScalarChanges(
+      baseline.chartOfAccounts, incoming.chartOfAccounts, out);
+    return out;
+  }
+
+  private static List<GranularPatchChange> businessProcessPropertyChanges(
+    MdObjectPropertiesDto baseline,
+    MdObjectPropertiesDto incoming) {
+    if (baseline.businessProcess == null || incoming.businessProcess == null) {
+      return docLikePropertyChanges(baseline, incoming);
+    }
+    List<GranularPatchChange> out = docLikePropertyChanges(baseline, incoming);
+    MdSimplePropertiesGranularSerial.appendBusinessProcessScalarChanges(
+      baseline.businessProcess, incoming.businessProcess, out);
+    return out;
+  }
+
+  private static List<GranularPatchChange> taskPropertyChanges(
+    MdObjectPropertiesDto baseline,
+    MdObjectPropertiesDto incoming) {
+    if (baseline.task == null || incoming.task == null) {
+      return docLikePropertyChanges(baseline, incoming);
+    }
+    List<GranularPatchChange> out = docLikePropertyChanges(baseline, incoming);
+    MdSimplePropertiesGranularSerial.appendTaskScalarChanges(baseline.task, incoming.task, out);
+    return out;
+  }
+
+  private static List<GranularPatchChange> chartOfCharacteristicTypesPropertyChanges(
+    MdObjectPropertiesDto baseline,
+    MdObjectPropertiesDto incoming) {
+    if (baseline.chartOfCharacteristicTypes == null || incoming.chartOfCharacteristicTypes == null) {
+      return docLikePropertyChanges(baseline, incoming);
+    }
+    List<GranularPatchChange> out = docLikePropertyChanges(baseline, incoming);
+    MdSimplePropertiesGranularSerial.appendChartOfCharacteristicTypesScalarChanges(
+      baseline.chartOfCharacteristicTypes, incoming.chartOfCharacteristicTypes, out);
+    return out;
+  }
+
+  private static List<GranularPatchChange> exchangePlanPropertyChanges(
+    MdObjectPropertiesDto baseline,
+    MdObjectPropertiesDto incoming) {
+    if (baseline.exchangePlan == null || incoming.exchangePlan == null) {
+      return docLikePropertyChanges(baseline, incoming);
+    }
+    List<GranularPatchChange> out = docLikePropertyChanges(baseline, incoming);
+    MdSimplePropertiesGranularSerial.appendExchangePlanScalarChanges(
+      baseline.exchangePlan, incoming.exchangePlan, out);
+    return out;
+  }
+
+  private static List<GranularPatchChange> documentJournalPropertyChanges(
+    MdObjectPropertiesDto baseline,
+    MdObjectPropertiesDto incoming) {
+    if (baseline.documentJournal == null || incoming.documentJournal == null) {
+      return docLikePropertyChanges(baseline, incoming);
+    }
+    List<GranularPatchChange> out = docLikePropertyChanges(baseline, incoming);
+    MdSimplePropertiesGranularSerial.appendDocumentJournalScalarChanges(
+      baseline.documentJournal, incoming.documentJournal, out);
+    return out;
   }
 
   private static List<GranularPatchChange> enumPropertyChanges(
@@ -222,8 +366,26 @@ public final class MdObjectPropertiesLeafDiff {
     if (baseline.document != null) {
       MdDocumentPropertiesGranularSerial.appendDocumentScalarChanges(baseline.document, incoming.document, out);
     }
-    appendNamedChildSynonymComment("Attribute", baseline.attributes, incoming.attributes, out);
-    appendNamedChildSynonymComment("TabularSection", baseline.tabularSections, incoming.tabularSections, out);
+    return out;
+  }
+
+  /** Изменения вида с плоским блоком свойств: общая часть плюс скаляры блока. */
+  private interface KindScalarChanges {
+    void append(
+      MdObjectPropertiesDto baseline,
+      MdObjectPropertiesDto incoming,
+      List<GranularPatchChange> out);
+  }
+
+  private static List<GranularPatchChange> simpleKindChanges(
+    MdObjectPropertiesDto baseline,
+    MdObjectPropertiesDto incoming,
+    KindScalarChanges scalars,
+    boolean hasBlock) {
+    List<GranularPatchChange> out = docLikePropertyChanges(baseline, incoming);
+    if (hasBlock) {
+      scalars.append(baseline, incoming, out);
+    }
     return out;
   }
 
@@ -241,8 +403,6 @@ public final class MdObjectPropertiesLeafDiff {
         "Comment",
         MdCatalogPropertiesGranularSerial.commentElement(incoming.comment)));
     }
-    appendNamedChildSynonymComment("Attribute", baseline.attributes, incoming.attributes, out);
-    appendNamedChildSynonymComment("TabularSection", baseline.tabularSections, incoming.tabularSections, out);
     return out;
   }
 
@@ -290,8 +450,6 @@ public final class MdObjectPropertiesLeafDiff {
     if (b != null) {
       MdCatalogPropertiesGranularSerial.appendCatalogScalarChanges(b, i, out);
     }
-    appendNamedChildSynonymComment("Attribute", baseline.attributes, incoming.attributes, out);
-    appendNamedChildSynonymComment("TabularSection", baseline.tabularSections, incoming.tabularSections, out);
     return out;
   }
 }

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertyEnums.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertyEnums.java
@@ -1,0 +1,103 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+import io.github.yellowhammer.designerxml.SchemaVersion;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Допустимые значения перечислимых свойств объектов метаданных для версии формата.
+ *
+ * <p>Ключ — путь в {@link MdObjectPropertiesDto} вида {@code chartOfCharacteristicTypes.codeSeries},
+ * значение — имена констант перечисления модели. Список снимается с самой модели формата, поэтому
+ * потребителю не нужно держать свою копию: перечисления меняются от версии к версии вместе с XSD.
+ */
+public final class MdObjectPropertyEnums {
+
+  private static final String JAXB_PKG_PREFIX = "io.github.yellowhammer.designerxml.jaxb.";
+
+  private MdObjectPropertyEnums() {
+  }
+
+  /**
+   * Словарь допустимых значений: {@code блок.свойство} → константы перечисления.
+   *
+   * @param version версия формата выгрузки
+   * @return отсортированный по ключу словарь; свойства без перечисления в него не попадают
+   */
+  public static Map<String, List<String>> forVersion(SchemaVersion version) {
+    Map<String, List<String>> out = new LinkedHashMap<>();
+    for (Field block : MdObjectPropertiesDto.class.getFields()) {
+      String typeName = block.getType().getSimpleName();
+      if (!typeName.startsWith("Md") || !typeName.endsWith("PropertiesDto")) {
+        continue;
+      }
+      for (String local : propertiesLocalNames(typeName)) {
+        collect(out, block.getName(), propertiesClass(version, local));
+      }
+    }
+    return out;
+  }
+
+  /**
+   * Классы свойств модели, которые описывает блок DTO.
+   *
+   * <p>Обычно блок соответствует одному виду объекта; отчёт с обработкой и регистры сведений с
+   * регистрами накопления делят один блок, поэтому их перечисления объединяются.
+   */
+  private static List<String> propertiesLocalNames(String blockTypeSimpleName) {
+    String local = blockTypeSimpleName.replaceFirst("^Md", "").replaceFirst("PropertiesDto$", "");
+    return switch (local) {
+      case "Report" -> List.of("Report", "DataProcessor");
+      case "Register" -> List.of("InformationRegister", "AccumulationRegister");
+      default -> List.of(local);
+    };
+  }
+
+  private static Class<?> propertiesClass(SchemaVersion version, String local) {
+    String fqcn = JAXB_PKG_PREFIX + version.name().toLowerCase() + ".mdclasses." + local + "Properties";
+    try {
+      return Class.forName(fqcn);
+    } catch (ClassNotFoundException e) {
+      throw new IllegalStateException("нет класса " + fqcn, e);
+    }
+  }
+
+  /** Добавляет в словарь перечислимые свойства класса; при повторе ключа значения объединяются. */
+  private static void collect(Map<String, List<String>> out, String block, Class<?> properties) {
+    for (Method getter : properties.getMethods()) {
+      if (getter.getParameterCount() != 0 || !getter.getName().startsWith("get")) {
+        continue;
+      }
+      Class<?> type = getter.getReturnType();
+      if (!type.isEnum()) {
+        continue;
+      }
+      String key = block + "." + propertyName(getter.getName());
+      List<String> constants = out.computeIfAbsent(key, k -> new ArrayList<>());
+      for (Object constant : type.getEnumConstants()) {
+        String name = ((Enum<?>) constant).name();
+        if (!constants.contains(name)) {
+          constants.add(name);
+        }
+      }
+    }
+  }
+
+  private static String propertyName(String getterName) {
+    String name = getterName.substring(3);
+    return Character.toLowerCase(name.charAt(0)) + name.substring(1);
+  }
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectStructureDto.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectStructureDto.java
@@ -28,6 +28,8 @@ public final class MdObjectStructureDto {
   public List<String> resources;
   public List<String> recalculations;
   public List<String> addressingAttributes;
+  /** Стандартные реквизиты объекта: платформа задаёт их сама, файл перечисляет с настройками. */
+  public List<String> standardAttributes;
   public List<String> operations;
   public List<String> urlTemplates;
   public List<String> channels;
@@ -49,6 +51,7 @@ public final class MdObjectStructureDto {
     this.resources = new ArrayList<>();
     this.recalculations = new ArrayList<>();
     this.addressingAttributes = new ArrayList<>();
+    this.standardAttributes = new ArrayList<>();
     this.operations = new ArrayList<>();
     this.urlTemplates = new ArrayList<>();
     this.channels = new ArrayList<>();

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectStructureRead.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectStructureRead.java
@@ -112,6 +112,16 @@ public final class MdObjectStructureRead {
     dto.kind = handle.kind;
     dto.internalName = safeString(invokeNoArgOrNull(props, "getName"));
 
+    Object standardAttributes = invokeNoArgOrNull(props, "getStandardAttributes");
+    if (standardAttributes != null) {
+      for (Object item : listOrEmpty(invokeNoArgOrNull(standardAttributes, "getStandardAttribute"))) {
+        String name = safeString(invokeNoArgOrNull(item, "getName"));
+        if (!name.isEmpty()) {
+          dto.standardAttributes.add(name);
+        }
+      }
+    }
+
     Object childObjects = invokeNoArgOrNull(handle.objectNode, "getChildObjects");
     if (childObjects == null) {
       return dto;

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdPropertiesBridgeSupport.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdPropertiesBridgeSupport.java
@@ -13,6 +13,9 @@ import io.github.yellowhammer.designerxml.reflect.JaxbReflect;
 
 import jakarta.xml.bind.JAXBException;
 
+import java.math.BigDecimal;
+import java.util.List;
+
 /**
  * Общие приёмы чтения и записи {@code *Properties} через JAXB-рефлексию.
  */
@@ -53,6 +56,71 @@ final class MdPropertiesBridgeSupport {
 
   static String nullIfBlank(String value) {
     return value == null || value.isBlank() ? null : value;
+  }
+
+  /** Число из XML как строка без экспоненты; {@code "0"}, если элемента нет. */
+  static String decimalOrZero(Object properties, String getter) {
+    Object value = JaxbReflect.getOptional(properties, getter);
+    return value == null ? "0" : ((BigDecimal) value).toPlainString();
+  }
+
+  /** Пишет число, если значение задано; пустую строку игнорирует. */
+  static void setDecimal(Object properties, String setter, String value) {
+    if (value == null || value.isBlank()) {
+      return;
+    }
+    JaxbReflect.setOptional(properties, setter, new BigDecimal(value.trim()));
+  }
+
+  /** Ссылки на объекты метаданных из {@code MDListType}. */
+  static void addItems(List<String> out, Object mdListType) {
+    if (mdListType != null) {
+      out.addAll(MdListTypeRefs.readItemTexts(JaxbReflect.list(mdListType, "getItem")));
+    }
+  }
+
+  /** Поля объекта из {@code FieldList}. */
+  static void addFields(List<String> out, Object fieldList) {
+    if (fieldList != null) {
+      out.addAll(JaxbReflect.<String>list(fieldList, "getField"));
+    }
+  }
+
+  /** Замена состава {@code FieldList}; отсутствующий список пропускается. */
+  static void setFields(Object fieldList, List<String> values) {
+    if (fieldList == null) {
+      return;
+    }
+    List<Object> field = JaxbReflect.list(fieldList, "getField");
+    field.clear();
+    if (values != null) {
+      field.addAll(values);
+    }
+  }
+
+  /** Пишет поддерево стандартных реквизитов; пустое значение оставляет XML как есть. */
+  static void applyStandardAttributes(SchemaVersion version, Object properties, String xml) {
+    applySubtree(version, properties, "setStandardAttributes", xml, true);
+  }
+
+  /** Пишет поддерево характеристик; пустое значение оставляет XML как есть. */
+  static void applyCharacteristics(SchemaVersion version, Object properties, String xml) {
+    applySubtree(version, properties, "setCharacteristics", xml, false);
+  }
+
+  private static void applySubtree(
+    SchemaVersion version, Object properties, String setter, String xml, boolean standardAttributes) {
+    if (xml == null || xml.isBlank()) {
+      return;
+    }
+    try {
+      Object value = standardAttributes
+        ? MdCfCatalogSubtreeXml.unmarshalStandardAttributes(version, xml.trim())
+        : MdCfCatalogSubtreeXml.unmarshalCharacteristics(version, xml.trim());
+      JaxbReflect.setOptional(properties, setter, value);
+    } catch (JAXBException e) {
+      throw new IllegalArgumentException(setter + ": " + e.getMessage(), e);
+    }
   }
 
   /** Проверяет, что DTO относится к тому же объекту, и пишет общие для всех видов свойства. */

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdPropertiesGranularChanges.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdPropertiesGranularChanges.java
@@ -56,6 +56,12 @@ final class MdPropertiesGranularChanges {
     }
   }
 
+  void fields(String localName, List<String> baseline, List<String> incoming) {
+    if (!MdObjectPropertiesDiff.listStringEquals(baseline, incoming)) {
+      add(localName, MdCatalogPropertiesGranularSerial.fieldListElement(localName, incoming));
+    }
+  }
+
   /** Поддерево, которое расширение не разбирает: пишем как есть либо пустым элементом. */
   void xmlBlob(String localName, String baseline, String incoming) {
     if (MdObjectPropertiesDiff.looseXmlBlobEquals(baseline, incoming)) {

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdReportPropertiesBridge.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdReportPropertiesBridge.java
@@ -1,0 +1,75 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+import io.github.yellowhammer.designerxml.reflect.JaxbReflect;
+
+import static io.github.yellowhammer.designerxml.cf.MdPropertiesBridgeSupport.enumName;
+import static io.github.yellowhammer.designerxml.cf.MdPropertiesBridgeSupport.ensureAndSetRu;
+import static io.github.yellowhammer.designerxml.cf.MdPropertiesBridgeSupport.nullIfBlank;
+
+/**
+ * Чтение и запись {@code ReportProperties} и {@code DataProcessorProperties} через
+ * JAXB-рефлексию.
+ *
+ * <p>Свойств отчёта у обработки нет: рефлексия пропускает отсутствующие геттеры и сеттеры,
+ * поэтому мост общий, а поля отчёта у обработки остаются пустыми.
+ */
+public final class MdReportPropertiesBridge {
+
+  private MdReportPropertiesBridge() {
+  }
+
+  public static void read(Object p, MdObjectPropertiesDto dto) {
+    MdReportPropertiesDto d = new MdReportPropertiesDto();
+    d.objectBelonging = enumName(p, "getObjectBelonging");
+    d.extendedConfigurationObject = nullIfBlank(JaxbReflect.getStringOptional(p, "getExtendedConfigurationObject"));
+    d.useStandardCommands = JaxbReflect.getBooleanOptional(p, "isUseStandardCommands");
+    d.defaultForm = JaxbReflect.getStringOptional(p, "getDefaultForm");
+    d.auxiliaryForm = JaxbReflect.getStringOptional(p, "getAuxiliaryForm");
+    d.objectModule = JaxbReflect.getStringOptional(p, "getObjectModule");
+    d.managerModule = JaxbReflect.getStringOptional(p, "getManagerModule");
+    d.includeHelpInContents = JaxbReflect.getBooleanOptional(p, "isIncludeHelpInContents");
+    d.extendedPresentationRu = LocalStringSync.firstRu(JaxbReflect.getOptional(p, "getExtendedPresentation"));
+    d.explanationRu = LocalStringSync.firstRu(JaxbReflect.getOptional(p, "getExplanation"));
+    d.mainDataCompositionSchema = JaxbReflect.getStringOptional(p, "getMainDataCompositionSchema");
+    d.defaultSettingsForm = JaxbReflect.getStringOptional(p, "getDefaultSettingsForm");
+    d.auxiliarySettingsForm = JaxbReflect.getStringOptional(p, "getAuxiliarySettingsForm");
+    d.defaultVariantForm = JaxbReflect.getStringOptional(p, "getDefaultVariantForm");
+    d.auxiliaryVariantForm = JaxbReflect.getStringOptional(p, "getAuxiliaryVariantForm");
+    d.variantsStorage = JaxbReflect.getStringOptional(p, "getVariantsStorage");
+    d.settingsStorage = JaxbReflect.getStringOptional(p, "getSettingsStorage");
+    dto.report = d;
+  }
+
+  public static void apply(Object p, MdObjectPropertiesDto dto) {
+    MdReportPropertiesDto d = dto.report;
+    if (d == null) {
+      throw new IllegalArgumentException("report required");
+    }
+    MdPropertiesBridgeSupport.applyCommon(p, dto);
+    JaxbReflect.setEnumOrKeep(p, "setObjectBelonging", d.objectBelonging);
+    JaxbReflect.setOptional(p, "setExtendedConfigurationObject", nullIfBlank(d.extendedConfigurationObject));
+    JaxbReflect.setOptional(p, "setUseStandardCommands", d.useStandardCommands);
+    JaxbReflect.setOptional(p, "setDefaultForm", d.defaultForm);
+    JaxbReflect.setOptional(p, "setAuxiliaryForm", d.auxiliaryForm);
+    JaxbReflect.setOptional(p, "setObjectModule", d.objectModule);
+    JaxbReflect.setOptional(p, "setManagerModule", d.managerModule);
+    JaxbReflect.setOptional(p, "setIncludeHelpInContents", d.includeHelpInContents);
+    ensureAndSetRu(p, "getExtendedPresentation", "setExtendedPresentation", d.extendedPresentationRu);
+    ensureAndSetRu(p, "getExplanation", "setExplanation", d.explanationRu);
+    JaxbReflect.setOptional(p, "setMainDataCompositionSchema", d.mainDataCompositionSchema);
+    JaxbReflect.setOptional(p, "setDefaultSettingsForm", d.defaultSettingsForm);
+    JaxbReflect.setOptional(p, "setAuxiliarySettingsForm", d.auxiliarySettingsForm);
+    JaxbReflect.setOptional(p, "setDefaultVariantForm", d.defaultVariantForm);
+    JaxbReflect.setOptional(p, "setAuxiliaryVariantForm", d.auxiliaryVariantForm);
+    JaxbReflect.setOptional(p, "setVariantsStorage", d.variantsStorage);
+    JaxbReflect.setOptional(p, "setSettingsStorage", d.settingsStorage);
+  }
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdReportPropertiesDto.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdReportPropertiesDto.java
@@ -1,0 +1,42 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+/**
+ * Поля {@code ReportProperties} и {@code DataProcessorProperties} для
+ * {@code cf-md-object-get/set} ({@code kind=report} и {@code kind=dataProcessor}).
+ *
+ * <p>Наборы свойств совпадают, кроме схемы компоновки, вариантов и хранилищ настроек,
+ * которых у обработки нет: DTO один, у обработки такие поля пусты.
+ */
+public final class MdReportPropertiesDto {
+
+  public String objectBelonging;
+  public String extendedConfigurationObject;
+  public boolean useStandardCommands;
+  public String defaultForm;
+  public String auxiliaryForm;
+  public String objectModule;
+  public String managerModule;
+  public boolean includeHelpInContents;
+  public String extendedPresentationRu;
+  public String explanationRu;
+
+  // Только отчёт
+  /** Основная схема компоновки данных. */
+  public String mainDataCompositionSchema;
+  public String defaultSettingsForm;
+  public String auxiliarySettingsForm;
+  public String defaultVariantForm;
+  public String auxiliaryVariantForm;
+  /** Хранилище вариантов отчёта. */
+  public String variantsStorage;
+  /** Хранилище настроек отчёта. */
+  public String settingsStorage;
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdRolePropertiesBridge.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdRolePropertiesBridge.java
@@ -1,0 +1,40 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+import io.github.yellowhammer.designerxml.reflect.JaxbReflect;
+
+import static io.github.yellowhammer.designerxml.cf.MdPropertiesBridgeSupport.enumName;
+import static io.github.yellowhammer.designerxml.cf.MdPropertiesBridgeSupport.nullIfBlank;
+
+/**
+ * Чтение и запись {@code RoleProperties} через JAXB-рефлексию. Состав прав живёт отдельным файлом Rights.xml и здесь не правится.
+ */
+public final class MdRolePropertiesBridge {
+
+  private MdRolePropertiesBridge() {
+  }
+
+  public static void read(Object p, MdObjectPropertiesDto dto) {
+    MdRolePropertiesDto d = new MdRolePropertiesDto();
+    d.objectBelonging = enumName(p, "getObjectBelonging");
+    d.extendedConfigurationObject = nullIfBlank(JaxbReflect.getStringOptional(p, "getExtendedConfigurationObject"));
+    dto.role = d;
+  }
+
+  public static void apply(Object p, MdObjectPropertiesDto dto) {
+    MdRolePropertiesDto d = dto.role;
+    if (d == null) {
+      throw new IllegalArgumentException("role required");
+    }
+    MdPropertiesBridgeSupport.applyCommon(p, dto);
+    JaxbReflect.setEnumOrKeep(p, "setObjectBelonging", d.objectBelonging);
+    JaxbReflect.setOptional(p, "setExtendedConfigurationObject", nullIfBlank(d.extendedConfigurationObject));
+  }
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdRolePropertiesDto.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdRolePropertiesDto.java
@@ -1,0 +1,19 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+/**
+ * Поля {@code RoleProperties} для {@code cf-md-object-get/set} ({@code kind=role}).
+ * Состав прав живёт отдельным файлом Rights.xml и здесь не правится.
+ */
+public final class MdRolePropertiesDto {
+
+  public String objectBelonging;
+  public String extendedConfigurationObject;
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdScheduledJobPropertiesBridge.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdScheduledJobPropertiesBridge.java
@@ -1,0 +1,56 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+import io.github.yellowhammer.designerxml.reflect.JaxbReflect;
+
+import static io.github.yellowhammer.designerxml.cf.MdPropertiesBridgeSupport.enumName;
+import static io.github.yellowhammer.designerxml.cf.MdPropertiesBridgeSupport.nullIfBlank;
+
+/**
+ * Чтение и запись {@code ScheduledJobProperties} через JAXB-рефлексию. Расписание правится строкой формата платформы.
+ */
+public final class MdScheduledJobPropertiesBridge {
+
+  private MdScheduledJobPropertiesBridge() {
+  }
+
+  public static void read(Object p, MdObjectPropertiesDto dto) {
+    MdScheduledJobPropertiesDto d = new MdScheduledJobPropertiesDto();
+    d.objectBelonging = enumName(p, "getObjectBelonging");
+    d.extendedConfigurationObject = nullIfBlank(JaxbReflect.getStringOptional(p, "getExtendedConfigurationObject"));
+    d.methodName = JaxbReflect.getStringOptional(p, "getMethodName");
+    d.description = JaxbReflect.getStringOptional(p, "getDescription");
+    d.key = JaxbReflect.getStringOptional(p, "getKey");
+    d.schedule = JaxbReflect.getStringOptional(p, "getSchedule");
+    d.use = JaxbReflect.getBooleanOptional(p, "isUse");
+    d.predefined = JaxbReflect.getBooleanOptional(p, "isPredefined");
+    d.restartCountOnFailure = MdPropertiesBridgeSupport.decimalOrZero(p, "getRestartCountOnFailure");
+    d.restartIntervalOnFailure = MdPropertiesBridgeSupport.decimalOrZero(p, "getRestartIntervalOnFailure");
+    dto.scheduledJob = d;
+  }
+
+  public static void apply(Object p, MdObjectPropertiesDto dto) {
+    MdScheduledJobPropertiesDto d = dto.scheduledJob;
+    if (d == null) {
+      throw new IllegalArgumentException("scheduledJob required");
+    }
+    MdPropertiesBridgeSupport.applyCommon(p, dto);
+    JaxbReflect.setEnumOrKeep(p, "setObjectBelonging", d.objectBelonging);
+    JaxbReflect.setOptional(p, "setExtendedConfigurationObject", nullIfBlank(d.extendedConfigurationObject));
+    JaxbReflect.setOptional(p, "setMethodName", d.methodName);
+    JaxbReflect.setOptional(p, "setDescription", d.description);
+    JaxbReflect.setOptional(p, "setKey", d.key);
+    JaxbReflect.setOptional(p, "setSchedule", d.schedule);
+    JaxbReflect.setOptional(p, "setse", d.use);
+    JaxbReflect.setOptional(p, "setredefined", d.predefined);
+    MdPropertiesBridgeSupport.setDecimal(p, "setRestartCountOnFailure", d.restartCountOnFailure);
+    MdPropertiesBridgeSupport.setDecimal(p, "setRestartIntervalOnFailure", d.restartIntervalOnFailure);
+  }
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdScheduledJobPropertiesDto.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdScheduledJobPropertiesDto.java
@@ -1,0 +1,27 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+/**
+ * Поля {@code ScheduledJobProperties} для {@code cf-md-object-get/set} ({@code kind=scheduledJob}).
+ * Расписание хранится строкой формата платформы и правится как есть.
+ */
+public final class MdScheduledJobPropertiesDto {
+
+  public String objectBelonging;
+  public String extendedConfigurationObject;
+  public String methodName;
+  public String description;
+  public String key;
+  public String schedule;
+  public boolean use;
+  public boolean predefined;
+  public String restartCountOnFailure;
+  public String restartIntervalOnFailure;
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdSessionParameterPropertiesBridge.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdSessionParameterPropertiesBridge.java
@@ -1,0 +1,44 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+import io.github.yellowhammer.designerxml.reflect.JaxbReflect;
+
+import static io.github.yellowhammer.designerxml.cf.MdPropertiesBridgeSupport.enumName;
+import static io.github.yellowhammer.designerxml.cf.MdPropertiesBridgeSupport.nullIfBlank;
+
+/**
+ * Чтение и запись {@code SessionParameterProperties} через JAXB-рефлексию. Тип значения задаётся палитрой типов.
+ */
+public final class MdSessionParameterPropertiesBridge {
+
+  private MdSessionParameterPropertiesBridge() {
+  }
+
+  public static void read(Object p, MdObjectPropertiesDto dto) {
+    MdSessionParameterPropertiesDto d = new MdSessionParameterPropertiesDto();
+    d.objectBelonging = enumName(p, "getObjectBelonging");
+    d.extendedConfigurationObject = nullIfBlank(JaxbReflect.getStringOptional(p, "getExtendedConfigurationObject"));
+    d.type = MdTypeDescriptionBridge.read(JaxbReflect.getOptional(p, "getType"));
+    dto.sessionParameter = d;
+  }
+
+  public static void apply(Object p, MdObjectPropertiesDto dto) {
+    MdSessionParameterPropertiesDto d = dto.sessionParameter;
+    if (d == null) {
+      throw new IllegalArgumentException("sessionParameter required");
+    }
+    MdPropertiesBridgeSupport.applyCommon(p, dto);
+    JaxbReflect.setEnumOrKeep(p, "setObjectBelonging", d.objectBelonging);
+    JaxbReflect.setOptional(p, "setExtendedConfigurationObject", nullIfBlank(d.extendedConfigurationObject));
+    if (d.type != null) {
+      MdTypeDescriptionBridge.apply(JaxbReflect.ensureOptional(p, "getType", "setType"), d.type);
+    }
+  }
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdSessionParameterPropertiesDto.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdSessionParameterPropertiesDto.java
@@ -1,0 +1,20 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+/**
+ * Поля {@code SessionParameterProperties} для {@code cf-md-object-get/set} ({@code kind=sessionParameter}).
+ * Тип значения параметра сеанса задаёт палитра типов.
+ */
+public final class MdSessionParameterPropertiesDto {
+
+  public String objectBelonging;
+  public String extendedConfigurationObject;
+  public MdTypeDescriptionDto type;
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdSimplePropertiesGranularSerial.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdSimplePropertiesGranularSerial.java
@@ -118,6 +118,386 @@ final class MdSimplePropertiesGranularSerial {
     c.text("AdditionalIndexes", b.additionalIndexes, i.additionalIndexes);
   }
 
+  static void appendReportScalarChanges(
+    MdReportPropertiesDto b,
+    MdReportPropertiesDto i,
+    List<MdObjectPropertiesLeafDiff.GranularPatchChange> out) {
+    MdPropertiesGranularChanges c = new MdPropertiesGranularChanges(out);
+    c.enumText("ObjectBelonging", b.objectBelonging, i.objectBelonging);
+    c.bool("UseStandardCommands", b.useStandardCommands, i.useStandardCommands);
+    c.text("DefaultForm", b.defaultForm, i.defaultForm);
+    c.text("AuxiliaryForm", b.auxiliaryForm, i.auxiliaryForm);
+    c.text("MainDataCompositionSchema", b.mainDataCompositionSchema, i.mainDataCompositionSchema);
+    c.text("DefaultSettingsForm", b.defaultSettingsForm, i.defaultSettingsForm);
+    c.text("AuxiliarySettingsForm", b.auxiliarySettingsForm, i.auxiliarySettingsForm);
+    c.text("DefaultVariantForm", b.defaultVariantForm, i.defaultVariantForm);
+    c.text("AuxiliaryVariantForm", b.auxiliaryVariantForm, i.auxiliaryVariantForm);
+    c.text("VariantsStorage", b.variantsStorage, i.variantsStorage);
+    c.text("SettingsStorage", b.settingsStorage, i.settingsStorage);
+    c.text("ObjectModule", b.objectModule, i.objectModule);
+    c.text("ManagerModule", b.managerModule, i.managerModule);
+    c.bool("IncludeHelpInContents", b.includeHelpInContents, i.includeHelpInContents);
+    c.localStringRu("ExtendedPresentation", b.extendedPresentationRu, i.extendedPresentationRu);
+    c.localStringRu("Explanation", b.explanationRu, i.explanationRu);
+  }
+
+  static void appendChartOfCalculationTypesScalarChanges(
+    MdChartOfCalculationTypesPropertiesDto b,
+    MdChartOfCalculationTypesPropertiesDto i,
+    List<MdObjectPropertiesLeafDiff.GranularPatchChange> out) {
+    MdPropertiesGranularChanges c = new MdPropertiesGranularChanges(out);
+    c.enumText("ObjectBelonging", b.objectBelonging, i.objectBelonging);
+    c.bool("UseStandardCommands", b.useStandardCommands, i.useStandardCommands);
+    c.text("CodeLength", b.codeLength, i.codeLength);
+    c.text("DescriptionLength", b.descriptionLength, i.descriptionLength);
+    c.enumText("CodeType", b.codeType, i.codeType);
+    c.enumText("CodeAllowedLength", b.codeAllowedLength, i.codeAllowedLength);
+    c.enumText("EditType", b.editType, i.editType);
+    c.fields("InputByString", b.inputByString, i.inputByString);
+    c.enumText("CreateOnInput", b.createOnInput, i.createOnInput);
+    c.enumText("SearchStringModeOnInputByString",
+      b.searchStringModeOnInputByString, i.searchStringModeOnInputByString);
+    c.enumText("ChoiceDataGetModeOnInputByString",
+      b.choiceDataGetModeOnInputByString, i.choiceDataGetModeOnInputByString);
+    c.enumText("FullTextSearchOnInputByString",
+      b.fullTextSearchOnInputByString, i.fullTextSearchOnInputByString);
+    c.enumText("ChoiceHistoryOnInput", b.choiceHistoryOnInput, i.choiceHistoryOnInput);
+    c.text("DefaultObjectForm", b.defaultObjectForm, i.defaultObjectForm);
+    c.text("DefaultListForm", b.defaultListForm, i.defaultListForm);
+    c.text("DefaultChoiceForm", b.defaultChoiceForm, i.defaultChoiceForm);
+    c.text("AuxiliaryObjectForm", b.auxiliaryObjectForm, i.auxiliaryObjectForm);
+    c.text("AuxiliaryListForm", b.auxiliaryListForm, i.auxiliaryListForm);
+    c.text("AuxiliaryChoiceForm", b.auxiliaryChoiceForm, i.auxiliaryChoiceForm);
+    c.text("ObjectModule", b.objectModule, i.objectModule);
+    c.text("ManagerModule", b.managerModule, i.managerModule);
+    c.refs("BasedOn", b.basedOn, i.basedOn);
+    c.enumText("DependenceOnCalculationTypes", b.dependenceOnCalculationTypes, i.dependenceOnCalculationTypes);
+    c.refs("BaseCalculationTypes", b.baseCalculationTypes, i.baseCalculationTypes);
+    c.bool("ActionPeriodUse", b.actionPeriodUse, i.actionPeriodUse);
+    c.xmlBlob("StandardAttributes", b.standardAttributesXml, i.standardAttributesXml);
+    c.xmlBlob("Characteristics", b.characteristicsXml, i.characteristicsXml);
+    c.enumText("PredefinedDataUpdate", b.predefinedDataUpdate, i.predefinedDataUpdate);
+    c.bool("IncludeHelpInContents", b.includeHelpInContents, i.includeHelpInContents);
+    c.fields("DataLockFields", b.dataLockFields, i.dataLockFields);
+    c.enumText("DataLockControlMode", b.dataLockControlMode, i.dataLockControlMode);
+    c.enumText("FullTextSearch", b.fullTextSearch, i.fullTextSearch);
+    c.localStringRu("ObjectPresentation", b.objectPresentationRu, i.objectPresentationRu);
+    c.localStringRu("ExtendedObjectPresentation", b.extendedObjectPresentationRu, i.extendedObjectPresentationRu);
+    c.localStringRu("ListPresentation", b.listPresentationRu, i.listPresentationRu);
+    c.localStringRu("ExtendedListPresentation", b.extendedListPresentationRu, i.extendedListPresentationRu);
+    c.localStringRu("Explanation", b.explanationRu, i.explanationRu);
+    c.enumText("DataHistory", b.dataHistory, i.dataHistory);
+    c.bool("UpdateDataHistoryImmediatelyAfterWrite",
+      b.updateDataHistoryImmediatelyAfterWrite, i.updateDataHistoryImmediatelyAfterWrite);
+    c.bool("ExecuteAfterWriteDataHistoryVersionProcessing",
+      b.executeAfterWriteDataHistoryVersionProcessing, i.executeAfterWriteDataHistoryVersionProcessing);
+    c.text("AdditionalIndexes", b.additionalIndexes, i.additionalIndexes);
+  }
+
+  static void appendChartOfAccountsScalarChanges(
+    MdChartOfAccountsPropertiesDto b,
+    MdChartOfAccountsPropertiesDto i,
+    List<MdObjectPropertiesLeafDiff.GranularPatchChange> out) {
+    MdPropertiesGranularChanges c = new MdPropertiesGranularChanges(out);
+    c.enumText("ObjectBelonging", b.objectBelonging, i.objectBelonging);
+    c.bool("UseStandardCommands", b.useStandardCommands, i.useStandardCommands);
+    c.bool("IncludeHelpInContents", b.includeHelpInContents, i.includeHelpInContents);
+    c.refs("BasedOn", b.basedOn, i.basedOn);
+    c.text("ExtDimensionTypes", b.extDimensionTypes, i.extDimensionTypes);
+    c.text("MaxExtDimensionCount", b.maxExtDimensionCount, i.maxExtDimensionCount);
+    c.text("CodeMask", b.codeMask, i.codeMask);
+    c.text("CodeLength", b.codeLength, i.codeLength);
+    c.text("DescriptionLength", b.descriptionLength, i.descriptionLength);
+    c.enumText("CodeSeries", b.codeSeries, i.codeSeries);
+    c.bool("CheckUnique", b.checkUnique, i.checkUnique);
+    c.enumText("DefaultPresentation", b.defaultPresentation, i.defaultPresentation);
+    c.xmlBlob("StandardAttributes", b.standardAttributesXml, i.standardAttributesXml);
+    c.xmlBlob("Characteristics", b.characteristicsXml, i.characteristicsXml);
+    c.enumText("PredefinedDataUpdate", b.predefinedDataUpdate, i.predefinedDataUpdate);
+    c.enumText("EditType", b.editType, i.editType);
+    c.bool("QuickChoice", b.quickChoice, i.quickChoice);
+    c.enumText("ChoiceMode", b.choiceMode, i.choiceMode);
+    c.fields("InputByString", b.inputByString, i.inputByString);
+    c.enumText("SearchStringModeOnInputByString",
+      b.searchStringModeOnInputByString, i.searchStringModeOnInputByString);
+    c.enumText("FullTextSearchOnInputByString",
+      b.fullTextSearchOnInputByString, i.fullTextSearchOnInputByString);
+    c.enumText("ChoiceDataGetModeOnInputByString",
+      b.choiceDataGetModeOnInputByString, i.choiceDataGetModeOnInputByString);
+    c.enumText("CreateOnInput", b.createOnInput, i.createOnInput);
+    c.enumText("ChoiceHistoryOnInput", b.choiceHistoryOnInput, i.choiceHistoryOnInput);
+    c.text("DefaultObjectForm", b.defaultObjectForm, i.defaultObjectForm);
+    c.text("DefaultListForm", b.defaultListForm, i.defaultListForm);
+    c.text("DefaultChoiceForm", b.defaultChoiceForm, i.defaultChoiceForm);
+    c.text("AuxiliaryObjectForm", b.auxiliaryObjectForm, i.auxiliaryObjectForm);
+    c.text("AuxiliaryListForm", b.auxiliaryListForm, i.auxiliaryListForm);
+    c.text("AuxiliaryChoiceForm", b.auxiliaryChoiceForm, i.auxiliaryChoiceForm);
+    c.text("ObjectModule", b.objectModule, i.objectModule);
+    c.text("ManagerModule", b.managerModule, i.managerModule);
+    c.fields("DataLockFields", b.dataLockFields, i.dataLockFields);
+    c.enumText("DataLockControlMode", b.dataLockControlMode, i.dataLockControlMode);
+    c.enumText("FullTextSearch", b.fullTextSearch, i.fullTextSearch);
+    c.localStringRu("ObjectPresentation", b.objectPresentationRu, i.objectPresentationRu);
+    c.localStringRu("ExtendedObjectPresentation", b.extendedObjectPresentationRu, i.extendedObjectPresentationRu);
+    c.localStringRu("ListPresentation", b.listPresentationRu, i.listPresentationRu);
+    c.localStringRu("ExtendedListPresentation", b.extendedListPresentationRu, i.extendedListPresentationRu);
+    c.localStringRu("Explanation", b.explanationRu, i.explanationRu);
+    c.enumText("DataHistory", b.dataHistory, i.dataHistory);
+    c.bool("UpdateDataHistoryImmediatelyAfterWrite",
+      b.updateDataHistoryImmediatelyAfterWrite, i.updateDataHistoryImmediatelyAfterWrite);
+    c.bool("ExecuteAfterWriteDataHistoryVersionProcessing",
+      b.executeAfterWriteDataHistoryVersionProcessing, i.executeAfterWriteDataHistoryVersionProcessing);
+    c.text("AdditionalIndexes", b.additionalIndexes, i.additionalIndexes);
+  }
+
+  static void appendBusinessProcessScalarChanges(
+    MdBusinessProcessPropertiesDto b,
+    MdBusinessProcessPropertiesDto i,
+    List<MdObjectPropertiesLeafDiff.GranularPatchChange> out) {
+    MdPropertiesGranularChanges c = new MdPropertiesGranularChanges(out);
+    c.enumText("ObjectBelonging", b.objectBelonging, i.objectBelonging);
+    c.bool("UseStandardCommands", b.useStandardCommands, i.useStandardCommands);
+    c.text("ObjectModule", b.objectModule, i.objectModule);
+    c.text("ManagerModule", b.managerModule, i.managerModule);
+    c.text("Flowchart", b.flowchart, i.flowchart);
+    c.enumText("EditType", b.editType, i.editType);
+    c.fields("InputByString", b.inputByString, i.inputByString);
+    c.enumText("CreateOnInput", b.createOnInput, i.createOnInput);
+    c.enumText("SearchStringModeOnInputByString",
+      b.searchStringModeOnInputByString, i.searchStringModeOnInputByString);
+    c.enumText("ChoiceDataGetModeOnInputByString",
+      b.choiceDataGetModeOnInputByString, i.choiceDataGetModeOnInputByString);
+    c.enumText("FullTextSearchOnInputByString",
+      b.fullTextSearchOnInputByString, i.fullTextSearchOnInputByString);
+    c.text("DefaultObjectForm", b.defaultObjectForm, i.defaultObjectForm);
+    c.text("DefaultListForm", b.defaultListForm, i.defaultListForm);
+    c.text("DefaultChoiceForm", b.defaultChoiceForm, i.defaultChoiceForm);
+    c.text("AuxiliaryObjectForm", b.auxiliaryObjectForm, i.auxiliaryObjectForm);
+    c.text("AuxiliaryListForm", b.auxiliaryListForm, i.auxiliaryListForm);
+    c.text("AuxiliaryChoiceForm", b.auxiliaryChoiceForm, i.auxiliaryChoiceForm);
+    c.enumText("ChoiceHistoryOnInput", b.choiceHistoryOnInput, i.choiceHistoryOnInput);
+    c.enumText("NumberType", b.numberType, i.numberType);
+    c.text("NumberLength", b.numberLength, i.numberLength);
+    c.enumText("NumberAllowedLength", b.numberAllowedLength, i.numberAllowedLength);
+    c.bool("CheckUnique", b.checkUnique, i.checkUnique);
+    c.xmlBlob("StandardAttributes", b.standardAttributesXml, i.standardAttributesXml);
+    c.xmlBlob("Characteristics", b.characteristicsXml, i.characteristicsXml);
+    c.bool("Autonumbering", b.autonumbering, i.autonumbering);
+    c.refs("BasedOn", b.basedOn, i.basedOn);
+    c.enumText("NumberPeriodicity", b.numberPeriodicity, i.numberPeriodicity);
+    c.text("Task", b.task, i.task);
+    c.bool("CreateTaskInPrivilegedMode", b.createTaskInPrivilegedMode, i.createTaskInPrivilegedMode);
+    c.fields("DataLockFields", b.dataLockFields, i.dataLockFields);
+    c.enumText("DataLockControlMode", b.dataLockControlMode, i.dataLockControlMode);
+    c.bool("IncludeHelpInContents", b.includeHelpInContents, i.includeHelpInContents);
+    c.enumText("FullTextSearch", b.fullTextSearch, i.fullTextSearch);
+    c.localStringRu("ObjectPresentation", b.objectPresentationRu, i.objectPresentationRu);
+    c.localStringRu("ExtendedObjectPresentation", b.extendedObjectPresentationRu, i.extendedObjectPresentationRu);
+    c.localStringRu("ListPresentation", b.listPresentationRu, i.listPresentationRu);
+    c.localStringRu("ExtendedListPresentation", b.extendedListPresentationRu, i.extendedListPresentationRu);
+    c.localStringRu("Explanation", b.explanationRu, i.explanationRu);
+    c.enumText("DataHistory", b.dataHistory, i.dataHistory);
+    c.bool("UpdateDataHistoryImmediatelyAfterWrite",
+      b.updateDataHistoryImmediatelyAfterWrite, i.updateDataHistoryImmediatelyAfterWrite);
+    c.bool("ExecuteAfterWriteDataHistoryVersionProcessing",
+      b.executeAfterWriteDataHistoryVersionProcessing, i.executeAfterWriteDataHistoryVersionProcessing);
+    c.text("AdditionalIndexes", b.additionalIndexes, i.additionalIndexes);
+  }
+
+  static void appendTaskScalarChanges(
+    MdTaskPropertiesDto b,
+    MdTaskPropertiesDto i,
+    List<MdObjectPropertiesLeafDiff.GranularPatchChange> out) {
+    MdPropertiesGranularChanges c = new MdPropertiesGranularChanges(out);
+    c.enumText("ObjectBelonging", b.objectBelonging, i.objectBelonging);
+    c.bool("UseStandardCommands", b.useStandardCommands, i.useStandardCommands);
+    c.text("ObjectModule", b.objectModule, i.objectModule);
+    c.text("ManagerModule", b.managerModule, i.managerModule);
+    c.enumText("NumberType", b.numberType, i.numberType);
+    c.text("NumberLength", b.numberLength, i.numberLength);
+    c.enumText("NumberAllowedLength", b.numberAllowedLength, i.numberAllowedLength);
+    c.bool("CheckUnique", b.checkUnique, i.checkUnique);
+    c.bool("Autonumbering", b.autonumbering, i.autonumbering);
+    c.enumText("TaskNumberAutoPrefix", b.taskNumberAutoPrefix, i.taskNumberAutoPrefix);
+    c.text("DescriptionLength", b.descriptionLength, i.descriptionLength);
+    c.text("Addressing", b.addressing, i.addressing);
+    c.text("MainAddressingAttribute", b.mainAddressingAttribute, i.mainAddressingAttribute);
+    c.text("CurrentPerformer", b.currentPerformer, i.currentPerformer);
+    c.refs("BasedOn", b.basedOn, i.basedOn);
+    c.xmlBlob("StandardAttributes", b.standardAttributesXml, i.standardAttributesXml);
+    c.xmlBlob("Characteristics", b.characteristicsXml, i.characteristicsXml);
+    c.enumText("DefaultPresentation", b.defaultPresentation, i.defaultPresentation);
+    c.enumText("EditType", b.editType, i.editType);
+    c.fields("InputByString", b.inputByString, i.inputByString);
+    c.enumText("SearchStringModeOnInputByString",
+      b.searchStringModeOnInputByString, i.searchStringModeOnInputByString);
+    c.enumText("FullTextSearchOnInputByString",
+      b.fullTextSearchOnInputByString, i.fullTextSearchOnInputByString);
+    c.enumText("ChoiceDataGetModeOnInputByString",
+      b.choiceDataGetModeOnInputByString, i.choiceDataGetModeOnInputByString);
+    c.enumText("CreateOnInput", b.createOnInput, i.createOnInput);
+    c.text("DefaultObjectForm", b.defaultObjectForm, i.defaultObjectForm);
+    c.text("DefaultListForm", b.defaultListForm, i.defaultListForm);
+    c.text("DefaultChoiceForm", b.defaultChoiceForm, i.defaultChoiceForm);
+    c.text("AuxiliaryObjectForm", b.auxiliaryObjectForm, i.auxiliaryObjectForm);
+    c.text("AuxiliaryListForm", b.auxiliaryListForm, i.auxiliaryListForm);
+    c.text("AuxiliaryChoiceForm", b.auxiliaryChoiceForm, i.auxiliaryChoiceForm);
+    c.enumText("ChoiceHistoryOnInput", b.choiceHistoryOnInput, i.choiceHistoryOnInput);
+    c.bool("IncludeHelpInContents", b.includeHelpInContents, i.includeHelpInContents);
+    c.fields("DataLockFields", b.dataLockFields, i.dataLockFields);
+    c.enumText("DataLockControlMode", b.dataLockControlMode, i.dataLockControlMode);
+    c.enumText("FullTextSearch", b.fullTextSearch, i.fullTextSearch);
+    c.localStringRu("ObjectPresentation", b.objectPresentationRu, i.objectPresentationRu);
+    c.localStringRu("ExtendedObjectPresentation", b.extendedObjectPresentationRu, i.extendedObjectPresentationRu);
+    c.localStringRu("ListPresentation", b.listPresentationRu, i.listPresentationRu);
+    c.localStringRu("ExtendedListPresentation", b.extendedListPresentationRu, i.extendedListPresentationRu);
+    c.localStringRu("Explanation", b.explanationRu, i.explanationRu);
+    c.enumText("DataHistory", b.dataHistory, i.dataHistory);
+    c.bool("UpdateDataHistoryImmediatelyAfterWrite",
+      b.updateDataHistoryImmediatelyAfterWrite, i.updateDataHistoryImmediatelyAfterWrite);
+    c.bool("ExecuteAfterWriteDataHistoryVersionProcessing",
+      b.executeAfterWriteDataHistoryVersionProcessing, i.executeAfterWriteDataHistoryVersionProcessing);
+    c.text("AdditionalIndexes", b.additionalIndexes, i.additionalIndexes);
+  }
+
+  static void appendChartOfCharacteristicTypesScalarChanges(
+    MdChartOfCharacteristicTypesPropertiesDto b,
+    MdChartOfCharacteristicTypesPropertiesDto i,
+    List<MdObjectPropertiesLeafDiff.GranularPatchChange> out) {
+    MdPropertiesGranularChanges c = new MdPropertiesGranularChanges(out);
+    c.enumText("ObjectBelonging", b.objectBelonging, i.objectBelonging);
+    c.bool("UseStandardCommands", b.useStandardCommands, i.useStandardCommands);
+    c.bool("IncludeHelpInContents", b.includeHelpInContents, i.includeHelpInContents);
+    c.text("CharacteristicExtValues", b.characteristicExtValues, i.characteristicExtValues);
+    if (!MdFlatDtoSupport.equalsFlat(b.type, i.type, false)) {
+      out.add(MdObjectPropertiesLeafDiff.GranularPatchChange.objectProperty(
+        "Type", MdTypeDescriptionSerial.typeElement("Type", i.type)));
+    }
+    c.bool("Hierarchical", b.hierarchical, i.hierarchical);
+    c.bool("FoldersOnTop", b.foldersOnTop, i.foldersOnTop);
+    c.text("CodeLength", b.codeLength, i.codeLength);
+    c.enumText("CodeAllowedLength", b.codeAllowedLength, i.codeAllowedLength);
+    c.text("DescriptionLength", b.descriptionLength, i.descriptionLength);
+    c.enumText("CodeSeries", b.codeSeries, i.codeSeries);
+    c.bool("CheckUnique", b.checkUnique, i.checkUnique);
+    c.bool("Autonumbering", b.autonumbering, i.autonumbering);
+    c.enumText("DefaultPresentation", b.defaultPresentation, i.defaultPresentation);
+    c.xmlBlob("StandardAttributes", b.standardAttributesXml, i.standardAttributesXml);
+    c.xmlBlob("Characteristics", b.characteristicsXml, i.characteristicsXml);
+    c.enumText("PredefinedDataUpdate", b.predefinedDataUpdate, i.predefinedDataUpdate);
+    c.enumText("EditType", b.editType, i.editType);
+    c.bool("QuickChoice", b.quickChoice, i.quickChoice);
+    c.enumText("ChoiceMode", b.choiceMode, i.choiceMode);
+    c.fields("InputByString", b.inputByString, i.inputByString);
+    c.enumText("CreateOnInput", b.createOnInput, i.createOnInput);
+    c.enumText("SearchStringModeOnInputByString",
+      b.searchStringModeOnInputByString, i.searchStringModeOnInputByString);
+    c.enumText("ChoiceDataGetModeOnInputByString",
+      b.choiceDataGetModeOnInputByString, i.choiceDataGetModeOnInputByString);
+    c.enumText("FullTextSearchOnInputByString",
+      b.fullTextSearchOnInputByString, i.fullTextSearchOnInputByString);
+    c.enumText("ChoiceHistoryOnInput", b.choiceHistoryOnInput, i.choiceHistoryOnInput);
+    c.text("DefaultObjectForm", b.defaultObjectForm, i.defaultObjectForm);
+    c.text("DefaultFolderForm", b.defaultFolderForm, i.defaultFolderForm);
+    c.text("DefaultListForm", b.defaultListForm, i.defaultListForm);
+    c.text("DefaultChoiceForm", b.defaultChoiceForm, i.defaultChoiceForm);
+    c.text("DefaultFolderChoiceForm", b.defaultFolderChoiceForm, i.defaultFolderChoiceForm);
+    c.text("AuxiliaryObjectForm", b.auxiliaryObjectForm, i.auxiliaryObjectForm);
+    c.text("AuxiliaryFolderForm", b.auxiliaryFolderForm, i.auxiliaryFolderForm);
+    c.text("AuxiliaryListForm", b.auxiliaryListForm, i.auxiliaryListForm);
+    c.text("AuxiliaryChoiceForm", b.auxiliaryChoiceForm, i.auxiliaryChoiceForm);
+    c.text("AuxiliaryFolderChoiceForm", b.auxiliaryFolderChoiceForm, i.auxiliaryFolderChoiceForm);
+    c.text("ObjectModule", b.objectModule, i.objectModule);
+    c.text("ManagerModule", b.managerModule, i.managerModule);
+    c.refs("BasedOn", b.basedOn, i.basedOn);
+    c.fields("DataLockFields", b.dataLockFields, i.dataLockFields);
+    c.enumText("DataLockControlMode", b.dataLockControlMode, i.dataLockControlMode);
+    c.enumText("FullTextSearch", b.fullTextSearch, i.fullTextSearch);
+    c.localStringRu("ObjectPresentation", b.objectPresentationRu, i.objectPresentationRu);
+    c.localStringRu("ExtendedObjectPresentation", b.extendedObjectPresentationRu, i.extendedObjectPresentationRu);
+    c.localStringRu("ListPresentation", b.listPresentationRu, i.listPresentationRu);
+    c.localStringRu("ExtendedListPresentation", b.extendedListPresentationRu, i.extendedListPresentationRu);
+    c.localStringRu("Explanation", b.explanationRu, i.explanationRu);
+    c.enumText("DataHistory", b.dataHistory, i.dataHistory);
+    c.bool("UpdateDataHistoryImmediatelyAfterWrite",
+      b.updateDataHistoryImmediatelyAfterWrite, i.updateDataHistoryImmediatelyAfterWrite);
+    c.bool("ExecuteAfterWriteDataHistoryVersionProcessing",
+      b.executeAfterWriteDataHistoryVersionProcessing, i.executeAfterWriteDataHistoryVersionProcessing);
+    c.text("AdditionalIndexes", b.additionalIndexes, i.additionalIndexes);
+  }
+
+  static void appendExchangePlanScalarChanges(
+    MdExchangePlanPropertiesDto b,
+    MdExchangePlanPropertiesDto i,
+    List<MdObjectPropertiesLeafDiff.GranularPatchChange> out) {
+    MdPropertiesGranularChanges c = new MdPropertiesGranularChanges(out);
+    c.enumText("ObjectBelonging", b.objectBelonging, i.objectBelonging);
+    c.bool("UseStandardCommands", b.useStandardCommands, i.useStandardCommands);
+    c.text("CodeLength", b.codeLength, i.codeLength);
+    c.enumText("CodeAllowedLength", b.codeAllowedLength, i.codeAllowedLength);
+    c.text("DescriptionLength", b.descriptionLength, i.descriptionLength);
+    c.enumText("DefaultPresentation", b.defaultPresentation, i.defaultPresentation);
+    c.enumText("EditType", b.editType, i.editType);
+    c.bool("QuickChoice", b.quickChoice, i.quickChoice);
+    c.enumText("ChoiceMode", b.choiceMode, i.choiceMode);
+    c.fields("InputByString", b.inputByString, i.inputByString);
+    c.enumText("SearchStringModeOnInputByString",
+      b.searchStringModeOnInputByString, i.searchStringModeOnInputByString);
+    c.enumText("FullTextSearchOnInputByString",
+      b.fullTextSearchOnInputByString, i.fullTextSearchOnInputByString);
+    c.enumText("ChoiceDataGetModeOnInputByString",
+      b.choiceDataGetModeOnInputByString, i.choiceDataGetModeOnInputByString);
+    c.enumText("ChoiceHistoryOnInput", b.choiceHistoryOnInput, i.choiceHistoryOnInput);
+    c.enumText("CreateOnInput", b.createOnInput, i.createOnInput);
+    c.text("DefaultObjectForm", b.defaultObjectForm, i.defaultObjectForm);
+    c.text("DefaultListForm", b.defaultListForm, i.defaultListForm);
+    c.text("DefaultChoiceForm", b.defaultChoiceForm, i.defaultChoiceForm);
+    c.text("AuxiliaryObjectForm", b.auxiliaryObjectForm, i.auxiliaryObjectForm);
+    c.text("AuxiliaryListForm", b.auxiliaryListForm, i.auxiliaryListForm);
+    c.text("AuxiliaryChoiceForm", b.auxiliaryChoiceForm, i.auxiliaryChoiceForm);
+    c.text("ObjectModule", b.objectModule, i.objectModule);
+    c.text("ManagerModule", b.managerModule, i.managerModule);
+    c.xmlBlob("StandardAttributes", b.standardAttributesXml, i.standardAttributesXml);
+    c.xmlBlob("Characteristics", b.characteristicsXml, i.characteristicsXml);
+    c.refs("BasedOn", b.basedOn, i.basedOn);
+    c.bool("DistributedInfoBase", b.distributedInfoBase, i.distributedInfoBase);
+    c.bool("IncludeConfigurationExtensions", b.includeConfigurationExtensions, i.includeConfigurationExtensions);
+    c.bool("IncludeHelpInContents", b.includeHelpInContents, i.includeHelpInContents);
+    c.fields("DataLockFields", b.dataLockFields, i.dataLockFields);
+    c.enumText("DataLockControlMode", b.dataLockControlMode, i.dataLockControlMode);
+    c.enumText("FullTextSearch", b.fullTextSearch, i.fullTextSearch);
+    c.localStringRu("ObjectPresentation", b.objectPresentationRu, i.objectPresentationRu);
+    c.localStringRu("ExtendedObjectPresentation", b.extendedObjectPresentationRu, i.extendedObjectPresentationRu);
+    c.localStringRu("ListPresentation", b.listPresentationRu, i.listPresentationRu);
+    c.localStringRu("ExtendedListPresentation", b.extendedListPresentationRu, i.extendedListPresentationRu);
+    c.localStringRu("Explanation", b.explanationRu, i.explanationRu);
+    c.enumText("DataHistory", b.dataHistory, i.dataHistory);
+    c.bool("UpdateDataHistoryImmediatelyAfterWrite",
+      b.updateDataHistoryImmediatelyAfterWrite, i.updateDataHistoryImmediatelyAfterWrite);
+    c.bool("ExecuteAfterWriteDataHistoryVersionProcessing",
+      b.executeAfterWriteDataHistoryVersionProcessing, i.executeAfterWriteDataHistoryVersionProcessing);
+    c.text("AdditionalIndexes", b.additionalIndexes, i.additionalIndexes);
+  }
+
+  static void appendDocumentJournalScalarChanges(
+    MdDocumentJournalPropertiesDto b,
+    MdDocumentJournalPropertiesDto i,
+    List<MdObjectPropertiesLeafDiff.GranularPatchChange> out) {
+    MdPropertiesGranularChanges c = new MdPropertiesGranularChanges(out);
+    c.enumText("ObjectBelonging", b.objectBelonging, i.objectBelonging);
+    c.bool("UseStandardCommands", b.useStandardCommands, i.useStandardCommands);
+    c.text("DefaultForm", b.defaultForm, i.defaultForm);
+    c.text("AuxiliaryForm", b.auxiliaryForm, i.auxiliaryForm);
+    c.refs("RegisteredDocuments", b.registeredDocuments, i.registeredDocuments);
+    c.text("ManagerModule", b.managerModule, i.managerModule);
+    c.bool("IncludeHelpInContents", b.includeHelpInContents, i.includeHelpInContents);
+    c.xmlBlob("StandardAttributes", b.standardAttributesXml, i.standardAttributesXml);
+    c.localStringRu("ListPresentation", b.listPresentationRu, i.listPresentationRu);
+    c.localStringRu("ExtendedListPresentation", b.extendedListPresentationRu, i.extendedListPresentationRu);
+    c.localStringRu("Explanation", b.explanationRu, i.explanationRu);
+    c.text("AdditionalIndexes", b.additionalIndexes, i.additionalIndexes);
+  }
+
   static void appendCommonModuleScalarChanges(
     MdCommonModulePropertiesDto b,
     MdCommonModulePropertiesDto i,
@@ -133,5 +513,126 @@ final class MdSimplePropertiesGranularSerial {
     c.bool("ServerCall", b.serverCall, i.serverCall);
     c.bool("Privileged", b.privileged, i.privileged);
     c.enumText("ReturnValuesReuse", b.returnValuesReuse, i.returnValuesReuse);
+  }
+
+  static void appendSessionParameterScalarChanges(
+    MdSessionParameterPropertiesDto b,
+    MdSessionParameterPropertiesDto i,
+    List<MdObjectPropertiesLeafDiff.GranularPatchChange> out) {
+    MdPropertiesGranularChanges c = new MdPropertiesGranularChanges(out);
+    c.enumText("ObjectBelonging", b.objectBelonging, i.objectBelonging);
+  }
+
+  static void appendDocumentNumeratorScalarChanges(
+    MdDocumentNumeratorPropertiesDto b,
+    MdDocumentNumeratorPropertiesDto i,
+    List<MdObjectPropertiesLeafDiff.GranularPatchChange> out) {
+    MdPropertiesGranularChanges c = new MdPropertiesGranularChanges(out);
+    c.enumText("ObjectBelonging", b.objectBelonging, i.objectBelonging);
+    c.enumText("NumberType", b.numberType, i.numberType);
+    c.text("NumberLength", b.numberLength, i.numberLength);
+    c.enumText("NumberAllowedLength", b.numberAllowedLength, i.numberAllowedLength);
+    c.enumText("NumberPeriodicity", b.numberPeriodicity, i.numberPeriodicity);
+    c.bool("CheckUnique", b.checkUnique, i.checkUnique);
+  }
+
+  static void appendEventSubscriptionScalarChanges(
+    MdEventSubscriptionPropertiesDto b,
+    MdEventSubscriptionPropertiesDto i,
+    List<MdObjectPropertiesLeafDiff.GranularPatchChange> out) {
+    MdPropertiesGranularChanges c = new MdPropertiesGranularChanges(out);
+    c.enumText("ObjectBelonging", b.objectBelonging, i.objectBelonging);
+    c.text("Event", b.event, i.event);
+    c.text("Handler", b.handler, i.handler);
+  }
+
+  static void appendScheduledJobScalarChanges(
+    MdScheduledJobPropertiesDto b,
+    MdScheduledJobPropertiesDto i,
+    List<MdObjectPropertiesLeafDiff.GranularPatchChange> out) {
+    MdPropertiesGranularChanges c = new MdPropertiesGranularChanges(out);
+    c.enumText("ObjectBelonging", b.objectBelonging, i.objectBelonging);
+    c.text("MethodName", b.methodName, i.methodName);
+    c.text("Description", b.description, i.description);
+    c.text("Key", b.key, i.key);
+    c.text("Schedule", b.schedule, i.schedule);
+    c.bool("Use", b.use, i.use);
+    c.bool("Predefined", b.predefined, i.predefined);
+    c.text("RestartCountOnFailure", b.restartCountOnFailure, i.restartCountOnFailure);
+    c.text("RestartIntervalOnFailure", b.restartIntervalOnFailure, i.restartIntervalOnFailure);
+  }
+
+  static void appendCommonCommandScalarChanges(
+    MdCommonCommandPropertiesDto b,
+    MdCommonCommandPropertiesDto i,
+    List<MdObjectPropertiesLeafDiff.GranularPatchChange> out) {
+    MdPropertiesGranularChanges c = new MdPropertiesGranularChanges(out);
+    c.enumText("ObjectBelonging", b.objectBelonging, i.objectBelonging);
+    c.text("Group", b.group, i.group);
+    c.enumText("Representation", b.representation, i.representation);
+    c.localStringRu("ToolTip", b.toolTipRu, i.toolTipRu);
+    c.text("Shortcut", b.shortcut, i.shortcut);
+    c.text("CommandModule", b.commandModule, i.commandModule);
+    c.bool("IncludeHelpInContents", b.includeHelpInContents, i.includeHelpInContents);
+    c.enumText("ParameterUseMode", b.parameterUseMode, i.parameterUseMode);
+    c.bool("ModifiesData", b.modifiesData, i.modifiesData);
+    c.enumText("OnMainServerUnavalableBehavior", b.onMainServerUnavalableBehavior, i.onMainServerUnavalableBehavior);
+  }
+
+  static void appendCommonAttributeScalarChanges(
+    MdCommonAttributePropertiesDto b,
+    MdCommonAttributePropertiesDto i,
+    List<MdObjectPropertiesLeafDiff.GranularPatchChange> out) {
+    MdPropertiesGranularChanges c = new MdPropertiesGranularChanges(out);
+    c.enumText("ObjectBelonging", b.objectBelonging, i.objectBelonging);
+    c.enumText("AutoUse", b.autoUse, i.autoUse);
+    c.enumText("DataSeparation", b.dataSeparation, i.dataSeparation);
+    c.enumText("SeparatedDataUse", b.separatedDataUse, i.separatedDataUse);
+    c.text("DataSeparationValue", b.dataSeparationValue, i.dataSeparationValue);
+    c.text("DataSeparationUse", b.dataSeparationUse, i.dataSeparationUse);
+    c.text("ConditionalSeparation", b.conditionalSeparation, i.conditionalSeparation);
+    c.enumText("UsersSeparation", b.usersSeparation, i.usersSeparation);
+    c.enumText("AuthenticationSeparation", b.authenticationSeparation, i.authenticationSeparation);
+    c.enumText("ConfigurationExtensionsSeparation",
+      b.configurationExtensionsSeparation, i.configurationExtensionsSeparation);
+    c.enumText("Indexing", b.indexing, i.indexing);
+    c.enumText("FullTextSearch", b.fullTextSearch, i.fullTextSearch);
+    c.enumText("DataHistory", b.dataHistory, i.dataHistory);
+    c.localStringRu("ToolTip", b.toolTipRu, i.toolTipRu);
+    c.bool("PasswordMode", b.passwordMode, i.passwordMode);
+    c.bool("MultiLine", b.multiLine, i.multiLine);
+    c.text("Mask", b.mask, i.mask);
+    c.enumText("QuickChoice", b.quickChoice, i.quickChoice);
+    c.enumText("CreateOnInput", b.createOnInput, i.createOnInput);
+    c.enumText("ChoiceHistoryOnInput", b.choiceHistoryOnInput, i.choiceHistoryOnInput);
+    c.enumText("FillChecking", b.fillChecking, i.fillChecking);
+    c.text("ChoiceForm", b.choiceForm, i.choiceForm);
+  }
+
+  static void appendCommonPictureScalarChanges(
+    MdCommonPicturePropertiesDto b,
+    MdCommonPicturePropertiesDto i,
+    List<MdObjectPropertiesLeafDiff.GranularPatchChange> out) {
+    MdPropertiesGranularChanges c = new MdPropertiesGranularChanges(out);
+    c.enumText("ObjectBelonging", b.objectBelonging, i.objectBelonging);
+    c.bool("AvailabilityForChoice", b.availabilityForChoice, i.availabilityForChoice);
+    c.bool("AvailabilityForAppearance", b.availabilityForAppearance, i.availabilityForAppearance);
+  }
+
+  static void appendRoleScalarChanges(
+    MdRolePropertiesDto b,
+    MdRolePropertiesDto i,
+    List<MdObjectPropertiesLeafDiff.GranularPatchChange> out) {
+    MdPropertiesGranularChanges c = new MdPropertiesGranularChanges(out);
+    c.enumText("ObjectBelonging", b.objectBelonging, i.objectBelonging);
+  }
+
+  static void appendExternalDataSourceScalarChanges(
+    MdExternalDataSourcePropertiesDto b,
+    MdExternalDataSourcePropertiesDto i,
+    List<MdObjectPropertiesLeafDiff.GranularPatchChange> out) {
+    MdPropertiesGranularChanges c = new MdPropertiesGranularChanges(out);
+    c.enumText("ObjectBelonging", b.objectBelonging, i.objectBelonging);
+    c.enumText("DataLockControlMode", b.dataLockControlMode, i.dataLockControlMode);
   }
 }

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdTaskPropertiesBridge.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdTaskPropertiesBridge.java
@@ -1,0 +1,135 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+import io.github.yellowhammer.designerxml.SchemaVersion;
+import io.github.yellowhammer.designerxml.reflect.JaxbReflect;
+
+import static io.github.yellowhammer.designerxml.cf.MdPropertiesBridgeSupport.enumName;
+import static io.github.yellowhammer.designerxml.cf.MdPropertiesBridgeSupport.ensureAndSetRu;
+import static io.github.yellowhammer.designerxml.cf.MdPropertiesBridgeSupport.nullIfBlank;
+
+/**
+ * Чтение и запись {@code TaskProperties} через JAXB-рефлексию.
+ */
+public final class MdTaskPropertiesBridge {
+
+  private MdTaskPropertiesBridge() {
+  }
+
+  public static void read(SchemaVersion version, Object p, MdObjectPropertiesDto dto) {
+    MdTaskPropertiesDto d = new MdTaskPropertiesDto();
+    d.objectBelonging = enumName(p, "getObjectBelonging");
+    d.extendedConfigurationObject = nullIfBlank(JaxbReflect.getStringOptional(p, "getExtendedConfigurationObject"));
+    d.useStandardCommands = JaxbReflect.getBooleanOptional(p, "isUseStandardCommands");
+    d.objectModule = JaxbReflect.getStringOptional(p, "getObjectModule");
+    d.managerModule = JaxbReflect.getStringOptional(p, "getManagerModule");
+    d.numberType = enumName(p, "getNumberType");
+    d.numberLength = MdPropertiesBridgeSupport.decimalOrZero(p, "getNumberLength");
+    d.numberAllowedLength = enumName(p, "getNumberAllowedLength");
+    d.checkUnique = JaxbReflect.getBooleanOptional(p, "isCheckUnique");
+    d.autonumbering = JaxbReflect.getBooleanOptional(p, "isAutonumbering");
+    d.taskNumberAutoPrefix = enumName(p, "getTaskNumberAutoPrefix");
+    d.descriptionLength = MdPropertiesBridgeSupport.decimalOrZero(p, "getDescriptionLength");
+    d.addressing = JaxbReflect.getStringOptional(p, "getAddressing");
+    d.mainAddressingAttribute = JaxbReflect.getStringOptional(p, "getMainAddressingAttribute");
+    d.currentPerformer = JaxbReflect.getStringOptional(p, "getCurrentPerformer");
+    MdPropertiesBridgeSupport.addItems(d.basedOn, JaxbReflect.getOptional(p, "getBasedOn"));
+    d.standardAttributesXml = MdPropertiesBridgeSupport.marshalStandardAttributesOrEmpty(
+      version, JaxbReflect.getOptional(p, "getStandardAttributes"));
+    d.characteristicsXml = MdPropertiesBridgeSupport.marshalCharacteristicsOrEmpty(
+      version, JaxbReflect.getOptional(p, "getCharacteristics"));
+    d.defaultPresentation = enumName(p, "getDefaultPresentation");
+    d.editType = enumName(p, "getEditType");
+    MdPropertiesBridgeSupport.addFields(d.inputByString, JaxbReflect.getOptional(p, "getInputByString"));
+    d.searchStringModeOnInputByString = enumName(p, "getSearchStringModeOnInputByString");
+    d.fullTextSearchOnInputByString = enumName(p, "getFullTextSearchOnInputByString");
+    d.choiceDataGetModeOnInputByString = enumName(p, "getChoiceDataGetModeOnInputByString");
+    d.createOnInput = enumName(p, "getCreateOnInput");
+    d.defaultObjectForm = JaxbReflect.getStringOptional(p, "getDefaultObjectForm");
+    d.defaultListForm = JaxbReflect.getStringOptional(p, "getDefaultListForm");
+    d.defaultChoiceForm = JaxbReflect.getStringOptional(p, "getDefaultChoiceForm");
+    d.auxiliaryObjectForm = JaxbReflect.getStringOptional(p, "getAuxiliaryObjectForm");
+    d.auxiliaryListForm = JaxbReflect.getStringOptional(p, "getAuxiliaryListForm");
+    d.auxiliaryChoiceForm = JaxbReflect.getStringOptional(p, "getAuxiliaryChoiceForm");
+    d.choiceHistoryOnInput = enumName(p, "getChoiceHistoryOnInput");
+    d.includeHelpInContents = JaxbReflect.getBooleanOptional(p, "isIncludeHelpInContents");
+    MdPropertiesBridgeSupport.addFields(d.dataLockFields, JaxbReflect.getOptional(p, "getDataLockFields"));
+    d.dataLockControlMode = enumName(p, "getDataLockControlMode");
+    d.fullTextSearch = enumName(p, "getFullTextSearch");
+    d.objectPresentationRu = LocalStringSync.firstRu(JaxbReflect.getOptional(p, "getObjectPresentation"));
+    d.extendedObjectPresentationRu =
+      LocalStringSync.firstRu(JaxbReflect.getOptional(p, "getExtendedObjectPresentation"));
+    d.listPresentationRu = LocalStringSync.firstRu(JaxbReflect.getOptional(p, "getListPresentation"));
+    d.extendedListPresentationRu = LocalStringSync.firstRu(JaxbReflect.getOptional(p, "getExtendedListPresentation"));
+    d.explanationRu = LocalStringSync.firstRu(JaxbReflect.getOptional(p, "getExplanation"));
+    d.dataHistory = enumName(p, "getDataHistory");
+    d.updateDataHistoryImmediatelyAfterWrite =
+      JaxbReflect.getBooleanOptional(p, "isUpdateDataHistoryImmediatelyAfterWrite");
+    d.executeAfterWriteDataHistoryVersionProcessing =
+      JaxbReflect.getBooleanOptional(p, "isExecuteAfterWriteDataHistoryVersionProcessing");
+    d.additionalIndexes = JaxbReflect.getStringOptional(p, "getAdditionalIndexes");
+    dto.task = d;
+  }
+
+  public static void apply(SchemaVersion version, Object p, MdObjectPropertiesDto dto) {
+    MdTaskPropertiesDto d = dto.task;
+    if (d == null) {
+      throw new IllegalArgumentException("task required");
+    }
+    MdPropertiesBridgeSupport.applyCommon(p, dto);
+    JaxbReflect.setEnumOrKeep(p, "setObjectBelonging", d.objectBelonging);
+    JaxbReflect.setOptional(p, "setExtendedConfigurationObject", nullIfBlank(d.extendedConfigurationObject));
+    JaxbReflect.setOptional(p, "setUseStandardCommands", d.useStandardCommands);
+    JaxbReflect.setOptional(p, "setObjectModule", d.objectModule);
+    JaxbReflect.setOptional(p, "setManagerModule", d.managerModule);
+    JaxbReflect.setEnumOrKeep(p, "setNumberType", d.numberType);
+    MdPropertiesBridgeSupport.setDecimal(p, "setNumberLength", d.numberLength);
+    JaxbReflect.setEnumOrKeep(p, "setNumberAllowedLength", d.numberAllowedLength);
+    JaxbReflect.setOptional(p, "setCheckUnique", d.checkUnique);
+    JaxbReflect.setOptional(p, "setAutonumbering", d.autonumbering);
+    JaxbReflect.setEnumOrKeep(p, "setTaskNumberAutoPrefix", d.taskNumberAutoPrefix);
+    MdPropertiesBridgeSupport.setDecimal(p, "setDescriptionLength", d.descriptionLength);
+    JaxbReflect.setOptional(p, "setAddressing", d.addressing);
+    JaxbReflect.setOptional(p, "setMainAddressingAttribute", d.mainAddressingAttribute);
+    JaxbReflect.setOptional(p, "setCurrentPerformer", d.currentPerformer);
+    MdListTypeRefs.replaceItems(JaxbReflect.getOptional(p, "getBasedOn"), d.basedOn);
+    MdPropertiesBridgeSupport.applyStandardAttributes(version, p, d.standardAttributesXml);
+    MdPropertiesBridgeSupport.applyCharacteristics(version, p, d.characteristicsXml);
+    JaxbReflect.setEnumOrKeep(p, "setDefaultPresentation", d.defaultPresentation);
+    JaxbReflect.setEnumOrKeep(p, "setEditType", d.editType);
+    MdPropertiesBridgeSupport.setFields(JaxbReflect.getOptional(p, "getInputByString"), d.inputByString);
+    JaxbReflect.setEnumOrKeep(p, "setSearchStringModeOnInputByString", d.searchStringModeOnInputByString);
+    JaxbReflect.setEnumOrKeep(p, "setFullTextSearchOnInputByString", d.fullTextSearchOnInputByString);
+    JaxbReflect.setEnumOrKeep(p, "setChoiceDataGetModeOnInputByString", d.choiceDataGetModeOnInputByString);
+    JaxbReflect.setEnumOrKeep(p, "setCreateOnInput", d.createOnInput);
+    JaxbReflect.setOptional(p, "setDefaultObjectForm", d.defaultObjectForm);
+    JaxbReflect.setOptional(p, "setDefaultListForm", d.defaultListForm);
+    JaxbReflect.setOptional(p, "setDefaultChoiceForm", d.defaultChoiceForm);
+    JaxbReflect.setOptional(p, "setAuxiliaryObjectForm", d.auxiliaryObjectForm);
+    JaxbReflect.setOptional(p, "setAuxiliaryListForm", d.auxiliaryListForm);
+    JaxbReflect.setOptional(p, "setAuxiliaryChoiceForm", d.auxiliaryChoiceForm);
+    JaxbReflect.setEnumOrKeep(p, "setChoiceHistoryOnInput", d.choiceHistoryOnInput);
+    JaxbReflect.setOptional(p, "setIncludeHelpInContents", d.includeHelpInContents);
+    MdPropertiesBridgeSupport.setFields(JaxbReflect.getOptional(p, "getDataLockFields"), d.dataLockFields);
+    JaxbReflect.setEnumOrKeep(p, "setDataLockControlMode", d.dataLockControlMode);
+    JaxbReflect.setEnumOrKeep(p, "setFullTextSearch", d.fullTextSearch);
+    ensureAndSetRu(p, "getObjectPresentation", "setObjectPresentation", d.objectPresentationRu);
+    ensureAndSetRu(p, "getExtendedObjectPresentation", "setExtendedObjectPresentation",
+      d.extendedObjectPresentationRu);
+    ensureAndSetRu(p, "getListPresentation", "setListPresentation", d.listPresentationRu);
+    ensureAndSetRu(p, "getExtendedListPresentation", "setExtendedListPresentation", d.extendedListPresentationRu);
+    ensureAndSetRu(p, "getExplanation", "setExplanation", d.explanationRu);
+    JaxbReflect.setEnumOrKeep(p, "setDataHistory", d.dataHistory);
+    JaxbReflect.setOptional(p, "setUpdateDataHistoryImmediatelyAfterWrite", d.updateDataHistoryImmediatelyAfterWrite);
+    JaxbReflect.setOptional(p, "setExecuteAfterWriteDataHistoryVersionProcessing",
+      d.executeAfterWriteDataHistoryVersionProcessing);
+    JaxbReflect.setOptional(p, "setAdditionalIndexes", d.additionalIndexes);
+  }
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdTaskPropertiesDto.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdTaskPropertiesDto.java
@@ -1,0 +1,75 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Поля {@code TaskProperties} для {@code cf-md-object-get/set} ({@code kind=task}).
+ * Enum-значения — имена Java-констант ({@code STRING}, {@code BOTH_WAYS}).
+ */
+public final class MdTaskPropertiesDto {
+
+  public String objectBelonging;
+  public String extendedConfigurationObject;
+  public boolean useStandardCommands;
+  public String objectModule;
+  public String managerModule;
+  public String numberType;
+  public String numberLength;
+  public String numberAllowedLength;
+  public boolean checkUnique;
+  public boolean autonumbering;
+  /** Автопрефикс номера: не использовать либо по реквизиту адресации. */
+  public String taskNumberAutoPrefix;
+  public String descriptionLength;
+  /** Регистр сведений адресации ({@code InformationRegister.Имя}) либо пусто. */
+  public String addressing;
+  /** Основной реквизит адресации ({@code Task.Имя.AddressingAttribute.Имя}). */
+  public String mainAddressingAttribute;
+  /** Реквизит текущего исполнителя. */
+  public String currentPerformer;
+  public List<String> basedOn;
+  public String standardAttributesXml;
+  public String characteristicsXml;
+  public String defaultPresentation;
+  public String editType;
+  public List<String> inputByString;
+  public String searchStringModeOnInputByString;
+  public String fullTextSearchOnInputByString;
+  public String choiceDataGetModeOnInputByString;
+  public String createOnInput;
+  public String defaultObjectForm;
+  public String defaultListForm;
+  public String defaultChoiceForm;
+  public String auxiliaryObjectForm;
+  public String auxiliaryListForm;
+  public String auxiliaryChoiceForm;
+  public String choiceHistoryOnInput;
+  public boolean includeHelpInContents;
+  public List<String> dataLockFields;
+  public String dataLockControlMode;
+  public String fullTextSearch;
+  public String objectPresentationRu;
+  public String extendedObjectPresentationRu;
+  public String listPresentationRu;
+  public String extendedListPresentationRu;
+  public String explanationRu;
+  public String dataHistory;
+  public boolean updateDataHistoryImmediatelyAfterWrite;
+  public boolean executeAfterWriteDataHistoryVersionProcessing;
+  public String additionalIndexes;
+
+  public MdTaskPropertiesDto() {
+    this.basedOn = new ArrayList<>();
+    this.inputByString = new ArrayList<>();
+    this.dataLockFields = new ArrayList<>();
+  }
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cli/ApplyMutationCmd.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cli/ApplyMutationCmd.java
@@ -129,6 +129,20 @@ final class ApplyMutationCmd implements Callable<Integer> {
       case "cf-md-attribute-add":
         MdObjectChildMutations.addAttribute(p.reqPath(p.objectXml, "objectXml"), p.version(), p.req(p.name, "name"));
         return "OK";
+      case "cf-md-command-add":
+        MdObjectChildMutations.addCommand(p.reqPath(p.objectXml, "objectXml"), p.version(), p.req(p.name, "name"));
+        return "OK";
+      case "cf-md-command-rename":
+        MdObjectChildMutations.renameCommand(
+          p.reqPath(p.objectXml, "objectXml"), p.version(), p.req(p.oldName, "oldName"), p.req(p.newName, "newName"));
+        return "OK";
+      case "cf-md-command-delete":
+        MdObjectChildMutations.deleteCommand(p.reqPath(p.objectXml, "objectXml"), p.version(), p.req(p.name, "name"));
+        return "OK";
+      case "cf-md-command-reorder":
+        MdObjectChildMutations.reorderCommands(
+          p.reqPath(p.objectXml, "objectXml"), p.version(), parseNameList(p));
+        return "OK";
       case "cf-md-attribute-rename":
         MdObjectChildMutations.renameAttribute(
           p.reqPath(p.objectXml, "objectXml"), p.version(), p.req(p.oldName, "oldName"), p.req(p.newName, "newName"));

--- a/src/main/java/io/github/yellowhammer/designerxml/cli/CliParams.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cli/CliParams.java
@@ -113,7 +113,10 @@ final class CliParams {
     try {
       return SchemaVersion.valueOf(v);
     } catch (IllegalArgumentException e) {
-      throw new IllegalArgumentException("неизвестная версия схемы: " + v);
+      SchemaVersion[] all = SchemaVersion.values();
+      throw new IllegalArgumentException("формат выгрузки " + v.replaceFirst("^V", "").replace('_', '.')
+        + " не поддержан; поддержаны " + all[0].metadataObjectVersionAttribute()
+        + "-" + all[all.length - 1].metadataObjectVersionAttribute());
     }
   }
 }

--- a/src/main/java/io/github/yellowhammer/designerxml/cli/DesignerXmlCli.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cli/DesignerXmlCli.java
@@ -34,6 +34,7 @@ import io.github.yellowhammer.designerxml.cf.ConfigurationPropertiesDto;
 import io.github.yellowhammer.designerxml.cf.ConfigurationPropertiesEdit;
 import io.github.yellowhammer.designerxml.cf.MdObjectPropertiesDto;
 import io.github.yellowhammer.designerxml.cf.MdObjectPropertiesEdit;
+import io.github.yellowhammer.designerxml.cf.MdObjectPropertyEnums;
 import io.github.yellowhammer.designerxml.cf.MdObjectStructureDto;
 import io.github.yellowhammer.designerxml.cf.MdObjectStructureRead;
 import io.github.yellowhammer.designerxml.cf.ConfigurationCatalogLister;
@@ -64,7 +65,7 @@ import java.util.concurrent.Callable;
 @Command(
   name = "md-sparrow",
   mixinStandardHelpOptions = true,
-  version = "md-sparrow 0.2",
+  versionProvider = DesignerXmlCli.ManifestVersion.class,
   subcommands = {
     DesignerXmlCli.ValidateCmd.class,
     DesignerXmlCli.RoundTripCmd.class,
@@ -83,6 +84,7 @@ import java.util.concurrent.Callable;
     ExternalArtifactCommands.ExternalArtifactDeleteCmd.class,
     ExternalArtifactCommands.ExternalArtifactDuplicateCmd.class,
     DesignerXmlCli.CfMdObjectGetCmd.class,
+    DesignerXmlCli.CfMdObjectEnumsCmd.class,
     DesignerXmlCli.CfMdObjectStructureGetCmd.class,
     MdObjectMutationCommands.CfMdObjectSetCmd.class,
     MdObjectMutationCommands.CfMdAttributeAddCmd.class,
@@ -114,6 +116,19 @@ public final class DesignerXmlCli implements Callable<Integer> {
 
   /** Создаёт корневую команду для picocli. */
   public DesignerXmlCli() {
+  }
+
+  /**
+   * Версия для {@code --version} из манифеста jar: в коде её держать незачем, она бы отставала
+   * от сборки. Вне jar (запуск из классов) версия неизвестна.
+   */
+  static final class ManifestVersion implements CommandLine.IVersionProvider {
+
+    @Override
+    public String[] getVersion() {
+      String version = DesignerXmlCli.class.getPackage().getImplementationVersion();
+      return new String[] {"md-sparrow " + (version == null ? "dev" : version)};
+    }
   }
 
   @Override
@@ -407,6 +422,22 @@ public final class DesignerXmlCli implements Callable<Integer> {
         System.err.println(e.getMessage());
         return 2;
       }
+      return 0;
+    }
+  }
+
+  @Command(
+    name = "cf-md-object-enums",
+    description = "Вывести JSON допустимых значений перечислимых свойств объектов метаданных."
+  )
+  static final class CfMdObjectEnumsCmd implements Callable<Integer> {
+    @Option(names = {"-v", "--schema-version"}, required = true, description = "Версия формата, например V2_17 (V2_10…V2_21)")
+    SchemaVersion version;
+
+    @Override
+    public Integer call() {
+      Gson gson = new GsonBuilder().disableHtmlEscaping().create();
+      System.out.println(gson.toJson(MdObjectPropertyEnums.forVersion(version)));
       return 0;
     }
   }

--- a/src/main/java/io/github/yellowhammer/designerxml/cli/ReadJsonCmd.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cli/ReadJsonCmd.java
@@ -35,6 +35,7 @@ import io.github.yellowhammer.designerxml.cf.ExternalArtifactPropertiesDto;
 import io.github.yellowhammer.designerxml.cf.ExternalArtifactPropertiesEdit;
 import io.github.yellowhammer.designerxml.cf.MdObjectPropertiesDto;
 import io.github.yellowhammer.designerxml.cf.MdObjectPropertiesEdit;
+import io.github.yellowhammer.designerxml.cf.MdObjectPropertyEnums;
 import io.github.yellowhammer.designerxml.cf.MdObjectStructureDto;
 import io.github.yellowhammer.designerxml.cf.MdObjectStructureRead;
 import io.github.yellowhammer.designerxml.cf.ProjectMetadataGraphBuilder;
@@ -107,6 +108,9 @@ final class ReadJsonCmd implements Callable<Integer> {
       case "cf-md-object-get": {
         MdObjectPropertiesDto dto = MdObjectPropertiesEdit.readDto(p.reqPath(p.objectXml, "objectXml"), p.version());
         return gson.toJson(dto);
+      }
+      case "cf-md-object-enums": {
+        return gson.toJson(MdObjectPropertyEnums.forVersion(p.version()));
       }
       case "cf-md-object-structure-get": {
         MdObjectStructureDto dto = MdObjectStructureRead.read(p.reqPath(p.objectXml, "objectXml"), p.version());

--- a/src/main/java/io/github/yellowhammer/designerxml/reflect/JaxbReflect.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/reflect/JaxbReflect.java
@@ -251,7 +251,11 @@ public final class JaxbReflect {
     try {
       value = Enum.valueOf(pt.asSubclass(Enum.class), v);
     } catch (IllegalArgumentException e) {
-      return;
+      // Молча оставить прежнее значение нельзя: правка пользователя потерялась бы, а запись
+      // потом упала бы сверкой с невнятным «причина не определена».
+      throw new IllegalArgumentException(
+        setter.replaceFirst("^set", "") + ": недопустимое значение " + v
+          + "; допустимы " + java.util.Arrays.toString(pt.getEnumConstants()), e);
     }
     try {
       m.invoke(target, value);

--- a/src/test/java/io/github/yellowhammer/designerxml/Ssl31SubmodulePaths.java
+++ b/src/test/java/io/github/yellowhammer/designerxml/Ssl31SubmodulePaths.java
@@ -53,9 +53,63 @@ public final class Ssl31SubmodulePaths {
 
   /** Любой {@code Catalogs/*.xml} в submodule (для тестов, где нужен образец структуры). */
   public static Path anyCatalogObjectXml() throws IOException {
+    return anyObjectXml("Catalogs");
+  }
+
+  /** Любой {@code Reports/*.xml} в submodule. */
+  public static Path anyReportObjectXml() throws IOException {
+    return anyObjectXml("Reports");
+  }
+
+  /** Любой {@code DataProcessors/*.xml} в submodule. */
+  public static Path anyDataProcessorObjectXml() throws IOException {
+    return anyObjectXml("DataProcessors");
+  }
+
+  /** Любой {@code DocumentJournals/*.xml} в submodule. */
+  public static Path anyDocumentJournalObjectXml() throws IOException {
+    return anyObjectXml("DocumentJournals");
+  }
+
+  /** Любой {@code ExchangePlans/*.xml} в submodule. */
+  public static Path anyExchangePlanObjectXml() throws IOException {
+    return anyObjectXml("ExchangePlans");
+  }
+
+  /** Любой {@code ChartsOfCharacteristicTypes/*.xml} в submodule. */
+  public static Path anyChartOfCharacteristicTypesObjectXml() throws IOException {
+    return anyObjectXml("ChartsOfCharacteristicTypes");
+  }
+
+  /** Любой {@code Tasks/*.xml} в submodule. */
+  public static Path anyTaskObjectXml() throws IOException {
+    return anyObjectXml("Tasks");
+  }
+
+  /** Любой {@code BusinessProcesses/*.xml} в submodule. */
+  public static Path anyBusinessProcessObjectXml() throws IOException {
+    return anyObjectXml("BusinessProcesses");
+  }
+
+  /** Любой {@code ChartsOfAccounts/*.xml} в submodule. */
+  public static Path anyChartOfAccountsObjectXml() throws IOException {
+    return anyObjectXml("ChartsOfAccounts");
+  }
+
+  /** Любой {@code ChartsOfCalculationTypes/*.xml} в submodule. */
+  public static Path anyChartOfCalculationTypesObjectXml() throws IOException {
+    return anyObjectXml("ChartsOfCalculationTypes");
+  }
+
+  /** Любой {@code src/cf/<подкаталог>/*.xml} в submodule: для видов без своего помощника. */
+  public static Path anyObjectXmlInCfSubdir(String subdir) throws IOException {
+    return anyObjectXml(subdir);
+  }
+
+  private static Path anyObjectXml(String subdir) throws IOException {
     String root = System.getProperty("fixtures.ssl31.root");
     assertThat(root).isNotBlank();
-    Path dir = Path.of(root, "src", "cf", "Catalogs");
+    Path dir = Path.of(root, "src", "cf", subdir);
     assertThat(dir).exists();
     try (Stream<Path> s = Files.list(dir)) {
       Path found = s
@@ -64,7 +118,7 @@ public final class Ssl31SubmodulePaths {
         .sorted()
         .findFirst()
         .orElse(null);
-      assertThat(found).as("catalog xml under %s", dir).isNotNull();
+      assertThat(found).as("object xml under %s", dir).isNotNull();
       return found;
     }
   }

--- a/src/test/java/io/github/yellowhammer/designerxml/cf/ConfigurationCatalogListerTest.java
+++ b/src/test/java/io/github/yellowhammer/designerxml/cf/ConfigurationCatalogListerTest.java
@@ -17,6 +17,7 @@ import java.nio.file.Path;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class ConfigurationCatalogListerTest {
 
@@ -31,6 +32,27 @@ class ConfigurationCatalogListerTest {
   @Test
   void toJsonArray_empty() {
     assertThat(ConfigurationCatalogLister.toJsonArray(List.of())).isEqualTo("[]");
+  }
+
+  @Test
+  void listNames_supportsAnyTagOfTheFormat() throws Exception {
+    Path cfg = Ssl31SubmodulePaths.configurationXml();
+    // теги берутся из модели формата, а не из зашитого списка: раньше состав вроде
+    // SettingsStorage отвергался как неизвестный
+    for (String tag : List.of("Catalog", "SettingsStorage", "DocumentJournal", "BusinessProcess", "WebService")) {
+      assertThat(ConfigurationChildObjectLister.listNames(cfg, SchemaVersion.V2_20, tag))
+        .as("состав по тегу %s", tag)
+        .isNotNull();
+    }
+  }
+
+  @Test
+  void listNames_unknownTag_reportsFormat() throws Exception {
+    Path cfg = Ssl31SubmodulePaths.configurationXml();
+    assertThatThrownBy(() -> ConfigurationChildObjectLister.listNames(cfg, SchemaVersion.V2_20, "ТегКоторогоНет"))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("2.20")
+      .hasMessageContaining("ТегКоторогоНет");
   }
 
   @Test

--- a/src/test/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesEditTest.java
+++ b/src/test/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesEditTest.java
@@ -293,6 +293,434 @@ class MdObjectPropertiesEditTest {
   }
 
   @Test
+  void readDto_report_fillsReportProperties() throws Exception {
+    Path any = Ssl31SubmodulePaths.anyReportObjectXml();
+    MdObjectPropertiesDto dto = MdObjectPropertiesEdit.readDto(any, SchemaVersion.V2_20);
+    assertThat(dto.kind).isEqualTo("report");
+    assertThat(dto.report).isNotNull();
+    // ObjectBelonging пишется только в расширениях, у объекта конфигурации его нет
+    assertThat(dto.report.defaultForm).isNotBlank();
+    assertThat(dto.report.mainDataCompositionSchema).startsWith("Report.");
+  }
+
+  @Test
+  void readDto_dataProcessor_fillsReportProperties_withoutReportOnlyFields() throws Exception {
+    Path any = Ssl31SubmodulePaths.anyDataProcessorObjectXml();
+    MdObjectPropertiesDto dto = MdObjectPropertiesEdit.readDto(any, SchemaVersion.V2_20);
+    assertThat(dto.kind).isEqualTo("dataProcessor");
+    assertThat(dto.report).isNotNull();
+    // схемы компоновки и хранилищ у обработки нет
+    assertThat(dto.report.mainDataCompositionSchema).isNull();
+    assertThat(dto.report.variantsStorage).isNull();
+  }
+
+  @Test
+  void writeDto_roundTrip_report_keepsProperties() throws Exception {
+    assertReportKindRoundTrip(Ssl31SubmodulePaths.anyReportObjectXml());
+  }
+
+  @Test
+  void writeDto_roundTrip_dataProcessor_keepsProperties() throws Exception {
+    assertReportKindRoundTrip(Ssl31SubmodulePaths.anyDataProcessorObjectXml());
+  }
+
+  @Test
+  void writeDto_report_onlyKindScalarChanged_isNotSkippedAsEqual() throws Exception {
+    // равенство DTO решает, писать ли файл: без учёта блока вида правка одного
+    // свойства отчёта молча терялась
+    Path src = Ssl31SubmodulePaths.anyReportObjectXml();
+    Path copy = tempDir.resolve(src.getFileName());
+    Files.copy(src, copy);
+
+    MdObjectPropertiesDto dto = MdObjectPropertiesEdit.readDto(copy, SchemaVersion.V2_20);
+    boolean expected = !dto.report.useStandardCommands;
+    dto.report.useStandardCommands = expected;
+    MdObjectPropertiesEdit.writeDto(copy, SchemaVersion.V2_20, dto);
+
+    MdObjectPropertiesDto after = MdObjectPropertiesEdit.readDto(copy, SchemaVersion.V2_20);
+    assertThat(after.report.useStandardCommands).isEqualTo(expected);
+  }
+
+  @Test
+  void writeDto_attributeSynonymChanged_keepsXmlIntact() throws Exception {
+    // правка синонима реквизита попадала в список изменений дважды: вторая правка резала уже
+    // изменённый XML по старым смещениям и рвала закрывающий тег
+    Path src = Ssl31SubmodulePaths.anyChartOfAccountsObjectXml();
+    Path copy = tempDir.resolve(src.getFileName());
+    Files.copy(src, copy);
+
+    MdObjectPropertiesDto dto = MdObjectPropertiesEdit.readDto(copy, SchemaVersion.V2_20);
+    String changed = dto.attributes.getFirst().synonymRu + " (изменён)";
+    dto.attributes.getFirst().synonymRu = changed;
+    MdObjectPropertiesEdit.writeDto(copy, SchemaVersion.V2_20, dto);
+
+    String xml = Files.readString(copy, StandardCharsets.UTF_8);
+    assertThat(xml).doesNotContain("</Synonym>nym");
+    assertThat(MdObjectPropertiesEdit.readDto(copy, SchemaVersion.V2_20).attributes.getFirst().synonymRu)
+      .isEqualTo(changed);
+  }
+
+  @Test
+  void readWriteDto_sessionParameter_roundTripsScalars() throws Exception {
+    Path copy = copyAnyObject("SessionParameters");
+
+    MdObjectPropertiesDto dto = MdObjectPropertiesEdit.readDto(copy, SchemaVersion.V2_20);
+    assertThat(dto.sessionParameter).as("блок параметра сеанса").isNotNull();
+    dto.comment = "Комментарий из теста";
+    MdObjectPropertiesEdit.writeDto(copy, SchemaVersion.V2_20, dto);
+
+    assertThat(MdObjectPropertiesEdit.readDto(copy, SchemaVersion.V2_20).comment).isEqualTo("Комментарий из теста");
+  }
+
+  @Test
+  void writeDto_scheduledJob_changedScalarIsWritten() throws Exception {
+    Path copy = copyAnyObject("ScheduledJobs");
+
+    MdObjectPropertiesDto dto = MdObjectPropertiesEdit.readDto(copy, SchemaVersion.V2_20);
+    assertThat(dto.scheduledJob).as("блок регламентного задания").isNotNull();
+    boolean expected = !dto.scheduledJob.use;
+    dto.scheduledJob.use = expected;
+    dto.scheduledJob.key = "КлючИзТеста";
+    MdObjectPropertiesEdit.writeDto(copy, SchemaVersion.V2_20, dto);
+
+    MdObjectPropertiesDto after = MdObjectPropertiesEdit.readDto(copy, SchemaVersion.V2_20);
+    assertThat(after.scheduledJob.use).isEqualTo(expected);
+    assertThat(after.scheduledJob.key).isEqualTo("КлючИзТеста");
+  }
+
+  @Test
+  void writeDto_commonCommand_changedScalarIsWritten() throws Exception {
+    Path copy = copyAnyObject("CommonCommands");
+
+    MdObjectPropertiesDto dto = MdObjectPropertiesEdit.readDto(copy, SchemaVersion.V2_20);
+    assertThat(dto.commonCommand).as("блок общей команды").isNotNull();
+    boolean expected = !dto.commonCommand.modifiesData;
+    dto.commonCommand.modifiesData = expected;
+    MdObjectPropertiesEdit.writeDto(copy, SchemaVersion.V2_20, dto);
+
+    assertThat(MdObjectPropertiesEdit.readDto(copy, SchemaVersion.V2_20).commonCommand.modifiesData)
+      .isEqualTo(expected);
+  }
+
+  @Test
+  void writeDto_eventSubscription_changedHandlerIsWritten() throws Exception {
+    Path copy = copyAnyObject("EventSubscriptions");
+
+    MdObjectPropertiesDto dto = MdObjectPropertiesEdit.readDto(copy, SchemaVersion.V2_20);
+    assertThat(dto.eventSubscription).as("блок подписки на событие").isNotNull();
+    dto.eventSubscription.handler = "ОбщийМодуль.Тест.Обработчик";
+    MdObjectPropertiesEdit.writeDto(copy, SchemaVersion.V2_20, dto);
+
+    assertThat(MdObjectPropertiesEdit.readDto(copy, SchemaVersion.V2_20).eventSubscription.handler)
+      .isEqualTo("ОбщийМодуль.Тест.Обработчик");
+  }
+
+  @Test
+  void writeDto_commonAttribute_changedSeparationIsWritten() throws Exception {
+    Path copy = copyAnyObject("CommonAttributes");
+
+    MdObjectPropertiesDto dto = MdObjectPropertiesEdit.readDto(copy, SchemaVersion.V2_20);
+    assertThat(dto.commonAttribute).as("блок общего реквизита").isNotNull();
+    dto.comment = "Комментарий из теста";
+    MdObjectPropertiesEdit.writeDto(copy, SchemaVersion.V2_20, dto);
+
+    MdObjectPropertiesDto after = MdObjectPropertiesEdit.readDto(copy, SchemaVersion.V2_20);
+    assertThat(after.comment).isEqualTo("Комментарий из теста");
+    assertThat(after.commonAttribute.dataSeparation).isEqualTo(dto.commonAttribute.dataSeparation);
+  }
+
+  @Test
+  void writeDto_role_keepsRightsFile() throws Exception {
+    Path copy = copyAnyObject("Roles");
+
+    MdObjectPropertiesDto dto = MdObjectPropertiesEdit.readDto(copy, SchemaVersion.V2_20);
+    assertThat(dto.role).as("блок роли").isNotNull();
+    dto.synonymRu = "Роль из теста";
+    MdObjectPropertiesEdit.writeDto(copy, SchemaVersion.V2_20, dto);
+
+    assertThat(MdObjectPropertiesEdit.readDto(copy, SchemaVersion.V2_20).synonymRu).isEqualTo("Роль из теста");
+  }
+
+  /** Копия произвольного объекта выгрузки ssl31 из подкаталога вида. */
+  private Path copyAnyObject(String subdir) throws Exception {
+    Path src = Ssl31SubmodulePaths.anyObjectXmlInCfSubdir(subdir);
+    Path copy = tempDir.resolve(src.getFileName());
+    Files.copy(src, copy);
+    return copy;
+  }
+
+  @Test
+  void writeDto_report_changedScalars_areWritten() throws Exception {
+    Path src = Ssl31SubmodulePaths.anyReportObjectXml();
+    Path copy = tempDir.resolve(src.getFileName());
+    Files.copy(src, copy);
+
+    MdObjectPropertiesDto dto = MdObjectPropertiesEdit.readDto(copy, SchemaVersion.V2_20);
+    dto.synonymRu = "[report-test] " + (dto.synonymRu == null ? "" : dto.synonymRu);
+    dto.report.useStandardCommands = !dto.report.useStandardCommands;
+    dto.report.includeHelpInContents = !dto.report.includeHelpInContents;
+    dto.report.explanationRu = "[report-test] пояснение";
+    MdObjectPropertiesEdit.writeDto(copy, SchemaVersion.V2_20, dto);
+
+    MdObjectPropertiesDto after = MdObjectPropertiesEdit.readDto(copy, SchemaVersion.V2_20);
+    assertThat(after.synonymRu).isEqualTo(dto.synonymRu);
+    assertThat(after.report.useStandardCommands).isEqualTo(dto.report.useStandardCommands);
+    assertThat(after.report.includeHelpInContents).isEqualTo(dto.report.includeHelpInContents);
+    assertThat(after.report.explanationRu).isEqualTo("[report-test] пояснение");
+  }
+
+  @Test
+  void readDto_chartOfCalculationTypes_fillsDependence() throws Exception {
+    Path any = Ssl31SubmodulePaths.anyChartOfCalculationTypesObjectXml();
+    MdObjectPropertiesDto dto = MdObjectPropertiesEdit.readDto(any, SchemaVersion.V2_20);
+    assertThat(dto.kind).isEqualTo("chartOfCalculationTypes");
+    assertThat(dto.chartOfCalculationTypes).isNotNull();
+    assertThat(dto.chartOfCalculationTypes.dependenceOnCalculationTypes).isNotBlank();
+  }
+
+  @Test
+  void writeDto_chartOfCalculationTypes_baseTypesAreWritten() throws Exception {
+    Path src = Ssl31SubmodulePaths.anyChartOfCalculationTypesObjectXml();
+    Path copy = tempDir.resolve(src.getFileName());
+    Files.copy(src, copy);
+
+    MdObjectPropertiesDto dto = MdObjectPropertiesEdit.readDto(copy, SchemaVersion.V2_20);
+    boolean expected = !dto.chartOfCalculationTypes.actionPeriodUse;
+    dto.chartOfCalculationTypes.actionPeriodUse = expected;
+    dto.chartOfCalculationTypes.descriptionLength = "80";
+    MdObjectPropertiesEdit.writeDto(copy, SchemaVersion.V2_20, dto);
+
+    MdObjectPropertiesDto after = MdObjectPropertiesEdit.readDto(copy, SchemaVersion.V2_20);
+    assertThat(after.chartOfCalculationTypes.actionPeriodUse).isEqualTo(expected);
+    assertThat(after.chartOfCalculationTypes.descriptionLength).isEqualTo("80");
+    assertThat(after.chartOfCalculationTypes.baseCalculationTypes)
+      .isEqualTo(dto.chartOfCalculationTypes.baseCalculationTypes);
+  }
+
+  @Test
+  void readDto_chartOfAccounts_fillsExtDimensions() throws Exception {
+    Path any = Ssl31SubmodulePaths.anyChartOfAccountsObjectXml();
+    MdObjectPropertiesDto dto = MdObjectPropertiesEdit.readDto(any, SchemaVersion.V2_20);
+    assertThat(dto.kind).isEqualTo("chartOfAccounts");
+    assertThat(dto.chartOfAccounts).isNotNull();
+    assertThat(dto.chartOfAccounts.maxExtDimensionCount).isNotBlank();
+    assertThat(dto.attributes).isNotNull();
+  }
+
+  @Test
+  void writeDto_chartOfAccounts_scalarChange_isWritten() throws Exception {
+    Path src = Ssl31SubmodulePaths.anyChartOfAccountsObjectXml();
+    Path copy = tempDir.resolve(src.getFileName());
+    Files.copy(src, copy);
+
+    MdObjectPropertiesDto dto = MdObjectPropertiesEdit.readDto(copy, SchemaVersion.V2_20);
+    dto.chartOfAccounts.maxExtDimensionCount = "5";
+    dto.chartOfAccounts.codeMask = "@@.@@";
+    MdObjectPropertiesEdit.writeDto(copy, SchemaVersion.V2_20, dto);
+
+    MdObjectPropertiesDto after = MdObjectPropertiesEdit.readDto(copy, SchemaVersion.V2_20);
+    assertThat(after.chartOfAccounts.maxExtDimensionCount).isEqualTo("5");
+    assertThat(after.chartOfAccounts.codeMask).isEqualTo("@@.@@");
+  }
+
+  @Test
+  void readDto_businessProcess_fillsTaskAndFlowchart() throws Exception {
+    Path any = Ssl31SubmodulePaths.anyBusinessProcessObjectXml();
+    MdObjectPropertiesDto dto = MdObjectPropertiesEdit.readDto(any, SchemaVersion.V2_20);
+    assertThat(dto.kind).isEqualTo("businessProcess");
+    assertThat(dto.businessProcess).isNotNull();
+    assertThat(dto.businessProcess.task).startsWith("Task.");
+    assertThat(dto.businessProcess.numberLength).isNotBlank();
+  }
+
+  @Test
+  void writeDto_businessProcess_scalarChange_isWritten() throws Exception {
+    Path src = Ssl31SubmodulePaths.anyBusinessProcessObjectXml();
+    Path copy = tempDir.resolve(src.getFileName());
+    Files.copy(src, copy);
+
+    MdObjectPropertiesDto dto = MdObjectPropertiesEdit.readDto(copy, SchemaVersion.V2_20);
+    boolean expected = !dto.businessProcess.createTaskInPrivilegedMode;
+    dto.businessProcess.createTaskInPrivilegedMode = expected;
+    MdObjectPropertiesEdit.writeDto(copy, SchemaVersion.V2_20, dto);
+
+    MdObjectPropertiesDto after = MdObjectPropertiesEdit.readDto(copy, SchemaVersion.V2_20);
+    assertThat(after.businessProcess.createTaskInPrivilegedMode).isEqualTo(expected);
+    assertThat(after.businessProcess.task).isEqualTo(dto.businessProcess.task);
+  }
+
+  @Test
+  void readDto_task_fillsAddressingProperties() throws Exception {
+    Path any = Ssl31SubmodulePaths.anyTaskObjectXml();
+    MdObjectPropertiesDto dto = MdObjectPropertiesEdit.readDto(any, SchemaVersion.V2_20);
+    assertThat(dto.kind).isEqualTo("task");
+    assertThat(dto.task).isNotNull();
+    assertThat(dto.task.numberLength).isNotBlank();
+    assertThat(dto.attributes).isNotNull();
+  }
+
+  @Test
+  void writeDto_task_scalarChange_isWritten() throws Exception {
+    Path src = Ssl31SubmodulePaths.anyTaskObjectXml();
+    Path copy = tempDir.resolve(src.getFileName());
+    Files.copy(src, copy);
+
+    MdObjectPropertiesDto dto = MdObjectPropertiesEdit.readDto(copy, SchemaVersion.V2_20);
+    boolean expected = !dto.task.checkUnique;
+    dto.task.checkUnique = expected;
+    dto.task.descriptionLength = "120";
+    MdObjectPropertiesEdit.writeDto(copy, SchemaVersion.V2_20, dto);
+
+    MdObjectPropertiesDto after = MdObjectPropertiesEdit.readDto(copy, SchemaVersion.V2_20);
+    assertThat(after.task.checkUnique).isEqualTo(expected);
+    assertThat(after.task.descriptionLength).isEqualTo("120");
+  }
+
+  @Test
+  void readDto_chartOfCharacteristicTypes_fillsTypeAndChildren() throws Exception {
+    Path any = Ssl31SubmodulePaths.anyChartOfCharacteristicTypesObjectXml();
+    MdObjectPropertiesDto dto = MdObjectPropertiesEdit.readDto(any, SchemaVersion.V2_20);
+    assertThat(dto.kind).isEqualTo("chartOfCharacteristicTypes");
+    assertThat(dto.chartOfCharacteristicTypes).isNotNull();
+    assertThat(dto.chartOfCharacteristicTypes.type).isNotNull();
+    assertThat(dto.chartOfCharacteristicTypes.codeLength).isNotBlank();
+    assertThat(dto.attributes).isNotNull();
+  }
+
+  @Test
+  void writeDto_chartOfCharacteristicTypes_scalarChange_isWritten() throws Exception {
+    Path src = Ssl31SubmodulePaths.anyChartOfCharacteristicTypesObjectXml();
+    Path copy = tempDir.resolve(src.getFileName());
+    Files.copy(src, copy);
+
+    MdObjectPropertiesDto dto = MdObjectPropertiesEdit.readDto(copy, SchemaVersion.V2_20);
+    boolean expected = !dto.chartOfCharacteristicTypes.foldersOnTop;
+    dto.chartOfCharacteristicTypes.foldersOnTop = expected;
+    dto.chartOfCharacteristicTypes.descriptionLength = "150";
+    MdObjectPropertiesEdit.writeDto(copy, SchemaVersion.V2_20, dto);
+
+    MdObjectPropertiesDto after = MdObjectPropertiesEdit.readDto(copy, SchemaVersion.V2_20);
+    assertThat(after.chartOfCharacteristicTypes.foldersOnTop).isEqualTo(expected);
+    assertThat(after.chartOfCharacteristicTypes.descriptionLength).isEqualTo("150");
+    assertThat(after.attributes.size()).isEqualTo(dto.attributes.size());
+  }
+
+  @Test
+  void readDto_exchangePlan_fillsProperties() throws Exception {
+    Path any = Ssl31SubmodulePaths.anyExchangePlanObjectXml();
+    MdObjectPropertiesDto dto = MdObjectPropertiesEdit.readDto(any, SchemaVersion.V2_20);
+    assertThat(dto.kind).isEqualTo("exchangePlan");
+    assertThat(dto.exchangePlan).isNotNull();
+    assertThat(dto.exchangePlan.codeLength).isNotBlank();
+    assertThat(dto.exchangePlan.standardAttributesXml).isNotNull();
+    assertThat(dto.attributes).isNotNull();
+  }
+
+  @Test
+  void writeDto_exchangePlan_onlyKindScalarChanged_isWritten() throws Exception {
+    Path src = Ssl31SubmodulePaths.anyExchangePlanObjectXml();
+    Path copy = tempDir.resolve(src.getFileName());
+    Files.copy(src, copy);
+
+    MdObjectPropertiesDto dto = MdObjectPropertiesEdit.readDto(copy, SchemaVersion.V2_20);
+    boolean expected = !dto.exchangePlan.distributedInfoBase;
+    dto.exchangePlan.distributedInfoBase = expected;
+    dto.exchangePlan.descriptionLength = "50";
+    MdObjectPropertiesEdit.writeDto(copy, SchemaVersion.V2_20, dto);
+
+    MdObjectPropertiesDto after = MdObjectPropertiesEdit.readDto(copy, SchemaVersion.V2_20);
+    assertThat(after.exchangePlan.distributedInfoBase).isEqualTo(expected);
+    assertThat(after.exchangePlan.descriptionLength).isEqualTo("50");
+    assertThat(after.attributes.size()).isEqualTo(dto.attributes.size());
+  }
+
+  @Test
+  void readDto_documentJournal_readsRegisteredDocuments() throws Exception {
+    Path any = Ssl31SubmodulePaths.anyDocumentJournalObjectXml();
+    MdObjectPropertiesDto dto = MdObjectPropertiesEdit.readDto(any, SchemaVersion.V2_20);
+    assertThat(dto.kind).isEqualTo("documentJournal");
+    assertThat(dto.documentJournal).isNotNull();
+    assertThat(dto.documentJournal.registeredDocuments).isNotEmpty();
+    assertThat(dto.documentJournal.registeredDocuments.get(0)).startsWith("Document.");
+  }
+
+  @Test
+  void writeDto_documentJournal_registeredDocumentsAreWritten() throws Exception {
+    Path src = Ssl31SubmodulePaths.anyDocumentJournalObjectXml();
+    Path copy = tempDir.resolve(src.getFileName());
+    Files.copy(src, copy);
+
+    MdObjectPropertiesDto dto = MdObjectPropertiesEdit.readDto(copy, SchemaVersion.V2_20);
+    String removed = dto.documentJournal.registeredDocuments.remove(0);
+    MdObjectPropertiesEdit.writeDto(copy, SchemaVersion.V2_20, dto);
+
+    MdObjectPropertiesDto after = MdObjectPropertiesEdit.readDto(copy, SchemaVersion.V2_20);
+    assertThat(after.documentJournal.registeredDocuments).doesNotContain(removed);
+    assertThat(after.documentJournal.registeredDocuments)
+      .isEqualTo(dto.documentJournal.registeredDocuments);
+  }
+
+  @Test
+  void granularPatch_documentJournalRegisteredDocuments_touchOnlyThatElement() throws Exception {
+    Path src = Ssl31SubmodulePaths.anyDocumentJournalObjectXml();
+    String xmlBefore = Files.readString(src, StandardCharsets.UTF_8);
+    MdObjectPropertiesDto b = MdObjectPropertiesEdit.readDto(src, SchemaVersion.V2_20);
+    MdObjectPropertiesDto i = MdObjectPropertiesEdit.readDto(src, SchemaVersion.V2_20);
+    i.documentJournal.registeredDocuments.remove(0);
+
+    MdObjectXmlRegions.Region region =
+      MdObjectXmlRegions.findDirectChildOfPropertiesRegion(xmlBefore, "DocumentJournal", "RegisteredDocuments");
+    assertThat(region.isValid()).isTrue();
+
+    Optional<byte[]> g =
+      MdObjectPropertiesGranularPatch.tryApply(xmlBefore, "DocumentJournal", SchemaVersion.V2_20, b, i);
+    assertThat(g).isPresent();
+    String xmlAfter = new String(g.get(), StandardCharsets.UTF_8);
+    int delta = xmlAfter.length() - xmlBefore.length();
+    assertThat(xmlAfter.substring(0, region.start())).isEqualTo(xmlBefore.substring(0, region.start()));
+    assertThat(xmlAfter.substring(region.end() + delta)).isEqualTo(xmlBefore.substring(region.end()));
+  }
+
+  @Test
+  void granularPatch_reportScalarChange_touchesOnlyThatElement() throws Exception {
+    Path src = Ssl31SubmodulePaths.anyReportObjectXml();
+    String xmlBefore = Files.readString(src, StandardCharsets.UTF_8);
+    MdObjectPropertiesDto b = MdObjectPropertiesEdit.readDto(src, SchemaVersion.V2_20);
+    MdObjectPropertiesDto i = MdObjectPropertiesEdit.readDto(src, SchemaVersion.V2_20);
+    i.report.defaultForm = "CommonForm.ДругаяФормаОтчета";
+
+    MdObjectXmlRegions.Region region =
+      MdObjectXmlRegions.findDirectChildOfPropertiesRegion(xmlBefore, "Report", "DefaultForm");
+    assertThat(region.isValid()).isTrue();
+
+    Optional<byte[]> g = MdObjectPropertiesGranularPatch.tryApply(xmlBefore, "Report", SchemaVersion.V2_20, b, i);
+    assertThat(g).isPresent();
+    String xmlAfter = new String(g.get(), StandardCharsets.UTF_8);
+    int delta = xmlAfter.length() - xmlBefore.length();
+    // всё вне изменённого элемента должно остаться байт в байт
+    assertThat(xmlAfter.substring(0, region.start())).isEqualTo(xmlBefore.substring(0, region.start()));
+    assertThat(xmlAfter.substring(region.end() + delta)).isEqualTo(xmlBefore.substring(region.end()));
+    assertThat(xmlAfter).contains("<DefaultForm>CommonForm.ДругаяФормаОтчета</DefaultForm>");
+  }
+
+  private void assertReportKindRoundTrip(Path src) throws Exception {
+    Path copy = tempDir.resolve(src.getFileName());
+    Files.copy(src, copy);
+
+    MdObjectPropertiesDto before = MdObjectPropertiesEdit.readDto(copy, SchemaVersion.V2_20);
+    MdObjectPropertiesEdit.writeDto(copy, SchemaVersion.V2_20, before);
+    MdObjectPropertiesDto after = MdObjectPropertiesEdit.readDto(copy, SchemaVersion.V2_20);
+
+    assertThat(after.kind).isEqualTo(before.kind);
+    assertThat(after.internalName).isEqualTo(before.internalName);
+    assertThat(after.report.defaultForm).isEqualTo(before.report.defaultForm);
+    assertThat(after.report.objectModule).isEqualTo(before.report.objectModule);
+    assertThat(after.report.managerModule).isEqualTo(before.report.managerModule);
+    assertThat(after.report.mainDataCompositionSchema).isEqualTo(before.report.mainDataCompositionSchema);
+    assertThat(after.report.extendedPresentationRu).isEqualTo(before.report.extendedPresentationRu);
+  }
+
+  @Test
   void trySplice_emptySource_returnsEmpty_soCallerFallsBackToFullWrite() throws Exception {
     Path src = Ssl31SubmodulePaths.anyCatalogObjectXml();
     MdObjectPropertiesDto baseline = MdObjectPropertiesEdit.readDto(src, SchemaVersion.V2_20);

--- a/src/test/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesVersionsTest.java
+++ b/src/test/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesVersionsTest.java
@@ -1,0 +1,94 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+import io.github.yellowhammer.designerxml.SchemaVersion;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Типизированные свойства читаются и пишутся во ВСЕХ форматах выгрузки, а не только в текущем:
+ * объект берётся из эталона нужного формата, а мосты работают JAXB-рефлексией по модели версии.
+ */
+class MdObjectPropertiesVersionsTest {
+
+  @TempDir
+  Path tempDir;
+
+  @ParameterizedTest
+  @EnumSource(SchemaVersion.class)
+  void reportAndDataProcessor_roundTripInEveryFormat(SchemaVersion version) throws Exception {
+    MdObjectPropertiesDto report = roundTrip(MdObjectAddType.REPORT, version);
+    assertThat(report.report).as("блок отчёта в формате %s", version).isNotNull();
+
+    MdObjectPropertiesDto processor = roundTrip(MdObjectAddType.DATA_PROCESSOR, version);
+    assertThat(processor.report).as("блок обработки в формате %s", version).isNotNull();
+    assertThat(processor.report.mainDataCompositionSchema).isNull();
+  }
+
+  @ParameterizedTest
+  @EnumSource(SchemaVersion.class)
+  void exchangePlanAndCharts_roundTripInEveryFormat(SchemaVersion version) throws Exception {
+    assertThat(roundTrip(MdObjectAddType.EXCHANGE_PLAN, version).exchangePlan).isNotNull();
+    assertThat(roundTrip(MdObjectAddType.CHART_OF_CHARACTERISTIC_TYPES, version).chartOfCharacteristicTypes)
+      .isNotNull();
+    assertThat(roundTrip(MdObjectAddType.CHART_OF_ACCOUNTS, version).chartOfAccounts).isNotNull();
+    assertThat(roundTrip(MdObjectAddType.CHART_OF_CALCULATION_TYPES, version).chartOfCalculationTypes).isNotNull();
+  }
+
+  @ParameterizedTest
+  @EnumSource(SchemaVersion.class)
+  void task_roundTripInEveryFormat(SchemaVersion version) throws Exception {
+    MdObjectPropertiesDto dto = roundTrip(MdObjectAddType.TASK, version);
+    assertThat(dto.task).as("блок задачи в формате %s", version).isNotNull();
+    assertThat(dto.task.numberLength).isNotBlank();
+  }
+
+  @ParameterizedTest
+  @EnumSource(SchemaVersion.class)
+  void changedScalar_isWrittenInEveryFormat(SchemaVersion version) throws Exception {
+    Path objectXml = writeGolden(MdObjectAddType.REPORT, version, "ОтчетВерсия");
+    MdObjectPropertiesDto dto = MdObjectPropertiesEdit.readDto(objectXml, version);
+    boolean expected = !dto.report.useStandardCommands;
+    dto.report.useStandardCommands = expected;
+    dto.synonymRu = "Отчёт формата " + version.metadataObjectVersionAttribute();
+    MdObjectPropertiesEdit.writeDto(objectXml, version, dto);
+
+    MdObjectPropertiesDto after = MdObjectPropertiesEdit.readDto(objectXml, version);
+    assertThat(after.report.useStandardCommands).isEqualTo(expected);
+    assertThat(after.synonymRu).isEqualTo(dto.synonymRu);
+  }
+
+  /** Пишет объект из эталона формата и возвращает DTO после записи без изменений. */
+  private MdObjectPropertiesDto roundTrip(MdObjectAddType type, SchemaVersion version) throws Exception {
+    Path objectXml = writeGolden(type, version, type.namePrefix() + "Проверка");
+    MdObjectPropertiesDto before = MdObjectPropertiesEdit.readDto(objectXml, version);
+    MdObjectPropertiesEdit.writeDto(objectXml, version, before);
+    MdObjectPropertiesDto after = MdObjectPropertiesEdit.readDto(objectXml, version);
+    assertThat(after.internalName).isEqualTo(before.internalName);
+    assertThat(after.synonymRu).isEqualTo(before.synonymRu);
+    return after;
+  }
+
+  private Path writeGolden(MdObjectAddType type, SchemaVersion version, String name) throws Exception {
+    String xml = GoldenScaffold.generateObject(type, name, version);
+    // имя файла обязано совпадать с именем объекта, поэтому каждый случай в своём каталоге
+    Path dir = Files.createDirectories(tempDir.resolve(version.name()).resolve(type.name()));
+    Path objectXml = dir.resolve(name + ".xml");
+    Files.writeString(objectXml, xml, StandardCharsets.UTF_8);
+    return objectXml;
+  }
+}

--- a/src/test/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertyEnumsTest.java
+++ b/src/test/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertyEnumsTest.java
@@ -1,0 +1,64 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+import io.github.yellowhammer.designerxml.SchemaVersion;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MdObjectPropertyEnumsTest {
+
+  @Test
+  void codeSeries_listsOnlyConstantsOfTheFormat() {
+    Map<String, List<String>> enums = MdObjectPropertyEnums.forVersion(SchemaVersion.V2_21);
+
+    assertThat(enums.get("chartOfCharacteristicTypes.codeSeries"))
+      .containsExactlyInAnyOrder("WHOLE_CHARACTERISTIC_KIND", "WITHIN_SUBORDINATION");
+    assertThat(enums.get("catalog.codeSeries"))
+      .containsExactlyInAnyOrder("WHOLE_CATALOG", "WITHIN_OWNER_SUBORDINATION", "WITHIN_SUBORDINATION");
+    assertThat(enums.get("chartOfCalculationTypes.dependenceOnCalculationTypes"))
+      .containsExactlyInAnyOrder("DONT_USE", "ON_ACTION_PERIOD", "ON_REGISTRATION_PERIOD");
+  }
+
+  @Test
+  void sharedBlocks_unionValuesOfBothKinds() {
+    Map<String, List<String>> enums = MdObjectPropertyEnums.forVersion(SchemaVersion.V2_21);
+
+    // отчёт и обработка описаны одним блоком DTO, регистры сведений и накопления - тоже
+    assertThat(enums).containsKey("report.objectBelonging");
+    assertThat(enums.get("register.writeMode")).containsExactlyInAnyOrder("INDEPENDENT", "RECORDER_SUBORDINATE");
+    assertThat(enums.get("register.informationRegisterPeriodicity")).contains("NONPERIODICAL", "SECOND", "RECORDER_POSITION");
+  }
+
+  @Test
+  void nonEnumProperties_areNotInDictionary() {
+    Map<String, List<String>> enums = MdObjectPropertyEnums.forVersion(SchemaVersion.V2_21);
+
+    // ссылка на форму и длина кода - не перечисления, значения им задаёт не модель
+    assertThat(enums).doesNotContainKey("catalog.defaultObjectForm");
+    assertThat(enums).doesNotContainKey("catalog.codeLength");
+  }
+
+  @ParameterizedTest
+  @EnumSource(SchemaVersion.class)
+  void everyFormatHasDictionary(SchemaVersion version) {
+    Map<String, List<String>> enums = MdObjectPropertyEnums.forVersion(version);
+
+    assertThat(enums).as("словарь формата %s", version).isNotEmpty();
+    assertThat(enums.get("catalog.editType")).as("способ редактирования в формате %s", version)
+      .containsExactlyInAnyOrder("IN_DIALOG", "IN_LIST", "BOTH_WAYS");
+    assertThat(enums.values()).allSatisfy(values -> assertThat(values).isNotEmpty());
+  }
+}

--- a/src/test/java/io/github/yellowhammer/designerxml/cf/MdObjectStructureAndMutationsTest.java
+++ b/src/test/java/io/github/yellowhammer/designerxml/cf/MdObjectStructureAndMutationsTest.java
@@ -9,7 +9,9 @@
 package io.github.yellowhammer.designerxml.cf;
 
 import io.github.yellowhammer.designerxml.SchemaVersion;
+import io.github.yellowhammer.designerxml.Ssl31SubmodulePaths;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -21,6 +23,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class MdObjectStructureAndMutationsTest {
 
+  @TempDir
+  Path tempDir;
+
   @Test
   void readStructure_document_hasNestedContent() throws Exception {
     MdObjectStructureDto dto = MdObjectStructureRead.read(sampleDocumentXml(), SchemaVersion.V2_20);
@@ -30,6 +35,14 @@ class MdObjectStructureAndMutationsTest {
     assertThat(dto.tabularSections.getFirst().attributes).isNotEmpty();
     assertThat(dto.forms).isNotEmpty();
     assertThat(dto.templates).isNotEmpty();
+  }
+
+  @Test
+  void readStructure_document_listsStandardAttributes() throws Exception {
+    MdObjectStructureDto dto = MdObjectStructureRead.read(sampleDocumentXml(), SchemaVersion.V2_20);
+
+    // состав стандартных реквизитов задаёт платформа, а перечисляет их сам файл объекта
+    assertThat(dto.standardAttributes).contains("Number", "Date");
   }
 
   @Test
@@ -138,6 +151,36 @@ class MdObjectStructureAndMutationsTest {
     Path target = dir.resolve(source.getFileName().toString());
     Files.copy(source, target);
     return target;
+  }
+
+  @Test
+  void addRenameDeleteCommand_updatesChildObjectsAndModuleDirectory() throws Exception {
+    Path objectXml = copyCatalogWithSubtree();
+    Path commands = objectXml.resolveSibling(
+      objectXml.getFileName().toString().replace(".xml", "")).resolve("Commands");
+
+    MdObjectChildMutations.addCommand(objectXml, SchemaVersion.V2_20, "КомандаИзТеста");
+    assertThat(MdObjectStructureRead.read(objectXml, SchemaVersion.V2_20).commands).contains("КомандаИзТеста");
+
+    Files.createDirectories(commands.resolve("КомандаИзТеста").resolve("Ext"));
+    Files.writeString(commands.resolve("КомандаИзТеста").resolve("Ext").resolve("CommandModule.bsl"), "// модуль");
+
+    MdObjectChildMutations.renameCommand(objectXml, SchemaVersion.V2_20, "КомандаИзТеста", "КомандаПереименована");
+    assertThat(MdObjectStructureRead.read(objectXml, SchemaVersion.V2_20).commands).contains("КомандаПереименована");
+    assertThat(commands.resolve("КомандаПереименована").resolve("Ext").resolve("CommandModule.bsl")).exists();
+
+    MdObjectChildMutations.deleteCommand(objectXml, SchemaVersion.V2_20, "КомандаПереименована");
+    assertThat(MdObjectStructureRead.read(objectXml, SchemaVersion.V2_20).commands)
+      .doesNotContain("КомандаПереименована");
+    assertThat(commands.resolve("КомандаПереименована")).doesNotExist();
+  }
+
+  /** Копия справочника из выгрузки: имя файла должно совпадать с именем объекта. */
+  private Path copyCatalogWithSubtree() throws Exception {
+    Path src = Ssl31SubmodulePaths.anyCatalogObjectXml();
+    Path copy = tempDir.resolve(src.getFileName());
+    Files.copy(src, copy);
+    return copy;
   }
 
   private static Path anyObjectXmlInCfSubdir(String subdir) throws IOException {

--- a/src/test/java/io/github/yellowhammer/designerxml/cli/ApplyMutationCmdTest.java
+++ b/src/test/java/io/github/yellowhammer/designerxml/cli/ApplyMutationCmdTest.java
@@ -652,6 +652,30 @@ class ApplyMutationCmdTest {
     assertThat(out.toString(StandardCharsets.UTF_8)).contains("\"document\"");
   }
 
+  @Test
+  void unsupportedFormatVersion_reportsSupportedRange() throws Exception {
+    // Старые выгрузки (2.4 и подобные) читать нечем: пользователю нужен внятный ответ, а не имя константы.
+    Path params = writeParams(
+      "{"
+        + "\"op\":\"cf-md-object-get\","
+        + "\"objectXml\":" + json(sampleCatalogXml().toString()) + ","
+        + "\"schemaVersion\":\"V2_4\""
+        + "}");
+
+    ByteArrayOutputStream err = new ByteArrayOutputStream();
+    PrintStream prev = System.err;
+    int exit;
+    try {
+      System.setErr(new PrintStream(err, true, StandardCharsets.UTF_8));
+      exit = new CommandLine(new DesignerXmlCli()).execute("read-json", "--params", params.toString());
+    } finally {
+      System.setErr(prev);
+    }
+
+    assertThat(exit).isEqualTo(2);
+    assertThat(err.toString(StandardCharsets.UTF_8)).contains("формат выгрузки 2.4 не поддержан", "2.10-2.21");
+  }
+
   private static String json(String raw) {
     return "\"" + raw.replace("\\", "\\\\").replace("\"", "\\\"") + "\"";
   }

--- a/src/test/java/io/github/yellowhammer/designerxml/reflect/JaxbReflectTest.java
+++ b/src/test/java/io/github/yellowhammer/designerxml/reflect/JaxbReflectTest.java
@@ -106,9 +106,21 @@ class JaxbReflectTest {
     assertThat(s.getMode()).isEqualTo(Mode.B);
     JaxbReflect.setEnumOrKeep(s, "setMode", "");
     assertThat(s.getMode()).isEqualTo(Mode.B);
-    JaxbReflect.setEnumOrKeep(s, "setMode", "UNKNOWN");
-    assertThat(s.getMode()).isEqualTo(Mode.B);
     JaxbReflect.setEnumOrKeep(s, "setMissingEnum", "B");
+  }
+
+  @Test
+  void setEnumOrKeepRejectsUnknownConstantWithAllowedValues() {
+    Sample s = new Sample();
+    JaxbReflect.setEnumOrKeep(s, "setMode", "B");
+
+    // прежнее значение молча не сохраняем: иначе правка теряется без объяснения
+    assertThatThrownBy(() -> JaxbReflect.setEnumOrKeep(s, "setMode", "UNKNOWN"))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("Mode")
+      .hasMessageContaining("UNKNOWN")
+      .hasMessageContaining("допустимы");
+    assertThat(s.getMode()).isEqualTo(Mode.B);
   }
 
   @Test


### PR DESCRIPTION
Типизированный блок свойств был только у справочника, документа, перечисления, константы, общего модуля и регистров - остальные виды читались базовыми полями. Теперь блок есть у всех видов, которые библиотека читает: отчёты и обработки, журналы документов, планы обмена, планы видов характеристик, счетов и видов расчёта, задачи и бизнес-процессы, параметры сеанса, нумераторы документов, подписки на событие, регламентные задания, общие команды, общие реквизиты и картинки, роли, внешние источники данных.

Запись у всех точечная: меняется только затронутый элемент XML, остальной файл остаётся байт в байт.

## Допустимые значения свойств

`cf-md-object-enums -v V2_10…V2_21` отдаёт словарь `блок.свойство` → константы модели. Раньше вызывающая программа держала свой список значений, он расходился с форматом, и правка падала на записи. Недопустимое значение больше не пропускается молча: в ответе перечень допустимых.

## Команды объекта

`cf-md-command-add/rename/delete/reorder`: команды живут в том же `ChildObjects`, что и реквизиты, и правятся той же машинерией. Каталог модуля команды переезжает и удаляется вместе с ней - осиротевший каталог конфигуратор считает мусором.

Структура объекта дополнительно отдаёт состав стандартных реквизитов: он нужен, чтобы предлагать поля блокировки данных.

## Документация

README без перечня команд и классов, матрица поддержки по видам приведена к факту, описание не привязано к конкретному потребителю.

## Проверка

512 тестов, `./gradlew build` зелёный. Round-trip, запись изменённых скаляров и гранулярный патч - на объектах выгрузки `fixtures/ssl31`; словарь значений проверен на всех версиях формата. Отдельно проверено на живых конфигурациях разных форматов (2.10, 2.11, 2.18, 2.20, 2.21): свойства читаются, пишутся и читаются обратно.

Парный PR в расширении: yellow-hammer/vscode-1c-platform-tools#276.
