### PR TITLE
feat(properties): свойства палитры, типы и параметры выбора

### DIFF
--- a/docs/cf-md-object.md
+++ b/docs/cf-md-object.md
@@ -74,7 +74,7 @@
 
 Для `catalog`, `document`, `exchangePlan`:
 
-- `attributes[]`, `tabularSections[]`: элементы `{ "name", "synonymRu", "comment" }`. Имя **не меняется** через `cf-md-object-set`; при сохранении число и порядок элементов должны совпадать с XML.
+- `attributes[]`, `tabularSections[]`: элементы `{ "name", "synonymRu", "comment", "type" }` плюс свойства палитры: `toolTipRu`, `fillChecking`, `indexing`, `fullTextSearch`, `dataHistory`, `use`, `quickChoice`, `createOnInput`, `choiceHistoryOnInput`, `choiceForm`, `choiceParameters`, `choiceParameterLinks`. Набор свойств зависит от вида узла и версии формата: чего в схеме нет, приходит пустым и при записи не трогается. Допустимые значения перечислений отдаёт `cf-md-object-enums` под ключами вида `attribute.indexing`. Имя **не меняется** через `cf-md-object-set`; при сохранении число и порядок элементов должны совпадать с XML.
 
 Для `subsystem`:
 
@@ -90,4 +90,5 @@ Round-trip и регрессии — на выгрузках вроде submodul
 - Для всех перечисленных `kind` поддержаны базовые поля `internalName/synonymRu/comment` с гранулярной записью.
 - Типизированный блок свойств есть у видов из строк «полная»; остальным доступны только базовые поля.
 - Для `subsystem` дополнительно поддержаны `nestedSubsystems` и `contentRefs`. Тем же полем `contentRefs` приходят состав функциональной опции и её параметра, общего реквизита, последовательности и критерия отбора: у критерия ссылки только снимаются, дерево кандидатов не строится.
+- Параметры выбора (`choiceParameters`) читаются текстом и не пишутся: значение платформа хранит типизированным, строкой его не восстановить. Связи параметров выбора (`choiceParameterLinks`: `name`, `dataPath`, `mode`) читаются и пишутся целиком, число и порядок связей при записи должны совпадать с XML.
 - Состав плана обмена лежит отдельным файлом `<План>/Ext/Content.xml` и правится операцией `cf-md-exchange-plan-content-set`.

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/ConfigurationRefTypeLister.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/ConfigurationRefTypeLister.java
@@ -1,0 +1,60 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+import io.github.yellowhammer.designerxml.SchemaVersion;
+
+import jakarta.xml.bind.JAXBException;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Ссылочные типы конфигурации: чем может быть реквизит или измерение.
+ *
+ * <p>Собирается из состава конфигурации и карты ссылочных типов платформы, поэтому потребителю
+ * не нужно знать, у какого вида объекта ссылочный тип есть, а у какого нет, и как он называется.
+ */
+public final class ConfigurationRefTypeLister {
+
+  private ConfigurationRefTypeLister() {
+  }
+
+  /**
+   * Ссылочные типы конфигурации, сгруппированные по виду объекта.
+   *
+   * <p>Ключ - вид объекта как в составе конфигурации ({@code Catalog}), значения - готовые тексты
+   * типов ({@code cfg:CatalogRef.Контрагенты}) в том виде, в каком они лежат в описании типа.
+   *
+   * @param configurationXml файл конфигурации
+   * @param version версия формата выгрузки
+   * @return вид объекта -&gt; тексты ссылочных типов; виды без объектов не попадают
+   */
+  public static Map<String, List<String>> listRefTypes(Path configurationXml, SchemaVersion version)
+    throws JAXBException, IOException {
+    Map<String, List<String>> byChildTag = ConfigurationChildObjectLister.listAll(configurationXml, version);
+    Map<String, List<String>> out = new LinkedHashMap<>();
+    for (Map.Entry<String, String> entry : MetadataRefParser.refTypeSuffixesByObjectType().entrySet()) {
+      List<String> names = byChildTag.get(entry.getKey());
+      if (names == null || names.isEmpty()) {
+        continue;
+      }
+      List<String> types = new ArrayList<>();
+      for (String name : names) {
+        types.add("cfg:" + entry.getValue() + "." + name);
+      }
+      out.put(entry.getKey(), types);
+    }
+    return out;
+  }
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/EnumValueLabels.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/EnumValueLabels.java
@@ -106,6 +106,12 @@ public final class EnumValueLabels {
     put(m, "MAKE_DISABLE", "Выключать");
     put(m, "DONT_CHANGE_BEHAVIOR", "Не менять поведение");
 
+    put(m, "FOR_ITEM", "Для элемента");
+    put(m, "FOR_FOLDER", "Для группы");
+    put(m, "FOR_FOLDER_AND_ITEM", "Для группы и элемента");
+    put(m, "DELETE_DATA", "Удалять данные");
+    put(m, "TRANSFORM_VALUES", "Преобразовывать значения");
+
     put(m, "AS_CODE", "В виде кода");
     put(m, "AS_DESCRIPTION", "В виде наименования");
     put(m, "AS_NUMBER", "В виде номера");

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdChoiceParameterDto.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdChoiceParameterDto.java
@@ -1,0 +1,30 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+/**
+ * Параметр выбора реквизита: имя параметра и его значение текстом.
+ *
+ * <p>Значение платформа хранит типизированным, поэтому здесь оно только читается: записать
+ * его текстом значило бы потерять тип, а с ним и работоспособность отбора.
+ */
+public final class MdChoiceParameterDto {
+
+  public String name;
+  /** Значение параметра текстом, как оно лежит в XML; несколько значений идут через запятую. */
+  public String valueText;
+
+  public MdChoiceParameterDto() {
+  }
+
+  public MdChoiceParameterDto(String name, String valueText) {
+    this.name = name;
+    this.valueText = valueText;
+  }
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdChoiceParameterLinkDto.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdChoiceParameterLinkDto.java
@@ -1,0 +1,34 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+/**
+ * Связь параметра выбора: чем реквизит отбирает список при вводе.
+ *
+ * <p>Все три поля текстовые, поэтому связь читается и пишется целиком, в отличие от
+ * {@link MdChoiceParameterDto}, где значение типизировано.
+ */
+public final class MdChoiceParameterLinkDto {
+
+  /** Имя параметра выбора, например {@code Отбор.Владелец}. */
+  public String name;
+  /** Путь к данным формы, откуда берётся значение. */
+  public String dataPath;
+  /** Режим изменения: {@code Any}, {@code Clear}, {@code DontClear}; пусто - как у платформы по умолчанию. */
+  public String mode;
+
+  public MdChoiceParameterLinkDto() {
+  }
+
+  public MdChoiceParameterLinkDto(String name, String dataPath, String mode) {
+    this.name = name;
+    this.dataPath = dataPath;
+    this.mode = mode;
+  }
+}

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdNamedPropertyDto.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdNamedPropertyDto.java
@@ -10,10 +10,11 @@ package io.github.yellowhammer.designerxml.cf;
 
 /**
  * Реквизит, табличная часть, значение перечисления, измерение или ресурс: имя не меняется через DTO,
- * только синоним ru, комментарий и тип.
+ * только синоним ru, комментарий, тип и свойства палитры.
  *
  * <p>{@link #type} есть у того, у чего платформа его требует; у табличных частей и значений
- * перечисления он {@code null}.
+ * перечисления он {@code null}. Свойства палитры версионно-вариативны и есть не у всякого вида
+ * узла: чего в схеме нет, то приходит пустым и при записи не трогается.
  */
 public final class MdNamedPropertyDto {
 
@@ -21,6 +22,30 @@ public final class MdNamedPropertyDto {
   public String synonymRu;
   public String comment;
   public MdTypeDescriptionDto type;
+  /** Подсказка на русском. */
+  public String toolTipRu;
+  /** Проверка заполнения: {@code DONT_CHECK}, {@code SHOW_ERROR}. */
+  public String fillChecking;
+  /** Индексирование: {@code DONT_INDEX}, {@code INDEX}, {@code INDEX_WITH_ADDITIONAL_ORDER}. */
+  public String indexing;
+  /** Полнотекстовый поиск: {@code USE}, {@code DONT_USE}. */
+  public String fullTextSearch;
+  /** История данных: {@code USE}, {@code DONT_USE}. */
+  public String dataHistory;
+  /** Использование реквизита: {@code FOR_ITEM}, {@code FOR_FOLDER}, {@code FOR_FOLDER_AND_ITEM}. */
+  public String use;
+  /** Быстрый выбор: {@code AUTO}, {@code USE}, {@code DONT_USE}. */
+  public String quickChoice;
+  /** Создание при вводе: {@code AUTO}, {@code USE}, {@code DONT_USE}. */
+  public String createOnInput;
+  /** История выбора при вводе: {@code AUTO}, {@code DONT_USE}. */
+  public String choiceHistoryOnInput;
+  /** Форма выбора: полное имя формы либо пусто. */
+  public String choiceForm;
+  /** Параметры выбора: значение типизировано, поэтому только для чтения. */
+  public java.util.List<MdChoiceParameterDto> choiceParameters;
+  /** Связи параметров выбора: читаются и пишутся целиком. */
+  public java.util.List<MdChoiceParameterLinkDto> choiceParameterLinks;
   /** Реквизиты табличной части; у остальных видов узлов пусто. */
   public java.util.List<MdNamedPropertyDto> attributes;
 

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesDiff.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesDiff.java
@@ -627,7 +627,42 @@ public final class MdObjectPropertiesDiff {
       if (!Objects.equals(x.name, y.name)
         || !Objects.equals(x.synonymRu, y.synonymRu)
         || !Objects.equals(x.comment, y.comment)
-        || !MdFlatDtoSupport.equalsFlat(x.type, y.type, false)) {
+        || !MdFlatDtoSupport.equalsFlat(x.type, y.type, false)
+        || !paletteEquals(x, y)
+        || !namedListEquals(x.attributes, y.attributes)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /** Свойства палитры узла состава: подсказка и перечислимые флаги. */
+  private static boolean paletteEquals(MdNamedPropertyDto x, MdNamedPropertyDto y) {
+    return Objects.equals(x.toolTipRu, y.toolTipRu)
+      && Objects.equals(x.fillChecking, y.fillChecking)
+      && Objects.equals(x.indexing, y.indexing)
+      && Objects.equals(x.fullTextSearch, y.fullTextSearch)
+      && Objects.equals(x.dataHistory, y.dataHistory)
+      && Objects.equals(x.use, y.use)
+      && Objects.equals(x.quickChoice, y.quickChoice)
+      && Objects.equals(x.createOnInput, y.createOnInput)
+      && Objects.equals(x.choiceHistoryOnInput, y.choiceHistoryOnInput)
+      && Objects.equals(x.choiceForm, y.choiceForm)
+      && choiceLinksEqual(x.choiceParameterLinks, y.choiceParameterLinks);
+  }
+
+  /** Связи параметров выбора: сравниваем поштучно, порядок значим как в XML. */
+  private static boolean choiceLinksEqual(
+    List<MdChoiceParameterLinkDto> a, List<MdChoiceParameterLinkDto> b) {
+    List<MdChoiceParameterLinkDto> left = a == null ? new ArrayList<>() : a;
+    List<MdChoiceParameterLinkDto> right = b == null ? new ArrayList<>() : b;
+    if (left.size() != right.size()) {
+      return false;
+    }
+    for (int i = 0; i < left.size(); i++) {
+      if (!Objects.equals(left.get(i).name, right.get(i).name)
+        || !Objects.equals(left.get(i).dataPath, right.get(i).dataPath)
+        || !Objects.equals(left.get(i).mode, right.get(i).mode)) {
         return false;
       }
     }

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesEdit.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesEdit.java
@@ -349,6 +349,7 @@ public final class MdObjectPropertiesEdit {
       comment == null ? "" : comment);
     // У табличной части и значения перечисления типа нет — getType вернёт null.
     dto.type = MdTypeDescriptionBridge.read(JaxbReflect.getOptional(p, "getType"));
+    readPaletteProperties(p, dto);
     // Реквизиты табличной части: у остальных видов узлов ChildObjects нет
     Object nested = invokeNoArgOrNull(attrOrSection, "getChildObjects");
     if (nested != null) {
@@ -473,6 +474,137 @@ public final class MdObjectPropertiesEdit {
     String syn = d.synonymRu == null ? "" : d.synonymRu;
     LocalStringSync.setOrPutRu(JaxbReflect.get(p, "getSynonym"), syn);
     JaxbReflect.set(p, "setComment", d.comment == null ? "" : d.comment);
+    applyPaletteProperties(p, d);
+  }
+
+  /**
+   * Свойства палитры узла состава: подсказка и перечислимые флаги.
+   *
+   * <p>Набор зависит от вида узла и версии формата: чего в схеме нет, у того нет и геттера,
+   * и поле остаётся пустым.
+   */
+  private static void readPaletteProperties(Object props, MdNamedPropertyDto dto) {
+    dto.toolTipRu = LocalStringSync.firstRu(JaxbReflect.getOptional(props, "getToolTip"));
+    dto.fillChecking = JaxbReflect.enumNameOptional(props, "getFillChecking");
+    dto.indexing = JaxbReflect.enumNameOptional(props, "getIndexing");
+    dto.fullTextSearch = JaxbReflect.enumNameOptional(props, "getFullTextSearch");
+    dto.dataHistory = JaxbReflect.enumNameOptional(props, "getDataHistory");
+    dto.use = JaxbReflect.enumNameOptional(props, "getUse");
+    dto.quickChoice = JaxbReflect.enumNameOptional(props, "getQuickChoice");
+    dto.createOnInput = JaxbReflect.enumNameOptional(props, "getCreateOnInput");
+    dto.choiceHistoryOnInput = JaxbReflect.enumNameOptional(props, "getChoiceHistoryOnInput");
+    dto.choiceForm = JaxbReflect.getStringOptional(props, "getChoiceForm");
+    readChoiceParameters(props, dto);
+  }
+
+  /**
+   * Кладёт свойства палитры обратно в XML.
+   *
+   * <p>Пустое значение оставляет прежнее: панель присылает только то, что правила, а
+   * отсутствующее в схеме свойство пропускается вместе со своим сеттером.
+   */
+  private static void applyPaletteProperties(Object props, MdNamedPropertyDto d) {
+    if (d.toolTipRu != null) {
+      Object toolTip = JaxbReflect.ensureOptional(props, "getToolTip", "setToolTip");
+      if (toolTip != null) {
+        LocalStringSync.setOrPutRu(toolTip, d.toolTipRu);
+      }
+    }
+    JaxbReflect.setEnumOrKeep(props, "setFillChecking", d.fillChecking);
+    JaxbReflect.setEnumOrKeep(props, "setIndexing", d.indexing);
+    JaxbReflect.setEnumOrKeep(props, "setFullTextSearch", d.fullTextSearch);
+    JaxbReflect.setEnumOrKeep(props, "setDataHistory", d.dataHistory);
+    JaxbReflect.setEnumOrKeep(props, "setUse", d.use);
+    JaxbReflect.setEnumOrKeep(props, "setQuickChoice", d.quickChoice);
+    JaxbReflect.setEnumOrKeep(props, "setCreateOnInput", d.createOnInput);
+    JaxbReflect.setEnumOrKeep(props, "setChoiceHistoryOnInput", d.choiceHistoryOnInput);
+    if (d.choiceForm != null) {
+      JaxbReflect.setOptional(props, "setChoiceForm", d.choiceForm);
+    }
+    applyChoiceParameterLinks(props, d);
+  }
+
+  /**
+   * Параметры выбора и связи параметров выбора.
+   *
+   * <p>У параметра значение типизировано (строка, число, ссылка, список выбора формы), поэтому
+   * оно читается текстом и не пишется: строкой его не восстановить. Связь состоит из имени, пути
+   * к данным и режима изменения - её читаем и пишем целиком.
+   */
+  private static void readChoiceParameters(Object props, MdNamedPropertyDto dto) {
+    Object parameters = JaxbReflect.getOptional(props, "getChoiceParameters");
+    if (parameters != null) {
+      List<MdChoiceParameterDto> out = new ArrayList<>();
+      for (Object item : JaxbReflect.<Object>listOptional(parameters, "getItem")) {
+        Object value = JaxbReflect.getOptional(item, "getValue");
+        out.add(new MdChoiceParameterDto(
+          JaxbReflect.getStringOptional(item, "getName"),
+          value == null ? "" : MdListTypeRefs.readItemTexts(List.of(value)).stream().findFirst().orElse("")));
+      }
+      if (!out.isEmpty()) {
+        dto.choiceParameters = out;
+      }
+    }
+    Object links = JaxbReflect.getOptional(props, "getChoiceParameterLinks");
+    if (links == null) {
+      return;
+    }
+    List<MdChoiceParameterLinkDto> out = new ArrayList<>();
+    for (Object link : JaxbReflect.<Object>listOptional(links, "getLink")) {
+      out.add(new MdChoiceParameterLinkDto(
+        firstText(link, "getName"),
+        firstText(link, "getDataPath"),
+        JaxbReflect.enumNameOptional(link, "getValueChange")));
+    }
+    if (!out.isEmpty()) {
+      dto.choiceParameterLinks = out;
+    }
+  }
+
+  /** Имя и путь к данным приходят списками из-за xs:choice схемы: берём первое значение. */
+  private static String firstText(Object node, String getter) {
+    List<String> values = JaxbReflect.listOptional(node, getter);
+    return values.isEmpty() ? "" : values.get(0);
+  }
+
+  /**
+   * Кладёт связи параметров выбора обратно.
+   *
+   * <p>Число и порядок связей должны совпадать с XML: панель их не добавляет и не удаляет,
+   * а расхождение означало бы правку поверх устаревшего снимка.
+   */
+  private static void applyChoiceParameterLinks(Object props, MdNamedPropertyDto d) {
+    if (d.choiceParameterLinks == null) {
+      return;
+    }
+    Object links = JaxbReflect.getOptional(props, "getChoiceParameterLinks");
+    if (links == null) {
+      return;
+    }
+    List<Object> items = JaxbReflect.listOptional(links, "getLink");
+    if (items.size() != d.choiceParameterLinks.size()) {
+      throw new IllegalArgumentException("choiceParameterLinks: число связей не совпадает с XML");
+    }
+    for (int i = 0; i < items.size(); i++) {
+      MdChoiceParameterLinkDto link = d.choiceParameterLinks.get(i);
+      Object item = items.get(i);
+      replaceFirstText(item, "getName", link.name);
+      replaceFirstText(item, "getDataPath", link.dataPath);
+      JaxbReflect.setEnumOrKeep(item, "setValueChange", link.mode);
+    }
+  }
+
+  /** Заменяет первое значение списка строк, оставляя остальные как в файле. */
+  private static void replaceFirstText(Object node, String getter, String value) {
+    if (value == null) {
+      return;
+    }
+    List<String> values = JaxbReflect.listOptional(node, getter);
+    if (values.isEmpty()) {
+      values.add(value);
+      return;
+    }
+    values.set(0, value);
   }
 
   private static void applySubsystem(Object sub, MdObjectPropertiesDto dto) {

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesGranularPatch.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesGranularPatch.java
@@ -80,7 +80,9 @@ public final class MdObjectPropertiesGranularPatch {
           continue;
         }
         String replacement = XmlGranularPatch.formatReplacementPreservingIndent(
-          xmlUtf8, reg.start(), ch.replacementElementXml());
+          xmlUtf8,
+          reg.start(),
+          XmlGranularPatch.dropRedundantNamespaces(xmlUtf8, ch.replacementElementXml()));
         reps.add(new XmlGranularPatch.Replacement(reg.start(), reg.end(), replacement));
       }
     } catch (XMLStreamException e) {

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesLeafDiff.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertiesLeafDiff.java
@@ -351,7 +351,53 @@ public final class MdObjectPropertiesLeafDiff {
           "Type",
           MdTypeDescriptionSerial.typeElement("Type", y.type)));
       }
+      appendNamedChildPaletteChanges(childContainerLocal, x, y, out);
     }
+  }
+
+  /**
+   * Свойства палитры узла состава: правятся точечно, по одному элементу XML.
+   *
+   * <p>Без этого правка одного индексирования уходила бы в пересборку блока состава: платформа
+   * такой файл примет, но diff в Git станет нечитаемым.
+   */
+  private static void appendNamedChildPaletteChanges(
+    String childContainerLocal,
+    MdNamedPropertyDto x,
+    MdNamedPropertyDto y,
+    List<GranularPatchChange> out) {
+    if (!Objects.equals(x.toolTipRu, y.toolTipRu)) {
+      out.add(GranularPatchChange.namedChild(childContainerLocal, y.name, "ToolTip",
+        MdCatalogPropertiesGranularSerial.localStringRuElement("ToolTip", y.toolTipRu)));
+    }
+    appendNamedChildEnum(childContainerLocal, y.name, "FillChecking", x.fillChecking, y.fillChecking, out);
+    appendNamedChildEnum(childContainerLocal, y.name, "Indexing", x.indexing, y.indexing, out);
+    appendNamedChildEnum(childContainerLocal, y.name, "FullTextSearch", x.fullTextSearch, y.fullTextSearch, out);
+    appendNamedChildEnum(childContainerLocal, y.name, "DataHistory", x.dataHistory, y.dataHistory, out);
+    appendNamedChildEnum(childContainerLocal, y.name, "Use", x.use, y.use, out);
+    appendNamedChildEnum(childContainerLocal, y.name, "QuickChoice", x.quickChoice, y.quickChoice, out);
+    appendNamedChildEnum(childContainerLocal, y.name, "CreateOnInput", x.createOnInput, y.createOnInput, out);
+    appendNamedChildEnum(
+      childContainerLocal, y.name, "ChoiceHistoryOnInput", x.choiceHistoryOnInput, y.choiceHistoryOnInput, out);
+    if (!Objects.equals(x.choiceForm, y.choiceForm)) {
+      out.add(GranularPatchChange.namedChild(childContainerLocal, y.name, "ChoiceForm",
+        MdCatalogPropertiesGranularSerial.textElement("ChoiceForm", MdCatalogPropertiesGranularSerial.nz(y.choiceForm))));
+    }
+  }
+
+  /** Перечислимое свойство узла: в DTO имя константы, в XML значение схемы. */
+  private static void appendNamedChildEnum(
+    String childContainerLocal,
+    String name,
+    String elementLocalName,
+    String before,
+    String after,
+    List<GranularPatchChange> out) {
+    if (Objects.equals(before, after) || after == null || after.isEmpty()) {
+      return;
+    }
+    out.add(GranularPatchChange.namedChild(childContainerLocal, name, elementLocalName,
+      MdCatalogPropertiesGranularSerial.enumTextElement(elementLocalName, after)));
   }
 
   private static List<GranularPatchChange> documentPropertyChanges(

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertyEnums.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MdObjectPropertyEnums.java
@@ -40,6 +40,11 @@ public final class MdObjectPropertyEnums {
   public static Map<String, List<String>> forVersion(SchemaVersion version) {
     Map<String, List<String>> out = new LinkedHashMap<>();
     collect(out, "configuration", propertiesClass(version, "Configuration"));
+    // Узлы состава лежат списками, а не блоками DTO: их перечисления собираются
+    // под общим ключом вида, чтобы палитра реквизита знала допустимые значения
+    for (String childKind : CHILD_KINDS) {
+      collect(out, childKind, propertiesClass(version, capitalize(childKind)));
+    }
     for (Field block : MdObjectPropertiesDto.class.getFields()) {
       String typeName = block.getType().getSimpleName();
       if (!typeName.startsWith("Md") || !typeName.endsWith("PropertiesDto")) {
@@ -95,6 +100,14 @@ public final class MdObjectPropertyEnums {
         }
       }
     }
+  }
+
+  /** Виды узлов состава, чьи перечислимые свойства нужны палитре. */
+  private static final List<String> CHILD_KINDS = List.of(
+    "attribute", "dimension", "resource", "accountingFlag", "extDimensionAccountingFlag", "addressingAttribute");
+
+  private static String capitalize(String value) {
+    return Character.toUpperCase(value.charAt(0)) + value.substring(1);
   }
 
   private static String propertyName(String getterName) {

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/MetadataRefParser.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/MetadataRefParser.java
@@ -72,6 +72,24 @@ public final class MetadataRefParser {
     Map.entry("AccountingRegisterRecordSet", "AccountingRegister"),
     Map.entry("CalculationRegisterRecordSet", "CalculationRegister"));
 
+  /**
+   * Вид объекта -&gt; суффикс его ссылочного типа: {@code Catalog} -&gt; {@code CatalogRef}.
+   *
+   * <p>Обратная карта к {@link #REF_SUFFIX_TO_TYPE}, только по ссылкам: типы объекта и набора
+   * записей встречаются в источниках подписок, а типом реквизита быть не могут.
+   *
+   * @return вид объекта -&gt; суффикс ссылочного типа
+   */
+  public static Map<String, String> refTypeSuffixesByObjectType() {
+    Map<String, String> out = new java.util.LinkedHashMap<>();
+    for (Map.Entry<String, String> entry : REF_SUFFIX_TO_TYPE.entrySet()) {
+      if (entry.getKey().endsWith("Ref")) {
+        out.put(entry.getValue(), entry.getKey());
+      }
+    }
+    return out;
+  }
+
   /** Псевдо-типы из {@code v8:TypeSet} / {@code Location}, разворачиваются в реальные типы метаданных. */
   private static final Map<String, String> ALIAS_TO_TYPE = Map.ofEntries(
     Map.entry("Characteristic", "ChartOfCharacteristicTypes"),

--- a/src/main/java/io/github/yellowhammer/designerxml/cf/XmlGranularPatch.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cf/XmlGranularPatch.java
@@ -12,6 +12,9 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
@@ -181,6 +184,47 @@ final class XmlGranularPatch {
   }
 
   /** Перевод строки исходного файла: не смешиваем CRLF и LF при точечных заменах. */
+  /**
+   * Убирает из фрагмента объявления пространств имён, которые уже стоят в корне файла.
+   *
+   * <p>Конфигуратор объявляет префиксы один раз в корневом теге, поэтому повторное объявление
+   * на элементе - лишняя разница в diff, хотя платформа принимает и так.
+   *
+   * @param xmlUtf8 файл целиком
+   * @param fragment вставляемый фрагмент
+   * @return фрагмент без повторных объявлений
+   */
+  /** Объявление пространства имён в корневом теге. */
+  private static final Pattern NAMESPACE_DECLARATION =
+    Pattern.compile("xmlns:([A-Za-z0-9_.-]+)=\"([^\"]+)\"");
+
+  static String dropRedundantNamespaces(String xmlUtf8, String fragment) {
+    Matcher declared = NAMESPACE_DECLARATION.matcher(rootTag(xmlUtf8));
+    Map<String, String> byPrefix = new LinkedHashMap<>();
+    while (declared.find()) {
+      byPrefix.put(declared.group(1), declared.group(2));
+    }
+    if (byPrefix.isEmpty()) {
+      return fragment;
+    }
+    String out = fragment;
+    for (Map.Entry<String, String> entry : byPrefix.entrySet()) {
+      String declaration = " xmlns:" + entry.getKey() + "=\"" + entry.getValue() + "\"";
+      out = out.replace(declaration, "");
+    }
+    return out;
+  }
+
+  /** Корневой тег файла: в нём конфигуратор и объявляет пространства имён. */
+  private static String rootTag(String xmlUtf8) {
+    int start = xmlUtf8.indexOf("<MetaDataObject");
+    if (start < 0) {
+      return "";
+    }
+    int end = xmlUtf8.indexOf('>', start);
+    return end < 0 ? "" : xmlUtf8.substring(start, end);
+  }
+
   static String fileEol(String xmlUtf8) {
     return xmlUtf8.contains("\r\n") ? "\r\n" : "\n";
   }

--- a/src/main/java/io/github/yellowhammer/designerxml/cli/ReadJsonCmd.java
+++ b/src/main/java/io/github/yellowhammer/designerxml/cli/ReadJsonCmd.java
@@ -36,6 +36,7 @@ import io.github.yellowhammer.designerxml.cf.CfDumpValidation;
 import io.github.yellowhammer.designerxml.cf.CatalogFormEdit;
 import io.github.yellowhammer.designerxml.cf.ConfigurationCatalogLister;
 import io.github.yellowhammer.designerxml.cf.ConfigurationChildObjectLister;
+import io.github.yellowhammer.designerxml.cf.ConfigurationRefTypeLister;
 import io.github.yellowhammer.designerxml.cf.ConfigurationPropertiesDto;
 import io.github.yellowhammer.designerxml.cf.ConfigurationPropertiesEdit;
 import io.github.yellowhammer.designerxml.cf.ExternalArtifactPropertiesDto;
@@ -240,6 +241,10 @@ final class ReadJsonCmd implements Callable<Integer> {
       }
       case "cf-md-exchange-plan-content-get": {
         return gson.toJson(ExchangePlanContentFile.read(p.reqPath(p.objectXml, "objectXml")));
+      }
+      case "cf-list-ref-types": {
+        return gson.toJson(ConfigurationRefTypeLister.listRefTypes(
+          p.reqPath(p.configurationXml, "configurationXml"), p.version()));
       }
       case "cf-list-all-child-objects": {
         return gson.toJson(ConfigurationChildObjectLister.listAll(

--- a/src/test/java/io/github/yellowhammer/designerxml/cf/AttributePalettePropertiesTest.java
+++ b/src/test/java/io/github/yellowhammer/designerxml/cf/AttributePalettePropertiesTest.java
@@ -1,0 +1,160 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+import io.github.yellowhammer.designerxml.Ssl31SubmodulePaths;
+import io.github.yellowhammer.designerxml.SchemaVersion;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Свойства палитры реквизита: проверка заполнения, индексирование, полнотекстовый
+ * поиск, история данных и подсказка читаются и пишутся, иначе палитра показывает
+ * их пустыми и теряет правку.
+ */
+class AttributePalettePropertiesTest {
+
+  private static final String CATALOG = "src/cf/Catalogs/_ДемоБанковскиеСчета.xml";
+  private static final String CATALOG_WITH_LINKS = "src/cf/Catalogs/_ДемоНоменклатура.xml";
+
+  private static MdNamedPropertyDto attribute(MdObjectPropertiesDto dto, String name) {
+    return dto.attributes.stream()
+      .filter(a -> name.equals(a.name))
+      .findFirst()
+      .orElseThrow(() -> new AssertionError("нет реквизита " + name));
+  }
+
+  @Test
+  void readsPalettePropertiesOfAttribute() throws Exception {
+    Path xml = Ssl31SubmodulePaths.projectRoot().resolve(CATALOG);
+    MdObjectPropertiesDto dto = MdObjectPropertiesEdit.readDto(xml, SchemaVersion.V2_20);
+
+    assertThat(dto.attributes).isNotEmpty();
+    MdNamedPropertyDto first = dto.attributes.get(0);
+    assertThat(first.indexing).isNotBlank();
+    assertThat(first.fillChecking).isNotBlank();
+    assertThat(first.fullTextSearch).isNotBlank();
+  }
+
+  @Test
+  void writesPalettePropertiesBack(@org.junit.jupiter.api.io.TempDir Path temp) throws Exception {
+    Path source = Ssl31SubmodulePaths.projectRoot().resolve(CATALOG);
+    Path xml = temp.resolve("_ДемоБанковскиеСчета.xml");
+    Files.copy(source, xml, StandardCopyOption.REPLACE_EXISTING);
+
+    MdObjectPropertiesDto dto = MdObjectPropertiesEdit.readDto(xml, SchemaVersion.V2_20);
+    String name = dto.attributes.get(0).name;
+    MdNamedPropertyDto edited = attribute(dto, name);
+    edited.indexing = "INDEX";
+    edited.fillChecking = "SHOW_ERROR";
+    edited.toolTipRu = "Подсказка из палитры";
+    MdObjectPropertiesEdit.writeDto(xml, SchemaVersion.V2_20, dto);
+
+    MdObjectPropertiesDto again = MdObjectPropertiesEdit.readDto(xml, SchemaVersion.V2_20);
+    MdNamedPropertyDto saved = attribute(again, name);
+    assertThat(saved.indexing).isEqualTo("INDEX");
+    assertThat(saved.fillChecking).isEqualTo("SHOW_ERROR");
+    assertThat(saved.toolTipRu).isEqualTo("Подсказка из палитры");
+  }
+
+  @Test
+  void readsChoiceParametersAndLinks() throws Exception {
+    Path xml = Ssl31SubmodulePaths.projectRoot().resolve(CATALOG_WITH_LINKS);
+    MdObjectPropertiesDto dto = MdObjectPropertiesEdit.readDto(xml, SchemaVersion.V2_20);
+
+    MdNamedPropertyDto withLinks = dto.attributes.stream()
+      .filter(a -> a.choiceParameterLinks != null && !a.choiceParameterLinks.isEmpty())
+      .findFirst()
+      .orElseThrow(() -> new AssertionError("в фикстуре нет реквизита со связями параметров выбора"));
+
+    assertThat(withLinks.choiceParameterLinks.get(0).name).isNotBlank();
+    assertThat(withLinks.choiceParameterLinks.get(0).dataPath).isNotBlank();
+  }
+
+  @Test
+  void writesChoiceParameterLinksBack(@org.junit.jupiter.api.io.TempDir Path temp) throws Exception {
+    Path source = Ssl31SubmodulePaths.projectRoot().resolve(CATALOG_WITH_LINKS);
+    Path xml = temp.resolve("_ДемоНоменклатура.xml");
+    Files.copy(source, xml, StandardCopyOption.REPLACE_EXISTING);
+
+    MdObjectPropertiesDto dto = MdObjectPropertiesEdit.readDto(xml, SchemaVersion.V2_20);
+    MdNamedPropertyDto attribute = dto.attributes.stream()
+      .filter(a -> a.choiceParameterLinks != null && !a.choiceParameterLinks.isEmpty())
+      .findFirst()
+      .orElseThrow(() -> new AssertionError("в фикстуре нет реквизита со связями параметров выбора"));
+    String name = attribute.name;
+    attribute.choiceParameterLinks.get(0).dataPath = "Объект.Владелец";
+    MdObjectPropertiesEdit.writeDto(xml, SchemaVersion.V2_20, dto);
+
+    MdObjectPropertiesDto again = MdObjectPropertiesEdit.readDto(xml, SchemaVersion.V2_20);
+    MdNamedPropertyDto saved = attribute(again, name);
+    assertThat(saved.choiceParameterLinks.get(0).dataPath).isEqualTo("Объект.Владелец");
+  }
+
+  @Test
+  void changesExactlyOneLinePerProperty(@org.junit.jupiter.api.io.TempDir Path temp) throws Exception {
+    Path source = Ssl31SubmodulePaths.projectRoot().resolve(CATALOG);
+    Path xml = temp.resolve("_ДемоБанковскиеСчета.xml");
+    Files.copy(source, xml, StandardCopyOption.REPLACE_EXISTING);
+    java.util.List<String> before = Files.readAllLines(xml);
+
+    MdObjectPropertiesDto dto = MdObjectPropertiesEdit.readDto(xml, SchemaVersion.V2_20);
+    MdNamedPropertyDto edited = dto.attributes.get(0);
+    edited.indexing = "INDEX";
+    MdObjectPropertiesEdit.writeDto(xml, SchemaVersion.V2_20, dto);
+
+    java.util.List<String> after = Files.readAllLines(xml);
+    assertThat(after).as("правка одного свойства не должна менять число строк").hasSameSizeAs(before);
+    long changed = java.util.stream.IntStream.range(0, before.size())
+      .filter(i -> !before.get(i).equals(after.get(i)))
+      .count();
+    assertThat(changed).as("изменилась ровно одна строка: %s", changed).isEqualTo(1L);
+  }
+
+  @Test
+  void changesOnlyTouchedLinesForSeveralProperties(@org.junit.jupiter.api.io.TempDir Path temp) throws Exception {
+    Path source = Ssl31SubmodulePaths.projectRoot().resolve(CATALOG);
+    Path xml = temp.resolve("_ДемоБанковскиеСчета.xml");
+    Files.copy(source, xml, StandardCopyOption.REPLACE_EXISTING);
+    java.util.List<String> before = Files.readAllLines(xml);
+
+    MdObjectPropertiesDto dto = MdObjectPropertiesEdit.readDto(xml, SchemaVersion.V2_20);
+    MdNamedPropertyDto edited = dto.attributes.get(0);
+    edited.indexing = "INDEX";
+    edited.fillChecking = "SHOW_ERROR";
+    edited.fullTextSearch = "DONT_USE";
+    MdObjectPropertiesEdit.writeDto(xml, SchemaVersion.V2_20, dto);
+
+    java.util.List<String> after = Files.readAllLines(xml);
+    assertThat(after).hasSameSizeAs(before);
+    long changed = java.util.stream.IntStream.range(0, before.size())
+      .filter(i -> !before.get(i).equals(after.get(i)))
+      .count();
+    assertThat(changed).as("по строке на свойство: %s", changed).isLessThanOrEqualTo(3L);
+  }
+
+  @Test
+  void keepsFileUntouchedWhenNothingChanged(@org.junit.jupiter.api.io.TempDir Path temp) throws Exception {
+    Path source = Ssl31SubmodulePaths.projectRoot().resolve(CATALOG);
+    Path xml = temp.resolve("_ДемоБанковскиеСчета.xml");
+    Files.copy(source, xml, StandardCopyOption.REPLACE_EXISTING);
+    byte[] before = Files.readAllBytes(xml);
+
+    MdObjectPropertiesDto dto = MdObjectPropertiesEdit.readDto(xml, SchemaVersion.V2_20);
+    MdObjectPropertiesEdit.writeDto(xml, SchemaVersion.V2_20, dto);
+
+    assertThat(Files.readAllBytes(xml)).isEqualTo(before);
+  }
+}

--- a/src/test/java/io/github/yellowhammer/designerxml/cf/ConfigurationRefTypeListerTest.java
+++ b/src/test/java/io/github/yellowhammer/designerxml/cf/ConfigurationRefTypeListerTest.java
@@ -1,0 +1,49 @@
+/*
+ * This file is a part of md-sparrow.
+ *
+ * Copyright (c) 2026
+ * Ivan Karlo <i.karlo@outlook.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package io.github.yellowhammer.designerxml.cf;
+
+import io.github.yellowhammer.designerxml.Ssl31SubmodulePaths;
+import io.github.yellowhammer.designerxml.SchemaVersion;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Ссылочные типы конфигурации: панель типов берёт их отсюда, своей карты
+ * «вид объекта - суффикс ссылки» потребитель не держит.
+ */
+class ConfigurationRefTypeListerTest {
+
+  private static Map<String, List<String>> read() throws Exception {
+    return ConfigurationRefTypeLister.listRefTypes(
+      Ssl31SubmodulePaths.projectRoot().resolve("src/cf/Configuration.xml"), SchemaVersion.V2_20);
+  }
+
+  @Test
+  void listsCatalogRefTypes() throws Exception {
+    Map<String, List<String>> types = read();
+
+    assertThat(types).containsKey("Catalog");
+    assertThat(types.get("Catalog")).allSatisfy(type -> assertThat(type).startsWith("cfg:CatalogRef."));
+    assertThat(types.get("Catalog")).hasSizeGreaterThan(10);
+  }
+
+  @Test
+  void coversReferenceKindsOnly() throws Exception {
+    Map<String, List<String>> types = read();
+
+    assertThat(types).containsKeys("Catalog", "Document", "Enum", "ChartOfCharacteristicTypes");
+    // Регистры ссылочного типа не имеют: набор записей типом реквизита не бывает
+    assertThat(types).doesNotContainKeys("InformationRegister", "AccumulationRegister");
+  }
+}

--- a/src/test/java/io/github/yellowhammer/designerxml/cli/ApplyMutationCmdTest.java
+++ b/src/test/java/io/github/yellowhammer/designerxml/cli/ApplyMutationCmdTest.java
@@ -359,7 +359,9 @@ class ApplyMutationCmdTest {
 
     assertThat(exit).isZero();
     String after = Files.readString(objectXml, StandardCharsets.UTF_8);
-    assertThat(after).contains("<v8:Type xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">xs:string</v8:Type>");
+    // Префикс объявлен в корне файла, на элементе его быть не должно: конфигуратор пишет так же
+    assertThat(after).contains("<v8:Type>xs:string</v8:Type>");
+    assertThat(after).doesNotContain("<v8:Type xmlns:xs=");
     assertThat(after).contains("<v8:Length>25</v8:Length>");
     assertThat(after).contains("<v8:AllowedLength>Variable</v8:AllowedLength>");
     assertThat(after).doesNotContain("xs:boolean");


### PR DESCRIPTION
Закрывает библиотечную часть yellow-hammer/vscode-1c-platform-tools#214.

## Свойства палитры у узлов состава

У реквизита, измерения и ресурса читаются и пишутся `toolTipRu`, `fillChecking`, `indexing`, `fullTextSearch`, `dataHistory`, `use`, `quickChoice`, `createOnInput`, `choiceHistoryOnInput`, `choiceForm`.

Набор зависит от вида узла и версии формата: у табличной части нет индексирования, у значения перечисления — проверки заполнения. Чего в схеме нет, у того нет и геттера: свойство приходит пустым и при записи не трогается, поэтому потребителю не нужно знать, что кому положено.

## Ссылочные типы конфигурации

Операция `cf-list-ref-types` отдаёт, чем может быть реквизит: `{"Catalog": ["cfg:CatalogRef.Валюты", …], "Document": […]}`. Собирается из состава конфигурации и карты ссылочных типов платформы, поэтому панель типов не держит своей карты «вид объекта → суффикс ссылки» — новый вид не пришлось бы дописывать руками.

## Параметры выбора

- **связи** (`choiceParameterLinks`: имя, путь к данным, режим) читаются и пишутся целиком; число и порядок при записи сверяются с файлом;
- **параметры** (`choiceParameters`) читаются текстом и не пишутся: значение платформа хранит типизированным (строка, число, ссылка, список выбора формы), и запись строкой потеряла бы тип.

## Значения

Допустимые значения новых перечислений собираются с модели формата и попадают в `cf-md-object-enums` под ключами вида `attribute.indexing`. У новых значений появились русские подписи — пропуск поймал стражевой тест подписей.

## Гранулярная запись

`MdObjectPropertiesDiff` сверяет свойства палитры, связи параметров выбора и вложенные реквизиты табличных частей: без этого правка одного индексирования выглядела бы как «ничего не изменилось».

## Проверено

- чтение и запись на выгрузке ssl_3_1: у `_ДемоНоменклатура` реквизит `ВидНоменклатуры` несёт связь и два параметра выбора;
- круг «прочитали → записали → прочитали» для индексирования, проверки заполнения, подсказки и пути к данным связи;
- запись без правок не меняет файл побайтово;
- 692 теста, `./gradlew check` целиком.

По ходу нашлась ловушка: в JAXB два разных класса `ChoiceParameterLink`. В выгрузке объектов используется тот, что из `v8_3_xcf_readable` с полями `Name`/`DataPath`/`ValueChange`, а не одноимённый из схемы компоновки с `choiceParameter`/`value`/`mode`. Первая версия чтения молча возвращала пустой список — поймали на реальных данных.