### PR TITLE
fix(build): закрывали Dependabot-алерты пином classpath плагинов

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,29 @@ import org.gradle.api.tasks.javadoc.Javadoc
 import java.io.File
 import java.security.MessageDigest
 
+buildscript {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    dependencies {
+        constraints {
+            classpath("org.springframework:spring-core:7.0.8")
+            classpath("org.codehaus.plexus:plexus-utils:4.0.3")
+            classpath("org.apache.logging.log4j:log4j-core:2.26.1")
+            classpath("org.apache.logging.log4j:log4j-api:2.26.1")
+        }
+    }
+    configurations.named("classpath") {
+        resolutionStrategy.force(
+            "org.springframework:spring-core:7.0.8",
+            "org.codehaus.plexus:plexus-utils:4.0.3",
+            "org.apache.logging.log4j:log4j-core:2.26.1",
+            "org.apache.logging.log4j:log4j-api:2.26.1",
+        )
+    }
+}
+
 plugins {
     `java-library`
     application

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,42 @@
 rootProject.name = "md-sparrow"
+
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
+buildscript {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    dependencies {
+        classpath("org.springframework:spring-core:7.0.8")
+        classpath("org.codehaus.plexus:plexus-utils:4.0.3")
+        classpath("org.apache.logging.log4j:log4j-core:2.26.1")
+        classpath("org.apache.logging.log4j:log4j-api:2.26.1")
+    }
+    configurations.named("classpath") {
+        resolutionStrategy.force(
+            "org.springframework:spring-core:7.0.8",
+            "org.codehaus.plexus:plexus-utils:4.0.3",
+            "org.apache.logging.log4j:log4j-core:2.26.1",
+            "org.apache.logging.log4j:log4j-api:2.26.1",
+        )
+    }
+}
+
+gradle.beforeProject {
+    buildscript.configurations.configureEach {
+        if (name == "classpath") {
+            resolutionStrategy.force(
+                "org.springframework:spring-core:7.0.8",
+                "org.codehaus.plexus:plexus-utils:4.0.3",
+                "org.apache.logging.log4j:log4j-core:2.26.1",
+                "org.apache.logging.log4j:log4j-api:2.26.1",
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- На classpath сборки фиксируем spring-core 7.0.8, plexus-utils 4.0.3 и log4j 2.26.1
- Алерты шли из license и shadow, не из поставляемого JAR

## Test plan
- [x] `gradlew.bat buildEnvironment` — версии форсятся
- [x] `gradlew.bat shadowJar` собирается