### PR TITLE
chore(deps): подняли зависимости, подмодуль схем и actions

### DIFF
--- a/.github/workflows/diagnose-golden-cf.yml
+++ b/.github/workflows/diagnose-golden-cf.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout (с submodule samples для семени)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: true
 
@@ -166,7 +166,7 @@ jobs:
           exit 0
 
       - name: Загрузить эталоны как артефакт
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: golden-config-${{ github.run_id }}
           path: golden/

--- a/.github/workflows/diagnose-golden-cfe.yml
+++ b/.github/workflows/diagnose-golden-cfe.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Установить OneScript
         uses: otymko/setup-onescript@v1.5.1
@@ -179,7 +179,7 @@ jobs:
           exit 0
 
       - name: Загрузить эталон как артефакт
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: golden-extension-${{ github.run_id }}
           path: golden/

--- a/.github/workflows/dump-standard-labels.yml
+++ b/.github/workflows/dump-standard-labels.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Установить OneScript
         uses: otymko/setup-onescript@v1.5.1
@@ -119,7 +119,7 @@ jobs:
           exit 0
 
       - name: Загрузить подписи как артефакт
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: standard-labels-${{ github.run_id }}
           path: labels/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,13 +35,13 @@ jobs:
 
     steps:
       - name: Получить код
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           submodules: recursive
 
       - name: Установить JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: temurin
           java-version: '21'
@@ -92,7 +92,7 @@ jobs:
           toolchain: stable
 
       - name: Кэшировать cargo
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/bin/
@@ -164,7 +164,7 @@ jobs:
         run: ./gradlew shadowJar --no-daemon
 
       - name: Создать GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ steps.ver.outputs.version }}
           files: build/libs/md-sparrow-*-all.jar

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -180,13 +180,13 @@ val modelToVersions = versionToModel.entries.groupBy({ it.value }, { it.key })
 val xjc by configurations.creating
 dependencies {
     xjc("org.glassfish.jaxb:jaxb-xjc:4.0.5")
-    xjc("org.glassfish.jaxb:jaxb-runtime:4.0.5")
+    xjc("org.glassfish.jaxb:jaxb-runtime:4.0.6")
 
     api("jakarta.xml.bind:jakarta.xml.bind-api:4.0.2")
     implementation("org.glassfish.jaxb:jaxb-runtime:4.0.5")
     implementation("info.picocli:picocli:4.7.7")
-    implementation("com.google.code.gson:gson:2.11.0")
-    implementation("com.fasterxml.woodstox:woodstox-core:6.6.0")
+    implementation("com.google.code.gson:gson:2.14.0")
+    implementation("com.fasterxml.woodstox:woodstox-core:7.1.0")
 
     testImplementation(platform("org.junit:junit-bom:5.11.4"))
     testImplementation("org.junit.jupiter:junit-jupiter")


### PR DESCRIPTION
## Зависимости

| Пакет | Было | Стало |
|---|---|---|
| jaxb-runtime | 4.0.5 | 4.0.6 |
| gson | 2.11.0 | 2.14.0 |
| woodstox-core | 6.6.0 | 7.1.0 |

**JUnit остался на 5.11.4.** На 5.12.2 исполнитель тестов Gradle не стартует: `Could not complete execution for Gradle Test Executor`. Обновление JUnit пойдёт вместе с Gradle, отдельно смысла нет.

**AssertJ остался на 3.27.7**: у четвёртой версии пока только milestone.

## Подмодуль схем

`resources/namespace-forest` подтянут на 3 коммита: поправлен фильтр приложения в workflow и обновлён список обработанных версий. Сами XSD не менялись, поэтому модель формата та же — это и было условием, чтобы обновление считать безопасным.

## Actions

checkout 7, setup-java 6, cache 6, upload-artifact 7, gh-release 3 — те же версии, что уже работают в расширении. В репозитории была смесь: часть шагов на v4, часть на v7.

## Проверено

`./gradlew check` с `--rerun-tasks`: 685 тестов, ноль падений. Отдельно проверено, что woodstox 7 (мажор) не сломал разбор выгрузок — на нём держится чтение XML.