### PR TITLE
Принадлежность объектов расширения в дереве метаданных

### DIFF
--- a/src/main/java/io/github/yellowhammer/designerxml/cf/ObjectBelongingReader.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/ObjectBelongingReader.java
@@ -1,0 +1,70 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+import com.ctc.wstx.stax.WstxInputFactory;
+
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Принадлежность объекта расширения: собственный он или заимствованный из расширяемой конфигурации.
+ *
+ * <p>Дерево метаданных строится по {@code Configuration.xml} и файлы объектов не открывает, поэтому
+ * признак читается отдельно и потоково: он лежит среди первых свойств объекта, и разбирать файл
+ * целиком незачем.
+ */
+public final class ObjectBelongingReader {
+
+  private static final String PROPERTY = "ObjectBelonging";
+
+  private ObjectBelongingReader() {
+  }
+
+  /**
+   * Читает {@code ObjectBelonging} объекта метаданных.
+   *
+   * @param objectXml путь к XML объекта
+   * @return значение свойства либо пусто, если объект его не объявляет или файл недоступен
+   */
+  public static String read(Path objectXml) {
+    if (!Files.isRegularFile(objectXml)) {
+      return null;
+    }
+    XMLInputFactory factory = new WstxInputFactory();
+    factory.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, Boolean.TRUE);
+    try (InputStream in = Files.newInputStream(objectXml)) {
+      XMLStreamReader reader = factory.createXMLStreamReader(in);
+      try {
+        while (reader.hasNext()) {
+          if (reader.next() != XMLStreamConstants.START_ELEMENT) {
+            continue;
+          }
+          if (PROPERTY.equals(reader.getLocalName())) {
+            String text = reader.getElementText();
+            return text == null || text.isBlank() ? null : text.trim();
+          }
+          // Состав объекта идёт после свойств: если дошли до него, свойства кончились.
+          if ("ChildObjects".equals(reader.getLocalName())) {
+            return null;
+          }
+        }
+      } finally {
+        reader.close();
+      }
+    } catch (IOException | XMLStreamException e) {
+      return null;
+    }
+    return null;
+  }
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/ProjectMetadataGraphBuilder.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/ProjectMetadataGraphBuilder.java
@@ -145,7 +145,7 @@ public final class ProjectMetadataGraphBuilder {
         }
         String relativePath = projectRoot.relativize(xml).toString().replace('\\', '/');
         ProjectMetadataTreeDto.MetadataItemDto fakeItem =
-          new ProjectMetadataTreeDto.MetadataItemDto("Subsystem", name, relativePath);
+          new ProjectMetadataTreeDto.MetadataItemDto("Subsystem", name, relativePath, null);
         processItem(projectRoot, source, fakeItem, nodes, edges, subsystemKeysByTarget);
       }
     }

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/ProjectMetadataTreeBuilder.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/ProjectMetadataTreeBuilder.java
@@ -117,7 +117,7 @@ public final class ProjectMetadataTreeBuilder {
     List<MetadataTreeTagGroups.MetadataTreeGroupPayload> payloads =
       MetadataTreeTagGroups.buildGroups(entries);
     List<ProjectMetadataTreeDto.MetadataGroupDto> groups =
-      mapGroups(projectRoot, extensionRoot, payloads);
+      mapGroups(projectRoot, extensionRoot, payloads, true);
     String cfgRel = projectRoot.relativize(configurationXml).toString().replace('\\', '/');
     String rootRel = projectRoot.relativize(extensionRoot).toString().replace('\\', '/');
     return new ProjectMetadataTreeDto.MetadataSourceDto(
@@ -128,6 +128,14 @@ public final class ProjectMetadataTreeBuilder {
       rootRel,
       groups
     );
+  }
+
+  /** Принадлежность объекта; пусто у основной конфигурации и у объектов без своего файла. */
+  private static String belonging(Path projectRoot, String relativePath, boolean readBelonging) {
+    if (!readBelonging || relativePath == null || relativePath.isEmpty()) {
+      return null;
+    }
+    return ObjectBelongingReader.read(projectRoot.resolve(relativePath));
   }
 
   private static List<ChildObjectEntry> loadChildObjects(Path configurationXml) throws IOException {
@@ -147,6 +155,19 @@ public final class ProjectMetadataTreeBuilder {
     Path metadataRoot,
     List<MetadataTreeTagGroups.MetadataTreeGroupPayload> payloads
   ) {
+    return mapGroups(projectRoot, metadataRoot, payloads, false);
+  }
+
+  /**
+   * @param readBelonging Читать принадлежность объектов: она бывает только у расширений, а чтение
+   *   файла на каждый объект основной конфигурации ничего бы не дало.
+   */
+  private static List<ProjectMetadataTreeDto.MetadataGroupDto> mapGroups(
+    Path projectRoot,
+    Path metadataRoot,
+    List<MetadataTreeTagGroups.MetadataTreeGroupPayload> payloads,
+    boolean readBelonging
+  ) {
     List<ProjectMetadataTreeDto.MetadataGroupDto> out = new ArrayList<>();
     for (MetadataTreeTagGroups.MetadataTreeGroupPayload p : payloads) {
       List<ProjectMetadataTreeDto.MetadataSubgroupDto> subgroups = new ArrayList<>();
@@ -154,14 +175,16 @@ public final class ProjectMetadataTreeBuilder {
         List<ProjectMetadataTreeDto.MetadataItemDto> items = new ArrayList<>();
         for (MetadataTreeTagGroups.MetadataTreeItemPayload it : sp.items()) {
           String rel = relativePathForItem(projectRoot, metadataRoot, it.objectType(), it.name());
-          items.add(new ProjectMetadataTreeDto.MetadataItemDto(it.objectType(), it.name(), rel));
+          items.add(new ProjectMetadataTreeDto.MetadataItemDto(
+            it.objectType(), it.name(), rel, belonging(projectRoot, rel, readBelonging)));
         }
         subgroups.add(new ProjectMetadataTreeDto.MetadataSubgroupDto(sp.id(), sp.label(), sp.iconHint(), items));
       }
       List<ProjectMetadataTreeDto.MetadataItemDto> items = new ArrayList<>();
       for (MetadataTreeTagGroups.MetadataTreeItemPayload it : p.items()) {
         String rel = relativePathForItem(projectRoot, metadataRoot, it.objectType(), it.name());
-        items.add(new ProjectMetadataTreeDto.MetadataItemDto(it.objectType(), it.name(), rel));
+        items.add(new ProjectMetadataTreeDto.MetadataItemDto(
+          it.objectType(), it.name(), rel, belonging(projectRoot, rel, readBelonging)));
       }
       out.add(new ProjectMetadataTreeDto.MetadataGroupDto(p.id(), p.label(), p.iconHint(), items, subgroups));
     }
@@ -206,7 +229,7 @@ public final class ProjectMetadataTreeBuilder {
   ) {
     List<ProjectMetadataTreeDto.MetadataItemDto> items = new ArrayList<>();
     for (ExternalArtifactLister.ExternalArtifactEntry e : entries) {
-      items.add(new ProjectMetadataTreeDto.MetadataItemDto("ExternalReport", e.name(), e.relativePath()));
+      items.add(new ProjectMetadataTreeDto.MetadataItemDto("ExternalReport", e.name(), e.relativePath(), null));
     }
     List<ProjectMetadataTreeDto.MetadataGroupDto> groups = List.of(
       new ProjectMetadataTreeDto.MetadataGroupDto("content", "", "report", items, List.of())
@@ -227,7 +250,7 @@ public final class ProjectMetadataTreeBuilder {
   ) {
     List<ProjectMetadataTreeDto.MetadataItemDto> items = new ArrayList<>();
     for (ExternalArtifactLister.ExternalArtifactEntry e : entries) {
-      items.add(new ProjectMetadataTreeDto.MetadataItemDto("ExternalDataProcessor", e.name(), e.relativePath()));
+      items.add(new ProjectMetadataTreeDto.MetadataItemDto("ExternalDataProcessor", e.name(), e.relativePath(), null));
     }
     List<ProjectMetadataTreeDto.MetadataGroupDto> groups = List.of(
       new ProjectMetadataTreeDto.MetadataGroupDto("content", "", "run-below", items, List.of())

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/ProjectMetadataTreeDto.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/ProjectMetadataTreeDto.java
@@ -61,7 +61,12 @@ public record ProjectMetadataTreeDto(
     String objectType,
     String name,
     /** Путь к файлу объекта относительно корня проекта; для объектов без одного файла — пусто. */
-    String relativePath
+    String relativePath,
+    /**
+     * Принадлежность объекта расширения: {@code Adopted} у заимствованного из расширяемой
+     * конфигурации. У объектов основной конфигурации пусто: там все объекты собственные.
+     */
+    String objectBelonging
   ) {
   }
 }

--- a/src/test/java/io/github/yellowhammer/designerxml/cf/ObjectBelongingReaderTest.java
+++ b/src/test/java/io/github/yellowhammer/designerxml/cf/ObjectBelongingReaderTest.java
@@ -1,0 +1,39 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Принадлежность объекта расширения читается потоково, без разбора файла целиком. */
+class ObjectBelongingReaderTest {
+
+  private static Path ssl31(String... parts) {
+    String root = System.getProperty("fixtures.ssl31.root");
+    assertThat(root).isNotBlank();
+    return Path.of(root, parts);
+  }
+
+  @Test
+  void заимствованныйОбъектРасширения() {
+    Path object = ssl31("src", "cfe", "_ДемоРасширение", "Catalogs", "_ДемоКонтрагенты.xml");
+
+    assertThat(ObjectBelongingReader.read(object)).isEqualTo("Adopted");
+  }
+
+  @Test
+  void уОбъектаКонфигурацииПризнакаНет() {
+    assertThat(ObjectBelongingReader.read(ssl31("src", "cf", "Catalogs", "Валюты.xml"))).isNull();
+  }
+
+  @Test
+  void несуществующийФайлНеЛомаетЧтение() {
+    assertThat(ObjectBelongingReader.read(ssl31("src", "cf", "нет-такого.xml"))).isNull();
+  }
+}


### PR DESCRIPTION
Дерево строится по `Configuration.xml` и файлы объектов не открывает, поэтому заимствованный объект расширения ничем не отличался от собственного — расширению VS Code нечего было показать.

Теперь `project-metadata-tree` отдаёт `objectBelonging`. Читается потоково: признак лежит среди первых свойств объекта, файл дальше не разбирается, а дойдя до `ChildObjects` чтение прекращается. Открываются только файлы расширений — в основной конфигурации все объекты собственные, и тысяча лишних чтений там ничего бы не дала.

Проверено на ssl31: в демо-расширении 16 заимствованных объектов из 31, в основной конфигурации признака нет.