### PR TITLE
test: подключили ssl_3_1 в формате EDT как фикстуру

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "fixtures/samples-1c-platform"]
 	path = fixtures/samples-1c-platform
 	url = git@github.com:yellow-hammer/samples-1c-platform.git
+[submodule "fixtures/ssl31-edt"]
+	path = fixtures/ssl31-edt
+	url = git@github.com:yellow-hammer/ssl_3_1_edt.git

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -333,6 +333,11 @@ tasks.test {
         "fixtures.ssl31.root",
         layout.projectDirectory.dir("fixtures/ssl31").asFile.absolutePath,
     )
+    // Та же конфигурация в формате EDT: сверка поведения на двух раскладках
+    systemProperty(
+        "fixtures.ssl31edt.root",
+        layout.projectDirectory.dir("fixtures/ssl31-edt").asFile.absolutePath,
+    )
     systemProperty(
         "samples.root",
         layout.projectDirectory.dir("fixtures/samples-1c-platform").asFile.absolutePath,


### PR DESCRIPTION
Рядом с `fixtures/ssl31` появилась та же конфигурация в формате EDT - [ssl_3_1_edt](https://github.com/yellow-hammer/ssl_3_1_edt).

Проект получен импортом выгрузки конфигуратора из `ssl_3_1` средствами самой EDT (`1cedtcli -command import`), поэтому метаданные в обеих фикстурах одни и те же и поведение на двух раскладках можно сверять напрямую.

Путь до фикстуры уходит в тесты системным свойством `fixtures.ssl31edt.root`, как и остальные.

Тесты: 694, все зелёные.