### PR TITLE
feat(cf): подписи и значения перечислимых свойств

### DIFF
--- a/src/main/java/io/github/yellowhammer/designerxml/cf/ConfigurationPropertiesDto.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/ConfigurationPropertiesDto.java
@@ -42,6 +42,8 @@ public final class ConfigurationPropertiesDto {
   public String synchronousPlatformExtensionAndAddInCallUseMode;
   public String interfaceCompatibilityMode;
   public String compatibilityMode;
+  /** Режим совместимости расширения; у конфигурации свойство тоже есть. */
+  public String configurationExtensionCompatibilityMode;
 
   public ConfigurationPropertiesDto() {
     this.usePurposes = new ArrayList<>();

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/ConfigurationPropertiesEdit.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/ConfigurationPropertiesEdit.java
@@ -38,7 +38,7 @@ public final class ConfigurationPropertiesEdit {
 
   public static ConfigurationPropertiesDto read(Path configurationXml, SchemaVersion schemaVersion)
     throws JAXBException, IOException {
-    return fill(properties(DesignerXml.read(configurationXml, schemaVersion)));
+    return fill(properties(DesignerXml.read(configurationXml, schemaVersion)), configurationXml);
   }
 
   public static void write(Path configurationXml, SchemaVersion schemaVersion, ConfigurationPropertiesDto dto)
@@ -80,12 +80,23 @@ public final class ConfigurationPropertiesEdit {
     JaxbReflect.setEnumOrKeep(p, "setSynchronousPlatformExtensionAndAddInCallUseMode",
       incoming.synchronousPlatformExtensionAndAddInCallUseMode);
     JaxbReflect.setEnumOrKeep(p, "setInterfaceCompatibilityMode", incoming.interfaceCompatibilityMode);
-    JaxbReflect.setEnumOrKeep(p, "setCompatibilityMode", incoming.compatibilityMode);
+    // Режимы совместимости бывают вне перечисления модели. Неизменённое значение в модель не
+    // переносим: точечная запись его не трогает, и в файле оно остаётся как было.
+    setEnumIfChanged(p, "setCompatibilityMode", baseline.compatibilityMode, incoming.compatibilityMode);
+    setEnumIfChanged(p, "setConfigurationExtensionCompatibilityMode",
+      baseline.configurationExtensionCompatibilityMode, incoming.configurationExtensionCompatibilityMode);
     byte[] patched = tryGranularWrite(originalXml, root, schemaVersion, baseline, incoming)
       .orElseThrow(() -> new IllegalStateException(
         "Не удалось применить изменения точечно. Полная пересборка XML через JAXB предотвращена."
       ));
     Files.write(configurationXml, patched);
+  }
+
+  /** Переносит значение в модель, только если оно изменилось: неизвестное ей значение она отвергнет. */
+  private static void setEnumIfChanged(Object p, String setter, String baseline, String incoming) {
+    if (!nvl(baseline).equals(nvl(incoming))) {
+      JaxbReflect.setEnumOrKeep(p, setter, incoming);
+    }
   }
 
   /** {@code Configuration.Properties} любой версии; иначе — исключение. */
@@ -101,7 +112,20 @@ public final class ConfigurationPropertiesEdit {
     return p;
   }
 
-  private static ConfigurationPropertiesDto fill(Object p) {
+  private static ConfigurationPropertiesDto fill(Object p, Path configurationXml) {
+    return fill(p, (value, element) -> UnknownEnumValues.orFromXml(value, configurationXml, element));
+  }
+
+  private static ConfigurationPropertiesDto fill(Object p, byte[] xml) {
+    return fill(p, (value, element) -> UnknownEnumValues.orFromXml(value, xml, element));
+  }
+
+  /** Значение перечислимого свойства: от модели либо дочитанное из выгрузки. */
+  private interface EnumValue {
+    String of(String fromModel, String element);
+  }
+
+  private static ConfigurationPropertiesDto fill(Object p, EnumValue enumValue) {
     var out = new ConfigurationPropertiesDto();
     out.name = nvl(JaxbReflect.getStringOptional(p, "getName"));
     out.synonymRu = LocalStringSync.firstRu(JaxbReflect.getOptional(p, "getSynonym"));
@@ -131,7 +155,11 @@ public final class ConfigurationPropertiesEdit {
     out.synchronousPlatformExtensionAndAddInCallUseMode =
       JaxbReflect.enumNameOptional(p, "getSynchronousPlatformExtensionAndAddInCallUseMode");
     out.interfaceCompatibilityMode = JaxbReflect.enumNameOptional(p, "getInterfaceCompatibilityMode");
-    out.compatibilityMode = JaxbReflect.enumNameOptional(p, "getCompatibilityMode");
+    out.compatibilityMode =
+      enumValue.of(JaxbReflect.enumNameOptional(p, "getCompatibilityMode"), "CompatibilityMode");
+    out.configurationExtensionCompatibilityMode = enumValue.of(
+      JaxbReflect.enumNameOptional(p, "getConfigurationExtensionCompatibilityMode"),
+      "ConfigurationExtensionCompatibilityMode");
     return out;
   }
 
@@ -191,7 +219,7 @@ public final class ConfigurationPropertiesEdit {
   }
 
   private static ConfigurationPropertiesDto readDto(byte[] xmlBytes, SchemaVersion version) throws JAXBException {
-    return fill(properties(DesignerXml.unmarshal(version, new ByteArrayInputStream(xmlBytes))));
+    return fill(properties(DesignerXml.unmarshal(version, new ByteArrayInputStream(xmlBytes))), xmlBytes);
   }
 
   private static List<String> enumListToNames(Object fixedArray) {

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/EnumValueLabels.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/EnumValueLabels.java
@@ -1,0 +1,214 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Подписи значений перечислимых свойств так, как их называет конфигуратор.
+ *
+ * <p>Значение приходит из модели именем константы ({@code AS_DESCRIPTION}), и показывать его
+ * человеку незачем. Словарь живёт здесь, а не у вызывающей стороны: набор значений задаёт формат
+ * выгрузки, и разбираться в нём должна библиотека формата.
+ *
+ * <p>Ключ - имя константы: одно и то же имя у разных свойств почти всегда называется одинаково.
+ * Свойства-исключения перечислены отдельно.
+ */
+public final class EnumValueLabels {
+
+  private static final Map<String, String> LABELS = labels();
+
+  /** Режимы совместимости: их три десятка, и с каждой несовместимой версией платформы прибавляется. */
+  private static final Pattern VERSION = Pattern.compile("^VERSION_(\\d+)_(\\d+)(?:_(\\d+))?$");
+
+  private EnumValueLabels() {
+  }
+
+  /** Свойства, у которых значение называется не так, как везде: {@code блок.свойство} -> подписи. */
+  private static final Map<String, Map<String, String>> BY_PROPERTY = Map.of(
+    "chartOfCalculationTypes.dependenceOnCalculationTypes", Map.of("DONT_USE", "Не зависит")
+  );
+
+  /**
+   * Словарь подписей.
+   *
+   * @return имя константы -> подпись
+   */
+  public static Map<String, String> all() {
+    return LABELS;
+  }
+
+  /**
+   * Подписи значений у свойств, где они называются иначе.
+   *
+   * @return {@code блок.свойство} -> имя константы -> подпись
+   */
+  public static Map<String, Map<String, String>> byProperty() {
+    return BY_PROPERTY;
+  }
+
+  /**
+   * Подпись значения.
+   *
+   * @param constantName имя константы перечисления
+   * @return подпись либо само имя, если значения в словаре нет
+   */
+  public static String labelOf(String constantName) {
+    return labelOf(null, constantName);
+  }
+
+  /**
+   * Подпись значения у свойства.
+   *
+   * @param property {@code блок.свойство}; пусто - подпись без привязки к свойству
+   * @param constantName имя константы перечисления
+   * @return подпись либо само имя, если значения в словаре нет
+   */
+  public static String labelOf(String property, String constantName) {
+    if (constantName == null || constantName.isEmpty()) {
+      return "";
+    }
+    String special = property == null ? null : BY_PROPERTY.getOrDefault(property, Map.of()).get(constantName);
+    if (special != null) {
+      return special;
+    }
+    String known = LABELS.get(constantName);
+    if (known != null) {
+      return known;
+    }
+    Matcher version = VERSION.matcher(constantName);
+    if (version.matches()) {
+      String patch = version.group(3) == null ? "" : "." + version.group(3);
+      return "Версия " + version.group(1) + "." + version.group(2) + patch;
+    }
+    return constantName;
+  }
+
+  private static Map<String, String> labels() {
+    Map<String, String> m = new LinkedHashMap<>();
+    put(m, "USE", "Использовать");
+    put(m, "DONT_USE", "Не использовать");
+    put(m, "USE_WITH_WARNINGS", "Использовать с предупреждениями");
+    put(m, "AUTO", "Авто");
+    put(m, "AUTOMATIC", "Автоматический");
+    put(m, "MANAGED", "Управляемый");
+    put(m, "AUTOMATIC_AND_MANAGED", "Автоматический и управляемый");
+    put(m, "ALLOW", "Разрешить");
+    put(m, "DENY", "Запретить");
+    put(m, "DONT_CHECK", "Не проверять");
+    put(m, "SHOW_ERROR", "Выдавать ошибку");
+    put(m, "MAKE_DISABLE", "Выключать");
+    put(m, "DONT_CHANGE_BEHAVIOR", "Не менять поведение");
+
+    put(m, "AS_CODE", "В виде кода");
+    put(m, "AS_DESCRIPTION", "В виде наименования");
+    put(m, "AS_NUMBER", "В виде номера");
+    put(m, "STRING", "Строка");
+    put(m, "NUMBER", "Число");
+    put(m, "TEXT", "Текст");
+    put(m, "PICTURE", "Картинка");
+    put(m, "PICTURE_AND_TEXT", "Картинка и текст");
+
+    put(m, "VARIABLE", "Переменная");
+    put(m, "FIXED", "Фиксированная");
+    put(m, "SINGLE", "Одиночный");
+    put(m, "MULTIPLE", "Множественный");
+    put(m, "SEPARATE", "Разделять");
+    put(m, "INDEPENDENT", "Независимый");
+    put(m, "INDEPENDENTLY", "Независимо");
+    put(m, "INDEPENDENTLY_AND_SIMULTANEOUSLY", "Независимо и совместно");
+    put(m, "RECORDER_SUBORDINATE", "Подчинение регистратору");
+    put(m, "RECORDER_POSITION", "По позиции регистратора");
+
+    put(m, "FOLDERS", "Группы");
+    put(m, "ITEMS", "Элементы");
+    put(m, "FOLDERS_AND_ITEMS", "Группы и элементы");
+    put(m, "TO_FOLDERS", "Группам");
+    put(m, "TO_ITEMS", "Элементам");
+    put(m, "TO_FOLDERS_AND_ITEMS", "Группам и элементам");
+    put(m, "HIERARCHY_FOLDERS_AND_ITEMS", "Иерархия групп и элементов");
+    put(m, "HIERARCHY_OF_ITEMS", "Иерархия элементов");
+    put(m, "WITHIN_SUBORDINATION", "В пределах подчинения");
+    put(m, "WITHIN_OWNER_SUBORDINATION", "В пределах подчинения владельцу");
+    put(m, "WHOLE_CATALOG", "Во всем справочнике");
+    put(m, "WHOLE_CHARACTERISTIC_KIND", "Во всём плане видов характеристик");
+    put(m, "WHOLE_CHART_OF_ACCOUNTS", "Во всём плане счетов");
+
+    put(m, "IN_DIALOG", "В диалоге");
+    put(m, "IN_LIST", "В списке");
+    put(m, "BOTH_WAYS", "Обоими способами");
+    put(m, "FROM_FORM", "Из формы");
+    put(m, "QUICK_CHOICE", "Быстрый выбор");
+    put(m, "DIRECTLY", "Непосредственно");
+    put(m, "BEGIN", "Начало");
+    put(m, "ANY_PART", "Любая часть");
+
+    put(m, "INDEX", "Индексировать");
+    put(m, "DONT_INDEX", "Не индексировать");
+    put(m, "INDEX_WITH_ADDITIONAL_ORDER", "Индексировать с дополнительным упорядочиванием");
+
+    put(m, "AUTO_UPDATE", "Обновлять автоматически");
+    put(m, "DONT_AUTO_UPDATE", "Не обновлять автоматически");
+    put(m, "AUTO_FILL", "Заполнять автоматически");
+    put(m, "AUTO_FILL_OFF", "Не заполнять автоматически");
+    put(m, "AUTO_DELETE", "Удалять автоматически");
+    put(m, "AUTO_DELETE_ON_UNPOST", "Удалять автоматически при отмене проведения");
+    put(m, "AUTO_DELETE_OFF", "Не удалять автоматически");
+    put(m, "WRITE_MODIFIED", "Записывать модифицированные");
+    put(m, "WRITE_SELECTED", "Записывать выбранные");
+
+    put(m, "BALANCE", "Остатки");
+    put(m, "TURNOVERS", "Обороты");
+    put(m, "NONPERIODICAL", "Непериодический");
+    put(m, "SECOND", "В пределах секунды");
+    put(m, "DAY", "В пределах дня");
+    put(m, "MONTH", "В пределах месяца");
+    put(m, "QUARTER", "В пределах квартала");
+    put(m, "YEAR", "В пределах года");
+    put(m, "ON_ACTION_PERIOD", "По периоду действия");
+    put(m, "ON_REGISTRATION_PERIOD", "По периоду регистрации");
+
+    put(m, "DURING_SESSION", "На время сеанса");
+    put(m, "DURING_REQUEST", "На время вызова");
+    put(m, "BACKGROUND", "Фоновым заданием");
+    put(m, "NATIVE", "Собственный");
+    put(m, "BUSINESS_PROCESS_NUMBER", "Номер бизнес-процесса");
+    put(m, "ADOPTED", "Заимствованный");
+
+    put(m, "MANAGED_APPLICATION", "Управляемое приложение");
+    put(m, "ORDINARY_APPLICATION", "Обычное приложение");
+    put(m, "RUSSIAN", "Русский");
+    put(m, "ENGLISH", "Английский");
+    put(m, "AUTO_FREE", "Освобождать автоматически");
+    put(m, "NOT_AUTO_FREE", "Не освобождать автоматически");
+    put(m, "TAXI", "Такси");
+    put(m, "TAXI_ENABLE_VERSION_8_2", "Такси с возможностью версии 8.2");
+    put(m, "VERSION_8_2_ENABLE_TAXI", "Версия 8.2 с возможностью Такси");
+    put(m, "VERSION_8_2", "Версия 8.2");
+    put(m, "NORMAL", "Обычный");
+    put(m, "WORKPLACE", "Рабочее место");
+    put(m, "FULLSCREEN_WORKPLACE", "Полноэкранное рабочее место");
+    put(m, "EMBEDDED_WORKPLACE", "Встроенное рабочее место");
+    put(m, "KIOSK", "Киоск");
+    put(m, "CUSTOMIZATION", "Адаптация");
+    put(m, "ADD_ON", "Дополнение");
+    put(m, "PATCH", "Исправление");
+    put(m, "LIGHT", "Светлая");
+    put(m, "DARK", "Тёмная");
+    put(m, "OPEN_DATA_IN_TABS", "Открывать данные в закладках");
+    put(m, "OPEN_DATA_IN_DIALOGS", "Открывать данные в отдельных окнах");
+    put(m, "NAVIGATION_LEFT", "Навигация слева");
+    put(m, "NAVIGATION_TOP", "Навигация сверху");
+    return Map.copyOf(m);
+  }
+
+  private static void put(Map<String, String> m, String constantName, String label) {
+    m.put(constantName, label);
+  }
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertyEnums.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertyEnums.java
@@ -39,6 +39,7 @@ public final class MdObjectPropertyEnums {
    */
   public static Map<String, List<String>> forVersion(SchemaVersion version) {
     Map<String, List<String>> out = new LinkedHashMap<>();
+    collect(out, "configuration", propertiesClass(version, "Configuration"));
     for (Field block : MdObjectPropertiesDto.class.getFields()) {
       String typeName = block.getType().getSimpleName();
       if (!typeName.startsWith("Md") || !typeName.endsWith("PropertiesDto")) {

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/UnknownEnumValues.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/UnknownEnumValues.java
@@ -1,0 +1,85 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+import java.nio.file.Path;
+import java.util.Locale;
+
+/**
+ * Значения перечислений, которых нет в модели.
+ *
+ * <p>Платформа пишет в выгрузку значения, которых её же XSD не объявляет: режим совместимости
+ * перечислен по несовместимым версиям и обрывается на 8.3.12, а в файлах встречаются и 8.3.27,
+ * и 8.5.1. Модель такое значение не разбирает, и свойство пропадает: примерно у половины
+ * конфигураций режим совместимости прочитать было нельзя.
+ *
+ * <p>Поэтому значение дочитывается из самого файла и приводится к той же записи, в которой модель
+ * отдаёт известные значения. Так вызывающая сторона получает одно и то же независимо от того,
+ * знает модель это значение или нет.
+ */
+public final class UnknownEnumValues {
+
+  private UnknownEnumValues() {
+  }
+
+  /**
+   * Значение перечислимого свойства, известное модели или дочитанное из файла.
+   *
+   * @param fromModel имя константы от модели; пусто, если значение ей неизвестно
+   * @param xml файл выгрузки
+   * @param element имя элемента свойства в XML
+   * @return имя константы либо пусто, если свойства в файле нет
+   */
+  public static String orFromXml(String fromModel, Path xml, String element) {
+    if (fromModel != null && !fromModel.isEmpty()) {
+      return fromModel;
+    }
+    return constantName(XmlElementTextReader.read(xml, element));
+  }
+
+  /**
+   * То же для уже собранной разметки: ею проверяется результат точечной записи.
+   *
+   * @param fromModel имя константы от модели; пусто, если значение ей неизвестно
+   * @param xml разметка выгрузки
+   * @param element имя элемента свойства в XML
+   * @return имя константы либо пусто, если свойства в разметке нет
+   */
+  public static String orFromXml(String fromModel, byte[] xml, String element) {
+    if (fromModel != null && !fromModel.isEmpty()) {
+      return fromModel;
+    }
+    return constantName(XmlElementTextReader.read(xml, element));
+  }
+
+  /**
+   * Запись значения XML именем константы: {@code Version8_3_24} -> {@code VERSION_8_3_24}.
+   *
+   * <p>Так же имена константам даёт генератор модели, поэтому известные и неизвестные значения
+   * приходят одинаковыми.
+   *
+   * @param xmlValue значение из файла
+   * @return имя константы либо пусто
+   */
+  public static String constantName(String xmlValue) {
+    if (xmlValue == null || xmlValue.isBlank()) {
+      return "";
+    }
+    String value = xmlValue.trim();
+    var out = new StringBuilder(value.length() + 4);
+    for (int i = 0; i < value.length(); i++) {
+      char c = value.charAt(i);
+      boolean boundary = i > 0
+        && (Character.isUpperCase(c) || (Character.isDigit(c) && !Character.isDigit(value.charAt(i - 1))))
+        && out.charAt(out.length() - 1) != '_';
+      if (boundary) {
+        out.append('_');
+      }
+      out.append(Character.toUpperCase(c));
+    }
+    return out.toString().toUpperCase(Locale.ROOT);
+  }
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/XmlElementTextReader.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/XmlElementTextReader.java
@@ -1,0 +1,77 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+import com.ctc.wstx.stax.WstxInputFactory;
+
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/** Текст первого элемента с заданным именем; читается потоково, файл целиком не разбирается. */
+public final class XmlElementTextReader {
+
+  private XmlElementTextReader() {
+  }
+
+  /**
+   * Читает текст элемента.
+   *
+   * @param xml файл выгрузки
+   * @param element локальное имя элемента
+   * @return текст либо пусто, если элемента нет или файл недоступен
+   */
+  public static String read(Path xml, String element) {
+    if (!Files.isRegularFile(xml)) {
+      return "";
+    }
+    try (InputStream in = Files.newInputStream(xml)) {
+      return read(in, element);
+    } catch (IOException e) {
+      return "";
+    }
+  }
+
+  /**
+   * Читает текст элемента из уже собранной разметки.
+   *
+   * @param xml разметка выгрузки
+   * @param element локальное имя элемента
+   * @return текст либо пусто, если элемента нет
+   */
+  public static String read(byte[] xml, String element) {
+    return read(new ByteArrayInputStream(xml), element);
+  }
+
+  private static String read(InputStream in, String element) {
+    XMLInputFactory factory = new WstxInputFactory();
+    factory.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, Boolean.TRUE);
+    try {
+      XMLStreamReader reader = factory.createXMLStreamReader(in);
+      try {
+        while (reader.hasNext()) {
+          if (reader.next() == XMLStreamConstants.START_ELEMENT
+            && element.equals(reader.getLocalName())) {
+            String text = reader.getElementText();
+            return text == null ? "" : text.trim();
+          }
+        }
+      } finally {
+        reader.close();
+      }
+    } catch (XMLStreamException e) {
+      return "";
+    }
+    return "";
+  }
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cli/ReadJsonCmd.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cli/ReadJsonCmd.java
@@ -24,6 +24,7 @@ package io.github.yellowhammer.designerxml.cli;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonSyntaxException;
+import io.github.yellowhammer.designerxml.cf.EnumValueLabels;
 import io.github.yellowhammer.designerxml.cf.CatalogFormDto;
 import io.github.yellowhammer.designerxml.cf.CfDumpValidation;
 import io.github.yellowhammer.designerxml.cf.CatalogFormEdit;
@@ -50,6 +51,7 @@ import io.github.yellowhammer.designerxml.cf.SubsystemTreeBuilder;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
+import java.util.Map;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.concurrent.Callable;
@@ -111,6 +113,12 @@ final class ReadJsonCmd implements Callable<Integer> {
       case "cf-md-object-get": {
         MdObjectPropertiesDto dto = MdObjectPropertiesEdit.readDto(p.reqPath(p.objectXml, "objectXml"), p.version());
         return gson.toJson(dto);
+      }
+      case "cf-enum-labels": {
+        return gson.toJson(Map.of(
+          "values", EnumValueLabels.all(),
+          "byProperty", EnumValueLabels.byProperty()
+        ));
       }
       case "cf-md-object-enums": {
         return gson.toJson(MdObjectPropertyEnums.forVersion(p.version()));

--- a/src/test/java/io/github/yellowhammer/designerxml/cf/EnumValueLabelsTest.java
+++ b/src/test/java/io/github/yellowhammer/designerxml/cf/EnumValueLabelsTest.java
@@ -1,0 +1,57 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+import io.github.yellowhammer.designerxml.SchemaVersion;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.TreeSet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Подписи значений перечислимых свойств. */
+class EnumValueLabelsTest {
+
+  @Test
+  void подписаныВсеЗначенияВсехПоддержанныхФорматов() {
+    var unnamed = new TreeSet<String>();
+    for (SchemaVersion version : SchemaVersion.values()) {
+      for (Map.Entry<String, List<String>> property : MdObjectPropertyEnums.forVersion(version).entrySet()) {
+        for (String value : property.getValue()) {
+          if (EnumValueLabels.labelOf(value).equals(value)) {
+            unnamed.add(property.getKey() + " = " + value);
+          }
+        }
+      }
+    }
+
+    assertThat(unnamed).as("значения без подписи").isEmpty();
+  }
+
+  @Test
+  void режимСовместимостиПодписываетсяПравилом() {
+    // Их три десятка, и с каждой несовместимой версией платформы прибавляется.
+    assertThat(EnumValueLabels.labelOf("VERSION_8_3_27")).isEqualTo("Версия 8.3.27");
+    assertThat(EnumValueLabels.labelOf("VERSION_8_5_1")).isEqualTo("Версия 8.5.1");
+    assertThat(EnumValueLabels.labelOf("VERSION_8_2")).isEqualTo("Версия 8.2");
+  }
+
+  @Test
+  void уСвойстваЗначениеМожетНазыватьсяИначе() {
+    String property = "chartOfCalculationTypes.dependenceOnCalculationTypes";
+
+    assertThat(EnumValueLabels.labelOf(property, "DONT_USE")).isEqualTo("Не зависит");
+    assertThat(EnumValueLabels.labelOf("DONT_USE")).isEqualTo("Не использовать");
+  }
+
+  @Test
+  void неизвестноеЗначениеОстаётсяСобой() {
+    assertThat(EnumValueLabels.labelOf("СОВСЕМ_НОВОЕ")).isEqualTo("СОВСЕМ_НОВОЕ");
+    assertThat(EnumValueLabels.labelOf(null)).isEmpty();
+  }
+}

--- a/src/test/java/io/github/yellowhammer/designerxml/cf/UnknownEnumValuesTest.java
+++ b/src/test/java/io/github/yellowhammer/designerxml/cf/UnknownEnumValuesTest.java
@@ -1,0 +1,47 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+import io.github.yellowhammer.designerxml.SchemaVersion;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Значения перечислений, которых нет в модели, доходят до вызывающей стороны. */
+class UnknownEnumValuesTest {
+
+  private static Path ssl31(String... parts) {
+    String root = System.getProperty("fixtures.ssl31.root");
+    assertThat(root).isNotBlank();
+    return Path.of(root, parts);
+  }
+
+  @Test
+  void режимСовместимостиЧитаетсяХотяВПеречисленииЕгоНет() throws Exception {
+    // Перечисление обрывается на 8.3.12: несовместимых версий после неё не было, а метки версий есть.
+    var props = ConfigurationPropertiesEdit.read(ssl31("src", "cf", "Configuration.xml"), SchemaVersion.V2_20);
+
+    assertThat(props.compatibilityMode).isEqualTo("VERSION_8_3_24");
+    assertThat(props.configurationExtensionCompatibilityMode).isEqualTo("VERSION_8_3_27");
+  }
+
+  @Test
+  void значениеXmlПриводитсяКЗаписиМодели() {
+    assertThat(UnknownEnumValues.constantName("Version8_3_24")).isEqualTo("VERSION_8_3_24");
+    assertThat(UnknownEnumValues.constantName("Version8_5_1")).isEqualTo("VERSION_8_5_1");
+    assertThat(UnknownEnumValues.constantName("TaxiEnableVersion8_2")).isEqualTo("TAXI_ENABLE_VERSION_8_2");
+    assertThat(UnknownEnumValues.constantName("Adopted")).isEqualTo("ADOPTED");
+    assertThat(UnknownEnumValues.constantName("")).isEmpty();
+  }
+
+  @Test
+  void известноеМоделиЗначениеИзФайлаНеДочитывается() {
+    assertThat(UnknownEnumValues.orFromXml("MANAGED", Path.of("нет-такого.xml"), "DataLockControlMode"))
+      .isEqualTo("MANAGED");
+  }
+}


### PR DESCRIPTION
Три вещи про перечислимые свойства, все из одного корня: разбираться в значениях формата должна библиотека формата.

**Подписи.** Значения приходили именами констант: `AS_DESCRIPTION`, `HIERARCHY_FOLDERS_AND_ITEMS`. Операция `cf-enum-labels` отдаёт словарь подписей так, как значения называет конфигуратор, плюс отдельный словарь для свойств, где значение называется иначе (у зависимости от видов расчёта `DONT_USE` это «Не зависит»). Режимы совместимости подписываются правилом: их три десятка, и с каждой несовместимой версией платформы прибавляется.

**Перечисления свойств конфигурации.** `cf-md-object-enums` теперь отдаёт и их: 16 свойств, включая назначение расширения, тему и вид основного окна. Раньше словарь знал только виды объектов метаданных, и вызывающей стороне приходилось держать свой снимок формата.

**Значения вне модели.** Перечисление `CompatibilityMode` обрывается на 8.3.12 - после неё несовместимых версий не было, - но в файлах лежат `Version8_3_24`, `Version8_3_27`, `Version8_5_1`. Модель их не разбирала, и свойство пропадало: из 92 конфигураций, что нашлись на диске, режим совместимости терялся у 49. Теперь значение дочитывается из файла и приводится к записи модели. Заодно появилось свойство `configurationExtensionCompatibilityMode` - раньше режим совместимости расширения было не увидеть.

Проверено на ssl31 (`VERSION_8_3_24` и `VERSION_8_3_27`) и на эталоне пустого расширения 2.21 (`VERSION_8_5_1`).

Схемы при этом трогать незачем: прогнал конвейер namespace-forest на 8.5.1.1343, формат тот же 2.21, перечисление то же, отличие от закоммиченных - порядок трёх объявлений в `cmi.xsd`.